### PR TITLE
SKID-1: Implement a unit test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # 1. Do everything in $(CODE_DIR)
 # 2. make
 # 3. Watch for errors
-# 4. Check $(CODE_DIR) for your binaries
+# 4. Check $(CODE_DIR)$(DIST_DIR) for your binaries
 # 5. Modifiy $(CODE_DIR)Makefile_linux with special rules
 #
 # Global "constants" are defined in code/Makefile_constants
@@ -26,6 +26,9 @@ include $(CODE_DIR)Makefile_constants
 ### MAKEFILE ARGUMENTS ###
 SKIP_MF_ARGS = --directory=$(CODE_DIR)
 
+.PHONY: all compile clean validate
+
+
 ##########################
 ##### MAKEFILE RULES #####
 ##########################
@@ -33,4 +36,14 @@ all:
 	@clear
 	$(CALL_MAKE) $(SKIP_MF_ARGS)
 
-.PHONY: all
+compile:
+	@clear
+	$(CALL_MAKE) $(SKIP_MF_ARGS) compile
+
+clean:
+	@clear
+	$(CALL_MAKE) $(SKIP_MF_ARGS) clean
+
+validate:
+	@clear
+	$(CALL_MAKE) $(SKIP_MF_ARGS) validate

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # sketchy-idea
 Reusable, stand-alone, Linux code
+
+## SKETCHY IDEA (SKID)
+
+My opportunity to write some clean Linux code that is tested and releasable.
+
+## DEPENDENCIES
+
+* [GNU Make](https://www.gnu.org/software/make/) - Underpins the build system
+* [GCC](https://gcc.gnu.org/) - The compiler
+* [Check](https://github.com/libcheck/check) - A unit test framework for C
+
+## USAGE
+
+### Do Everything Everywhere All At Once
+
+`make`
+
+### Is everything installed properly?
+
+`make validate`

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -60,7 +60,7 @@ _all:
 	$(CALL_MAKE) clean
 	$(CALL_MAKE) compile
 
-.PHONY: _all _clean _clean_dist _compile _compilation _test_link _validate _validate_gcc
+.PHONY: _all _clean _clean_dist _compile _compilation _test_link _validate _validate_check _validate_gcc
 
 _clean:
 	$(CALL_MAKE) _clean_dist
@@ -79,6 +79,12 @@ _test_link: $(foreach BIN_FILE, $(BIN_LIST), $(BIN_FILE))
 
 _validate:
 	$(CALL_MAKE) _validate_gcc
+	$(CALL_MAKE) _validate_check
+
+_validate_check:
+	@echo "    Validating Check"
+	@grep "Check" /usr/include/check.h > $(NULL)
+	@echo "        $(CHECK) $(shell echo -n "Check unit test version: "; printf "%s %s %s\n" CHECK_MAJOR_VERSION CHECK_MINOR_VERSION CHECK_MICRO_VERSION | gcc -include check.h -E - | tail -n 1)"
 
 _validate_gcc:
 	@echo "    Validating "$(CC)""

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -40,6 +40,8 @@ $(error Wrong operating system.  This is $(OS).)
 endif
 
 ### DYNAMIC VARIABLES ###
+
+# SOURCE FILES
 # All .c filenames found in SRC_DIR
 RAW_SRC_FILES := $(shell cd $(SRC_DIR); ls *$(SRC_FILE_EXT))
 # All RAW_SRC_FILES with the file extension stripped
@@ -47,10 +49,36 @@ BASE_SRC_NAMES := $(basename $(RAW_SRC_FILES))
 # Convert base filenames to object code filenames
 RAW_OBJ_FILES := $(addsuffix $(OBJ_FILE_EXT),$(BASE_SRC_NAMES))
 
+# CHECK UNIT TEST VARIABLES
+# Prefix for *all* Check unit test files
+CHECK_PREFIX = check_
+# Prefix for all skip_file_metadata_read library unit tests
+CHECK_SFMR_PREFIX = $(CHECK_PREFIX)sfmr_
+# All check*.c filenames found in TEST_DIR
+CHECK_SRC_FILES := $(shell cd $(TEST_DIR); ls check*$(SRC_FILE_EXT))
+# All CHECK_SRC_FILES with the file extension stripped
+CHECK_BASE_NAMES := $(basename $(CHECK_SRC_FILES))
+# Convert base Check filenames to object code filenames
+CHECK_OBJ_FILES := $(addsuffix $(OBJ_FILE_EXT),$(CHECK_BASE_NAMES))
+# Convert base Check filenames to object code filenames
+CHECK_BIN_FILES := $(addsuffix $(BIN_FILE_EXT),$(CHECK_BASE_NAMES))
+# Check unit test library arguments for $(CC)
+CHECK_CC_ARGS = -lcheck -lm -lsubunit
+
+# BINARIES
 # A space-separated list of all the test binaries
 BIN_LIST := $(DIST_DIR)test_is_regular_file$(BIN_FILE_EXT) $(DIST_DIR)test_is_symbolic_link$(BIN_FILE_EXT) \
             $(DIST_DIR)test_is_named_pipe$(BIN_FILE_EXT) $(DIST_DIR)test_is_block_device$(BIN_FILE_EXT) \
             $(DIST_DIR)test_is_character_device$(BIN_FILE_EXT)
+
+### SPECIAL BUILT-IN TARGET NAMES ###
+
+# Do not treat these target names as file names
+.PHONY: _all _check_link _clean _clean_dist _compile _compilation _test_link _validate _validate_check _validate_gcc
+
+# Don't auto-remove my object code
+.PRECIOUS: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILES)) \
+           $(foreach CHECK_OBJ_FILE, $(CHECK_OBJ_FILES), $(DIST_DIR)$(CHECK_OBJ_FILES))
 
 ##################################
 ###### LINUX MAKEFILE RULES ######
@@ -60,7 +88,9 @@ _all:
 	$(CALL_MAKE) clean
 	$(CALL_MAKE) compile
 
-.PHONY: _all _clean _clean_dist _compile _compilation _test_link _validate _validate_check _validate_gcc
+# Link all of the Check unit test binaries
+_check_link: $(foreach CHECK_BIN_FILE, $(CHECK_BIN_FILES), $(DIST_DIR)$(CHECK_BIN_FILES))
+	@#echo "$@ needs $^"  # DEBUGGING
 
 _clean:
 	$(CALL_MAKE) _clean_dist
@@ -72,10 +102,13 @@ _clean_dist:
 _compile:
 	$(CALL_MAKE) _compilation
 	$(CALL_MAKE) _test_link
+	$(CALL_MAKE) _check_link
 
-_compilation: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(RAW_OBJ_FILES))
+_compilation: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILES))
+	@#echo "$@ needs $^"  # DEBUGGING
 
 _test_link: $(foreach BIN_FILE, $(BIN_LIST), $(BIN_FILE))
+	@#echo "$@ needs $^"  # DEBUGGING
 
 _validate:
 	$(CALL_MAKE) _validate_gcc
@@ -111,14 +144,32 @@ $(DIST_DIR)test_is_symbolic_link$(BIN_FILE_EXT): $(TEST_DIR)test_is_symbolic_lin
 	@echo "    Linking: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 
-%$(BIN_FILE_EXT): $(DIST_DIR)%$(OBJ_FILE_EXT)
-	@echo "    Linking: $@"
-	@$(CC) $(CFLAGS) -o $(DIST_DIR)$@ $^
-
-%$(OBJ_FILE_EXT): $(SRC_DIR)%$(SRC_FILE_EXT)
+# CHECK: Compiling unit test object code
+$(DIST_DIR)$(CHECK_PREFIX)%$(OBJ_FILE_EXT): $(TEST_DIR)$(CHECK_PREFIX)%$(SRC_FILE_EXT)
+	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Compiling: $^"
-	@$(CC) $(CFLAGS) -c $^ -o $(DIST_DIR)$@ -I $(INCLUDE_DIR)
+	@$(CC) $(CFLAGS) -c $^ -o $@ -I $(INCLUDE_DIR)
 
+# CHECK: Linking skip_file_metadata_read library unit test binaries
+$(DIST_DIR)$(CHECK_SFMR_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SFMR_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skip_file_metadata_read$(OBJ_FILE_EXT)
+	@#echo "$@ needs $^"  # DEBUGGING
+	@echo "    Linking: $@"
+	@$(CC) $(CFLAGS) -o $@ $^ $(CHECK_CC_ARGS)
+
+# DEFAULT: Linking binaries
+$(DIST_DIR)%$(BIN_FILE_EXT): $(DIST_DIR)%$(OBJ_FILE_EXT)
+	@#echo "$@ needs $^"  # DEBUGGING
+	@echo "    Linking: $@"
+	@$(CC) $(CFLAGS) -o $@ $^
+
+# DEFAULT: Compiling object code
+$(DIST_DIR)%$(OBJ_FILE_EXT): $(SRC_DIR)%$(SRC_FILE_EXT)
+	@#echo "$@ needs $^"  # DEBUGGING
+	@echo "    Compiling: $^"
+	@$(CC) $(CFLAGS) -c $^ -o $@ -I $(INCLUDE_DIR)
+
+# DEFAULT: Validating source files exist
 %$(SRC_FILE_EXT):
+	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Verifying $@"
 	@if ! [ -f $@ ] ; then echo "Unable to locate the $@ file" >&2 && exit 2 ; fi

--- a/code/test/check_is_regular_file.c
+++ b/code/test/check_is_regular_file.c
@@ -1,0 +1,68 @@
+/*
+ *  Check unit test suit for skip_file_metadata_read.h's is_regular_file() function.
+ */
+
+#include <stdlib.h>
+#include <check.h>                    // START_TEST(), END_TEST
+// Local includes
+#include "skip_file_metadata_read.h"  // is_character_device()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE
+
+
+START_TEST(test_n01_regular_file)
+{
+    bool result = false;      // Return value from function call
+    int errnum = CANARY_INT;  // Errno from the function call
+    result = is_regular_file("./code/test/test_input/regular_file.txt", &errnum);
+    ck_assert(true == result);  // This input is a regular file
+    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+}
+END_TEST
+
+
+START_TEST(test_n02_directory)
+{
+    bool result = false;      // Return value from function call
+    int errnum = CANARY_INT;  // Errno from the function call
+    result = is_regular_file("./code/test/test_input/", &errnum);
+    ck_assert(false == result);  // This input is *NOT* a regular file
+    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+}
+END_TEST
+
+ 
+Suite *is_regular_file_suite(void)
+{
+    Suite *suite = NULL;
+    TCase *tc_core = NULL;
+
+    suite = suite_create("Is_Regular_File");
+
+    /* Core test case */
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_n01_regular_file);
+    tcase_add_test(tc_core, test_n02_directory);
+    suite_add_tcase(suite, tc_core);
+
+    return suite;
+}
+
+
+int main(void)
+{
+    int number_failed = 0;
+    Suite *suite = NULL;
+    SRunner *suite_runner = NULL;
+
+    suite = is_regular_file_suite();
+    suite_runner = srunner_create(suite);
+
+    srunner_run_all(suite_runner, CK_NORMAL);
+    number_failed = srunner_ntests_failed(suite_runner);
+    srunner_free(suite_runner);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmr_is_regular_file.c
+++ b/code/test/check_sfmr_is_regular_file.c
@@ -9,7 +9,7 @@
 
 
 // Use this to help highlight an errnum that wasn't updated
-#define CANARY_INT (int)0xBADC0DE
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
 
 
 START_TEST(test_n01_regular_file)
@@ -33,6 +33,39 @@ START_TEST(test_n02_directory)
 }
 END_TEST
 
+
+START_TEST(test_n03_symbolic_link)
+{
+    bool result = false;      // Return value from function call
+    int errnum = CANARY_INT;  // Errno from the function call
+    result = is_regular_file("./code/test/test_input/sym_link.txt", &errnum);
+    ck_assert(true == result);  // This may not be a regular file but stat() follows links
+    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+}
+END_TEST
+
+
+START_TEST(test_n04_block_device)
+{
+    bool result = false;      // Return value from function call
+    int errnum = CANARY_INT;  // Errno from the function call
+    result = is_regular_file("/dev/loop0", &errnum);
+    ck_assert(false == result);  // This input is *NOT* a regular file
+    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+}
+END_TEST
+
+
+START_TEST(test_n05_character_device)
+{
+    bool result = false;      // Return value from function call
+    int errnum = CANARY_INT;  // Errno from the function call
+    result = is_regular_file("/dev/null", &errnum);
+    ck_assert(false == result);  // This input is *NOT* a regular file
+    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+}
+END_TEST
+
  
 Suite *is_regular_file_suite(void)
 {
@@ -46,6 +79,9 @@ Suite *is_regular_file_suite(void)
 
     tcase_add_test(tc_core, test_n01_regular_file);
     tcase_add_test(tc_core, test_n02_directory);
+    tcase_add_test(tc_core, test_n03_symbolic_link);
+    tcase_add_test(tc_core, test_n04_block_device);
+    tcase_add_test(tc_core, test_n05_character_device);
     suite_add_tcase(suite, tc_core);
 
     return suite;


### PR DESCRIPTION
Check has been implemented as a base unit test framework.
Makefile validation has been updated to attempt to verify the installation of Check's libraries.
The Make build system has been updated to look for `code/test/check*.c` files and manage them specially (e.g. link against the Check libraries)
One "suite" of Check test cases, for `is_regular_file()` have been partially implemented as PoC.
Check-based unit tests for new libraries should only require one extra Makefile rule.

Also:

- Updated `README` with a bit more information
- Updated top-level `Makefile` with pass-throughs down to the lower level `code/Makefile` interface rules  (Why does that matter?  Now you can just `make` from the top-level without any `make -C code/` shenanigans)