### PR TITLE
SKID-4: Fixed all the N06 socket unit test cases

### DIFF
--- a/code/test/check_sfmr_get_block_size.c
+++ b/code/test/check_sfmr_get_block_size.c
@@ -28,231 +28,246 @@ code/dist/check_sfmr_get_block_size.bin && CK_FORK=no valgrind --leak-check=full
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    blksize_t result = 0;      // Return value from function call
-    int errnum = CANARY_INT;   // Errno from the function call
-    blksize_t exp_result = 0;  // Expected results
+	// LOCAL VARIABLES
+	blksize_t result = 0;      // Return value from function call
+	int errnum = CANARY_INT;   // Errno from the function call
+	blksize_t exp_result = 0;  // Expected results
 
-    // SETUP
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// SETUP
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
 
-    // VALIDATION
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_block_size("/dev/loop0", &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_block_size("/dev/loop0", &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    blksize_t result = 0;      // Return value from function call
-    int errnum = CANARY_INT;   // Errno from the function call
-    blksize_t exp_result = 0;  // Expected results
+	// LOCAL VARIABLES
+	blksize_t result = 0;      // Return value from function call
+	int errnum = CANARY_INT;   // Errno from the function call
+	blksize_t exp_result = 0;  // Expected results
 
-    // SETUP
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// SETUP
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
 
-    // VALIDATION
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_block_size("/dev/null", &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_block_size("/dev/null", &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    blksize_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    blksize_t exp_result = 0;                // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	blksize_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	blksize_t exp_result = 0;                // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_block_size(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_block_size(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    blksize_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    blksize_t exp_result = 0;                // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	blksize_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	blksize_t exp_result = 0;                // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_block_size(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_block_size(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    blksize_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    blksize_t exp_result = 0;                // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	blksize_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	blksize_t exp_result = 0;                // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_block_size(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_block_size(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    blksize_t result = 0;      // Return value from function call
-    int errnum = CANARY_INT;   // Errno from the function call
-    blksize_t exp_result = 0;  // Expected results
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	blksize_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	blksize_t exp_result = 0;                // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // SETUP
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // VALIDATION
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// TEST START
+	result = get_block_size(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // TEST START
-    result = get_block_size("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    blksize_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    blksize_t exp_result = 0;                // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	blksize_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	blksize_t exp_result = 0;                // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = (blksize_t)get_sys_block_size(&errnum);
-    // It is important get_sys_block_size() succeeds
-    ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = (blksize_t)get_sys_block_size(&errnum);
+	// It is important get_sys_block_size() succeeds
+	ck_assert_msg(0 == errnum, "get_sys_block_size() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_sys_block_size() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_block_size(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_block_size(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -262,37 +277,37 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    blksize_t result = 0;      // Return value from function call
-    int errnum = CANARY_INT;   // Errno from the function call
-    blksize_t exp_result = 0;  // Expected results
-    result = get_block_size(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	blksize_t result = 0;      // Return value from function call
+	int errnum = CANARY_INT;   // Errno from the function call
+	blksize_t exp_result = 0;  // Expected results
+	result = get_block_size(NULL, &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    blksize_t result = 0;      // Return value from function call
-    int errnum = CANARY_INT;   // Errno from the function call
-    blksize_t exp_result = 0;  // Expected results
-    result = get_block_size("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	blksize_t result = 0;      // Return value from function call
+	int errnum = CANARY_INT;   // Errno from the function call
+	blksize_t exp_result = 0;  // Expected results
+	result = get_block_size("\0 NOT HERE!", &errnum);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    blksize_t result = 0;      // Return value from function call
-    blksize_t exp_result = 0;  // Expected results
-    result = get_block_size("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
-                  result, exp_result);
+	blksize_t result = 0;      // Return value from function call
+	blksize_t exp_result = 0;  // Expected results
+	result = get_block_size("/dev/loop0", NULL);
+	ck_assert_msg(exp_result == result, "get_block_size() returned %ld instead of %ld",
+				  result, exp_result);
 }
 END_TEST
 
@@ -302,67 +317,67 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    blksize_t result = 0;     // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_block_size("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	blksize_t result = 0;     // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = get_block_size("/does/not/exist.txt", &errnum);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *get_block_size_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_Block_Size");
+	suite = suite_create("SFMR_Get_Block_Size");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_block_size.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_block_size.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_block_size_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_block_size_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_change_time.c
+++ b/code/test/check_sfmr_get_change_time.c
@@ -28,253 +28,253 @@ code/dist/check_sfmr_get_change_time.bin && CK_FORK=no valgrind --leak-check=ful
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    time_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    time_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	time_t result = 0;                     // Return value from function call
+	int errnum = CANARY_INT;               // Errno from the function call
+	time_t exp_result = 0;                 // Expected results
+	char input_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_ctime(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_ctime(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    time_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    time_t exp_result = 0;                // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	time_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;              // Errno from the function call
+	time_t exp_result = 0;                // Expected results
+	char input_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_ctime(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_ctime(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_ctime(input_abs_path, &errnum);
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_ctime(input_abs_path, &errnum);
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_ctime(input_abs_path, &errnum);
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_ctime(input_abs_path, &errnum);
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_ctime(input_abs_path, &errnum);
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_ctime(input_abs_path, &errnum);
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/raw_socket" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_socket() succeeds
-    errnum = make_a_socket(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_ctime(input_abs_path, &errnum);
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_ctime(input_abs_path, &errnum);
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Relative path for this test case's input
+	char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_ctime(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_ctime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_ctime(actual_abs_path, &errnum);  // Special because of sym link
+	// It is important get_shell_ctime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_change_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_change_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
 }
 END_TEST
 
@@ -284,37 +284,37 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    time_t exp_result = 0;    // Expected results
-    result = get_change_time(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	time_t exp_result = 0;    // Expected results
+	result = get_change_time(NULL, &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    time_t exp_result = 0;    // Expected results
-    result = get_change_time("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	time_t exp_result = 0;    // Expected results
+	result = get_change_time("\0 NOT HERE!", &errnum);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    time_t result = 0;        // Return value from function call
-    time_t exp_result = 0;    // Expected results
-    result = get_change_time("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
-                  result, exp_result);
+	time_t result = 0;        // Return value from function call
+	time_t exp_result = 0;    // Expected results
+	result = get_change_time("/dev/loop0", NULL);
+	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
+				  result, exp_result);
 }
 END_TEST
 
@@ -324,67 +324,67 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_change_time("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = get_change_time("/does/not/exist.txt", &errnum);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
 }
 END_TEST
 
  
 Suite *get_change_time_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_Change_Time");
+	suite = suite_create("SFMR_Get_Change_Time");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_change_time.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_change_time.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_change_time_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_change_time_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_file_device_id.c
+++ b/code/test/check_sfmr_get_file_device_id.c
@@ -28,130 +28,208 @@ code/dist/check_sfmr_get_file_device_id.bin && CK_FORK=no valgrind --leak-check=
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    dev_t result = 0;                      // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    dev_t exp_result = 0;                  // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	dev_t result = 0;                      // Return value from function call
+	int errnum = CANARY_INT;               // Errno from the function call
+	dev_t exp_result = 0;                  // Expected results
+	char input_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_device_id(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_device_id(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_device_id() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_device_id(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_device_id(input_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    dev_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    dev_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	dev_t result = 0;                     // Return value from function call
+	int errnum = CANARY_INT;              // Errno from the function call
+	dev_t exp_result = 0;                 // Expected results
+	char input_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_device_id(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_device_id(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_device_id() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_device_id(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_device_id(input_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    dev_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    dev_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	dev_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	dev_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_device_id(input_abs_path, &errnum);
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_device_id(input_abs_path, &errnum);
+	// It is important get_shell_device_id() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_device_id(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_device_id(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	dev_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	dev_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_device_id(input_abs_path, &errnum);
+	// It is important get_shell_device_id() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = get_file_device_id(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n05_regular_file)
+{
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	dev_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	dev_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_device_id(input_abs_path, &errnum);
+	// It is important get_shell_device_id() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = get_file_device_id(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n06_socket)
+{
+	// LOCAL VARIABLES
     const char *repo_name = SKID_REPO_NAME;  // Repo name
-    dev_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    dev_t exp_result = 0;                    // Expected results
+	dev_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	dev_t exp_result = 0;                    // Expected results
     // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+    char input_rel_path[] = { "./code/test/test_input/raw_socket" };
     // Absolute path for input_rel_path as resolved against the repo name
     char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
+	// VALIDATION
     // It is important resolve_to_repo() succeeds
     ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
                   input_rel_path, errnum, strerror(errnum));
     remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+    // It is important make_a_socket() succeeds
+    errnum = make_a_socket(input_abs_path);
+    ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
                   errnum, strerror(errnum));
-    exp_result = get_shell_device_id(input_abs_path, &errnum);
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// It is important get_shell_device_id() succeeds
+	exp_result = get_shell_device_id(input_abs_path, &errnum);
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_device_id(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_device_id(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
@@ -160,107 +238,43 @@ START_TEST(test_n04_named_pipe)
 END_TEST
 
 
-START_TEST(test_n05_regular_file)
-{
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    dev_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    dev_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_device_id(input_abs_path, &errnum);
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
-
-    // TEST START
-    result = get_file_device_id(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
-
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
-}
-END_TEST
-
-
-START_TEST(test_n06_socket)
-{
-    // LOCAL VARIABLES
-    dev_t result = 0;                                           // Return value from function call
-    int errnum = CANARY_INT;                                    // Errno from the function call
-    dev_t exp_result = 0;                                       // Expected results
-    char input_path[] = { "/var/run/dbus/system_bus_socket" };  // Test case input
-
-    // SETUP
-    exp_result = get_shell_device_id(input_path, &errnum);
-
-    // VALIDATION
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
-
-    // TEST START
-    result = get_file_device_id(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
-}
-END_TEST
-
-
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    dev_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    blkcnt_t exp_result = 0664;              // Expected results?
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	dev_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	blkcnt_t exp_result = 0664;              // Expected results?
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Relative path for this test case's input
+	char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_device_id(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_device_id() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_device_id(actual_abs_path, &errnum);  // Special because of sym link
+	// It is important get_shell_device_id() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_device_id() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_device_id() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_device_id(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_device_id(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
 }
 END_TEST
 
@@ -270,37 +284,37 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    dev_t result = 0;         // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    dev_t exp_result = 0;     // Expected results
-    result = get_file_device_id(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	dev_t result = 0;         // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	dev_t exp_result = 0;     // Expected results
+	result = get_file_device_id(NULL, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    dev_t result = 0;         // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    dev_t exp_result = 0;     // Expected results
-    result = get_file_device_id("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	dev_t result = 0;         // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	dev_t exp_result = 0;     // Expected results
+	result = get_file_device_id("\0 NOT HERE!", &errnum);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    dev_t result = 0;         // Return value from function call
-    dev_t exp_result = 0;     // Expected results
-    result = get_file_device_id("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
-                  result, exp_result);
+	dev_t result = 0;         // Return value from function call
+	dev_t exp_result = 0;     // Expected results
+	result = get_file_device_id("/dev/loop0", NULL);
+	ck_assert_msg(exp_result == result, "get_file_device_id() returned %ld instead of %ld",
+				  result, exp_result);
 }
 END_TEST
 
@@ -310,67 +324,67 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    blksize_t result = 0;     // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_file_device_id("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	blksize_t result = 0;     // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = get_file_device_id("/does/not/exist.txt", &errnum);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
 }
 END_TEST
 
  
 Suite *get_file_device_id_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_File_Device_ID");
+	suite = suite_create("SFMR_Get_File_Device_ID");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_file_device_id.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_file_device_id.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_file_device_id_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_file_device_id_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_file_perms.c
+++ b/code/test/check_sfmr_get_file_perms.c
@@ -28,239 +28,253 @@ code/dist/check_sfmr_get_file_perms.bin && CK_FORK=no valgrind --leak-check=full
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    mode_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    mode_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	mode_t result = 0;                     // Return value from function call
+	int errnum = CANARY_INT;               // Errno from the function call
+	mode_t exp_result = 0;                 // Expected results
+	char input_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_file_perms(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_file_perms(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_file_perms() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_perms(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_perms(input_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    mode_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    mode_t exp_result = 0;                // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	mode_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;              // Errno from the function call
+	mode_t exp_result = 0;                // Expected results
+	char input_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_file_perms(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_file_perms(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_file_perms() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_perms(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_perms(input_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    mode_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    mode_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	mode_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	mode_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_file_perms(input_abs_path, &errnum);
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_file_perms(input_abs_path, &errnum);
+	// It is important get_shell_file_perms() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_perms(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_perms(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    mode_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    mode_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	mode_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	mode_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_file_perms(input_abs_path, &errnum);
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_file_perms(input_abs_path, &errnum);
+	// It is important get_shell_file_perms() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_perms(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_perms(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    mode_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    mode_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	mode_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	mode_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_file_perms(input_abs_path, &errnum);
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_file_perms(input_abs_path, &errnum);
+	// It is important get_shell_file_perms() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_perms(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_perms(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    mode_t result = 0;                                          // Return value from function call
-    int errnum = CANARY_INT;                                    // Errno from the function call
-    mode_t exp_result = 0;                                      // Expected results
-    char input_path[] = { "/var/run/dbus/system_bus_socket" };  // Test case input
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	mode_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	mode_t exp_result = 0;                   // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // SETUP
-    exp_result = get_shell_file_perms(input_path, &errnum);
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	// It is important get_shell_file_perms() succeeds
+	exp_result = get_shell_file_perms(input_abs_path, &errnum);
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // VALIDATION
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// TEST START
+	result = get_file_perms(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // TEST START
-    result = get_file_perms(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    mode_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    mode_t exp_result = 0664;                // Expected results?
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	mode_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	mode_t exp_result = 0664;                // Expected results?
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Relative path for this test case's input
+	char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_file_perms(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_file_perms() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_file_perms(actual_abs_path, &errnum);  // Special because of sym link
+	// It is important get_shell_file_perms() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_file_perms() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result > 0, "get_shell_file_perms() provided an invalid value of %o",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_file_perms(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_file_perms(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
 }
 END_TEST
 
@@ -270,37 +284,37 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    mode_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    mode_t exp_result = 0;    // Expected results
-    result = get_file_perms(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	mode_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	mode_t exp_result = 0;    // Expected results
+	result = get_file_perms(NULL, &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    mode_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    mode_t exp_result = 0;    // Expected results
-    result = get_file_perms("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	mode_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	mode_t exp_result = 0;    // Expected results
+	result = get_file_perms("\0 NOT HERE!", &errnum);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    mode_t result = 0;      // Return value from function call
-    mode_t exp_result = 0;  // Expected results
-    result = get_file_perms("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
-                  result, exp_result);
+	mode_t result = 0;      // Return value from function call
+	mode_t exp_result = 0;  // Expected results
+	result = get_file_perms("/dev/loop0", NULL);
+	ck_assert_msg(exp_result == result, "get_file_perms() returned %o instead of %o",
+				  result, exp_result);
 }
 END_TEST
 
@@ -310,67 +324,67 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    blksize_t result = 0;     // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_file_perms("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	blksize_t result = 0;     // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = get_file_perms("/does/not/exist.txt", &errnum);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
 }
 END_TEST
 
  
 Suite *get_file_perms_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_File_Perms");
+	suite = suite_create("SFMR_Get_File_Perms");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_file_perms.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_file_perms.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_file_perms_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_file_perms_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_block_device.c
+++ b/code/test/check_sfmr_is_block_device.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_block_device.bin && CK_FORK=no valgrind --leak-check=ful
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_block_device("/dev/loop0", &errnum);
-    ck_assert(true == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_block_device("/dev/loop0", &errnum);
+	ck_assert(true == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_block_device("/dev/null", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_block_device("/dev/null", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_block_device(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_block_device(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_block_device(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_block_device(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_block_device(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_block_device(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_block_device("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_block_device(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_block_device(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_block_device(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_block_device(NULL, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_block_device(NULL, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_block_device("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_block_device("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_block_device("/dev/loop0", NULL);
-    ck_assert(false == result);
+	bool result = false;  // Return value from function call
+	result = is_block_device("/dev/loop0", NULL);
+	ck_assert(false == result);
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_block_device("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_block_device("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_block_device_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Block_Device");
+	suite = suite_create("SFMR_Is_Block_Device");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_block_device_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_block_device_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_character_device.c
+++ b/code/test/check_sfmr_is_character_device.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_character_device.bin && CK_FORK=no valgrind --leak-check
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_character_device("/dev/loop0", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_character_device("/dev/loop0", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_character_device("/dev/null", &errnum);
-    ck_assert(true == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_character_device("/dev/null", &errnum);
+	ck_assert(true == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_character_device(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_character_device(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_character_device(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_character_device(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_character_device(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_character_device(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_character_device("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_character_device(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_character_device(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_character_device(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_character_device(NULL, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_character_device(NULL, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_character_device("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_character_device("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_character_device("/dev/loop0", NULL);
-    ck_assert(false == result);
+	bool result = false;  // Return value from function call
+	result = is_character_device("/dev/loop0", NULL);
+	ck_assert(false == result);
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_character_device("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_character_device("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_character_device_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Character_Device");
+	suite = suite_create("SFMR_Is_Character_Device");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_character_device_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_character_device_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_directory.c
+++ b/code/test/check_sfmr_is_directory.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_directory.bin && CK_FORK=no valgrind --leak-check=full -
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_directory("/dev/loop0", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_directory("/dev/loop0", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_directory("/dev/null", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_directory("/dev/null", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_directory(input_abs_path, &errnum);
-    ck_assert(true == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_directory(input_abs_path, &errnum);
+	ck_assert(true == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_directory(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_directory(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_directory(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_directory(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_directory("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_directory(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_directory(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_directory(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_directory(NULL, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_directory(NULL, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_directory("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_directory("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_directory("/dev/loop0", NULL);
-    ck_assert(false == result);
+	bool result = false;  // Return value from function call
+	result = is_directory("/dev/loop0", NULL);
+	ck_assert(false == result);
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_directory("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_directory("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_directory_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Directory");
+	suite = suite_create("SFMR_Is_Directory");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_directory_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_directory_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_named_pipe.c
+++ b/code/test/check_sfmr_is_named_pipe.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_named_pipe.bin && CK_FORK=no valgrind --leak-check=full 
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_named_pipe("/dev/loop0", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_named_pipe("/dev/loop0", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_named_pipe("/dev/null", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_named_pipe("/dev/null", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_named_pipe(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_named_pipe(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_named_pipe(input_abs_path, &errnum);
-    ck_assert(true == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_named_pipe(input_abs_path, &errnum);
+	ck_assert(true == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_named_pipe(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_named_pipe(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_named_pipe("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_named_pipe(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_named_pipe(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_named_pipe(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_named_pipe(NULL, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_named_pipe(NULL, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_named_pipe("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_named_pipe("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_named_pipe("/dev/loop0", NULL);
-    ck_assert(false == result);
+	bool result = false;  // Return value from function call
+	result = is_named_pipe("/dev/loop0", NULL);
+	ck_assert(false == result);
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_named_pipe("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_named_pipe("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_named_pipe_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Named_Pipe");
+	suite = suite_create("SFMR_Is_Named_Pipe");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_named_pipe_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_named_pipe_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_regular_file.c
+++ b/code/test/check_sfmr_is_regular_file.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_regular_file.bin && CK_FORK=no valgrind --leak-check=ful
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_regular_file("/dev/loop0", &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_regular_file("/dev/loop0", &errnum);
+	ck_assert(false == result);  // This input is *NOT* a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_regular_file("/dev/null", &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_regular_file("/dev/null", &errnum);
+	ck_assert(false == result);  // This input is *NOT* a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_regular_file(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_regular_file(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is *NOT* a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_regular_file(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_regular_file(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_regular_file(input_abs_path, &errnum);
-    ck_assert(true == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_regular_file(input_abs_path, &errnum);
+	ck_assert(true == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_regular_file("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_regular_file(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_regular_file(input_abs_path, &errnum);
-    ck_assert(true == result);  // This may not be a regular file but stat() follows links
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_regular_file(input_abs_path, &errnum);
+	ck_assert(true == result);  // This may not be a regular file but stat() follows links
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_regular_file(NULL, &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_regular_file(NULL, &errnum);
+	ck_assert(false == result);  // This input is *NOT* a regular file
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_regular_file("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_regular_file("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);  // This input is *NOT* a regular file
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_regular_file("/dev/loop0", NULL);
-    ck_assert(false == result);  // This input is *NOT* a regular file
+	bool result = false;  // Return value from function call
+	result = is_regular_file("/dev/loop0", NULL);
+	ck_assert(false == result);  // This input is *NOT* a regular file
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_regular_file("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);  // This input is *NOT* a regular file
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_regular_file("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);  // This input is *NOT* a regular file
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_regular_file_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Regular_File");
+	suite = suite_create("SFMR_Is_Regular_File");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_regular_file_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_regular_file_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_socket.c
+++ b/code/test/check_sfmr_is_socket.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_socket.bin && CK_FORK=no valgrind --leak-check=full --sh
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_socket("/dev/loop0", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_socket("/dev/loop0", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_socket("/dev/null", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_socket("/dev/null", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_socket(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_socket(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_socket(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_socket(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_socket(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_socket(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_socket("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(true == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_socket(input_abs_path, &errnum);
+	ck_assert(true == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_socket(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_socket(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_socket(NULL, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_socket(NULL, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_socket("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_socket("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_socket("/dev/loop0", NULL);
-    ck_assert(false == result);
+	bool result = false;  // Return value from function call
+	result = is_socket("/dev/loop0", NULL);
+	ck_assert(false == result);
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_socket("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_socket("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_socket_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Socket");
+	suite = suite_create("SFMR_Is_Socket");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_socket_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_socket_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_is_sym_link.c
+++ b/code/test/check_sfmr_is_sym_link.c
@@ -28,150 +28,173 @@ code/dist/check_sfmr_is_sym_link.bin && CK_FORK=no valgrind --leak-check=full --
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_sym_link("/dev/loop0", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_sym_link("/dev/loop0", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_sym_link("/dev/null", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_sym_link("/dev/null", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_sym_link(input_abs_path, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_sym_link(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_sym_link(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_sym_link(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_sym_link(input_abs_path, &errnum);
-    ck_assert(false == result);  // This input is a regular file
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_sym_link(input_abs_path, &errnum);
+	ck_assert(false == result);  // This input is a regular file
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_sym_link("/var/run/dbus/system_bus_socket", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = is_sym_link(input_abs_path, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    bool result = false;                     // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	bool result = false;                     // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = is_sym_link(input_abs_path, &errnum);
-    ck_assert(true == result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = is_sym_link(input_abs_path, &errnum);
+	ck_assert(true == result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
@@ -181,31 +204,31 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_sym_link(NULL, &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_sym_link(NULL, &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_sym_link("\0 NOT HERE!", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_sym_link("\0 NOT HERE!", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    bool result = false;  // Return value from function call
-    result = is_sym_link("/dev/loop0", NULL);
-    ck_assert(false == result);
+	bool result = false;  // Return value from function call
+	result = is_sym_link("/dev/loop0", NULL);
+	ck_assert(false == result);
 }
 END_TEST
 
@@ -215,53 +238,53 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    bool result = false;      // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = is_sym_link("/does/not/exist.txt", &errnum);
-    ck_assert(false == result);
-    ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
+	bool result = false;      // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = is_sym_link("/does/not/exist.txt", &errnum);
+	ck_assert(false == result);
+	ck_assert_int_eq(ENOENT, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
  
 Suite *is_sym_link_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Is_Sym_Link");
+	suite = suite_create("SFMR_Is_Sym_Link");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    suite = is_sym_link_suite();
-    suite_runner = srunner_create(suite);
+	suite = is_sym_link_suite();
+	suite_runner = srunner_create(suite);
 
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
-    srunner_free(suite_runner);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+	srunner_free(suite_runner);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Many of the older n06 unit tests were using a hard-coded socket that exists on my OS.  Well, turns out it doesn't exist everywhere so I refactored the old unit tests to create and delete a raw socket file at "test time".

All tests passing
Valgrind is happy

The bad news is that I also updated to 4-space tabs and that threw the diff off, kinda burying all the n06 work I did.

Changes to be committed:
	modified:   code/test/check_sfmr_get_block_size.c
	modified:   code/test/check_sfmr_get_change_time.c
	modified:   code/test/check_sfmr_get_file_device_id.c
	modified:   code/test/check_sfmr_get_file_perms.c
	modified:   code/test/check_sfmr_get_file_type.c
	modified:   code/test/check_sfmr_is_block_device.c
	modified:   code/test/check_sfmr_is_character_device.c
	modified:   code/test/check_sfmr_is_directory.c
	modified:   code/test/check_sfmr_is_named_pipe.c
	modified:   code/test/check_sfmr_is_regular_file.c
	modified:   code/test/check_sfmr_is_socket.c
	modified:   code/test/check_sfmr_is_sym_link.c