### PR TITLE
SKID-3: Added addional linker flags for Check

### DIFF
--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -68,7 +68,7 @@ CHECK_OBJ_FILES := $(addsuffix $(OBJ_FILE_EXT),$(CHECK_BASE_NAMES))
 # Convert base Check filenames to object code filenames
 CHECK_BIN_FILES := $(addsuffix $(BIN_FILE_EXT),$(CHECK_BASE_NAMES))
 # Check unit test library arguments for $(CC)
-CHECK_CC_ARGS = -lcheck -lm -lsubunit
+CHECK_CC_ARGS = -lcheck -lm -lsubunit -lrt -lpthread
 
 # MANUAL TEST VARIABLES
 # Prefix for *all* manual test_* files


### PR DESCRIPTION
Older versions of gcc(?) (e.g., 10.2.1) seem to need a bit more help linking Check unit test code.

Added two additional libraries to link the Check unit test code against.

Everything passing locally.

Changes to be committed:
	modified:   code/Makefile_linux