### PR TITLE
13-2: Manipulate file metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ make && \
 for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break || CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin; [[ $? -ne 0 ]] && break || continue; done
 ```
 
+### How many Check unit tests *are* there?
+
+```
+for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}'
+```
+
 ## NOTES
 
 ### Check unit test framework

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ The for loop will stop if any failure is encountered: Check, Valgrind, or otherw
 make && \
 for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break || CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin; [[ $? -ne 0 ]] && break || continue; done
 ```
+
+## NOTES
+
+### Check unit test framework
+
+* Convient function-like [test macros](https://libcheck.github.io/check/doc/check_html/check_4.html#Convenience-Test-Functions)
+* [Test Fixtures](https://libcheck.github.io/check/doc/check_html/check_4.html#Test-Fixtures)

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -75,6 +75,8 @@ CHECK_CC_ARGS = -lcheck -lm -lsubunit -lrt -lpthread
 # MANUAL TEST VARIABLES
 # Prefix for *all* manual test_* files
 MAN_TEST_PREFIX = test_
+# Prefix for all devops_code library manual tests
+MAN_TEST_DEVOPS_PREFIX = $(MAN_TEST_PREFIX)devops_code_
 # Prefix for all skid_file_metadata_read library manual tests
 MAN_TEST_SFMR_PREFIX = $(MAN_TEST_PREFIX)sfmr_
 # Prefix for all skid_file_metadata_read library manual tests
@@ -177,6 +179,11 @@ $(DIST_DIR)$(CHECK_PREFIX)%$(OBJ_FILE_EXT): $(TEST_DIR)$(CHECK_PREFIX)%$(SRC_FIL
 	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Compiling Check unit test code: $^"
 	@$(CC) $(CFLAGS) -c $^ -o $@ -I $(INCLUDE_DIR)
+
+# MANUAL TEST: Linking devops_code library manual test binaries
+$(DIST_DIR)$(MAN_TEST_DEVOPS_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_DEVOPS_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)devops_code$(OBJ_FILE_EXT)
+	@echo "    Linking manual test binary: $@"
+	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 
 # MANUAL TEST: Linking skid_file_metadata_read library manual test binaries
 $(DIST_DIR)$(MAN_TEST_SFMR_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFMR_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT)

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -167,7 +167,7 @@ $(DIST_DIR)$(CHECK_SFMR_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SFMR_PREFIX)
 	@$(CC) $(CFLAGS) -o $@ $^ $(CHECK_CC_ARGS)
 
 # CHECK: Linking skid_file_metadata_write library unit test binaries
-$(DIST_DIR)$(CHECK_SFMW_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SFMW_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_write$(OBJ_FILE_EXT) $(DIST_DIR)devops_code$(OBJ_FILE_EXT)
+$(DIST_DIR)$(CHECK_SFMW_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SFMW_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_write$(OBJ_FILE_EXT) $(DIST_DIR)devops_code$(OBJ_FILE_EXT)
 	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Linking Check unit test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ $(CHECK_CC_ARGS)

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -189,6 +189,23 @@ time_t get_shell_mtime(const char *pathname, int *errnum);
 
 /*
  *  Description:
+ *      Get the current user's username by executing the following command in a shell:
+ *          whoami
+ *      This is intended as a double-do and not meant to be "production code".
+ *      Also, the caller is responsible for using free_devops_mem() to free the memory address
+ *      returned by this function.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      Heap-allocated string containing the username on success, NULL on error.
+ *      Check errnum for actual errno value on error.
+ */
+char *get_shell_my_username(int *errnum);
+
+/*
+ *  Description:
  *      Get the ID of pathname's owner by executing the following command in a shell:
  *          stat -c %u <pathname>
  *      This is intended as a double-do to validate the results of skid_file_metadata_read's
@@ -277,6 +294,21 @@ int micro_sleep(useconds_t num_microsecs);
 
 /*
  *  Description:
+ *      Read the contents of filename into a heap-allocated buffer.  The caller is responsible
+ *      for using free_devops_mem() to free the memory address returned by this function.
+ *
+ *  Args:
+ *      filename: The relative or absolute path of a filename to read.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      Pointer to a heap-allocated buffer, which contains the contents of filename, on success.
+ *      Returns NULL on error.  Check errnum for errno value (or -1 on unspecified error).
+ */
+char *read_a_file(const char *filename, int *errnum);
+
+/*
+ *  Description:
  *      Use remove() to delete a file.
  *
  *  Args:
@@ -342,7 +374,8 @@ int run_command(const char *command, char *output, size_t output_len);
  *  Returns:
  *      0 on success, errno on error.
  */
-int run_command_append(const char *base_cmd, const char *cmd_suffix, char *output, size_t output_len);
+int run_command_append(const char *base_cmd, const char *cmd_suffix, char *output,
+                       size_t output_len);
 
 /*
  *  Description:

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -74,6 +74,28 @@ blkcnt_t get_shell_block_count(const char *pathname, int *errnum);
 
 /*
  *  Description:
+ *      Using devops_code run_command-family functions:
+ *          1. Get the current user's username (using get_shell_my_username())
+ *          2. Parse /etc/group for all GIDs "my username" is a member of
+ *          3. Store those GIDs in a heap-allocated array of gid_t values
+ *          4. Terminate the array with "my username"'s GID (using get_shell_*() functionality)
+ *      This is intended as a double-do to facilitate testing of skid_file_metadata_write's
+ *      set_ownership() without having to hard-code brittle expected return values.
+ *      The caller is responsible for using free_devops_mem() to free the array of gid_t's
+ *      returned by this function.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      A "my GID"-terminated heap-allocated array of compatible GIDs on success.
+ *      NULL on error.  Check errnum for actual errno value.
+ */
+gid_t *get_shell_compatible_gid(int *errnum);
+
+
+/*
+ *  Description:
  *      Get the pathname's raw status change time by executing the following command in a shell:
  *          stat -c %Z <pathname>
  *      This is intended as a double-do to validate the results of skid_file_metadata_read's
@@ -269,6 +291,23 @@ uid_t get_shell_owner(const char *pathname, int *errnum);
  *      On success, errnum will be zeroized.
  */
 off_t get_shell_size(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *      Get the username's GID by executing the following command in a shell:
+ *          id -g <username>
+ *      This is intended as a double-do to facilitate testing of skid_file_metadata_write's
+ *      set_ownership() without having to hard-code brittle expected return values.
+ *
+ *  Args:
+ *      username: The name to fetch the GID for.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      GID on success, 0 on error.  The only true indication of an error is the errnum value
+ *      since 0 is a valid GID.
+ */
+gid_t get_shell_user_gid(const char *username, int *errnum);
 
 /*
  *  Description:

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -327,6 +327,25 @@ long get_sys_block_size(int *errnum);
 
 /*
  *  Description:
+ *      Answers the question, "Does pathname exist?".  Any invalid input is treated as a "no".
+ *      The following errno values are also treated as a "no":
+ *			ENOENT is obvious... file flat out doesn't exist.
+ *			ENAMETOOLONG means pathname is too long to it *can't* exist.
+ *			ENOTDIR means part of the path prefix of pathname is not a dir so it *can't* exist.
+ *		EACCES is tricky because it could be inconclusive.  Permission could be denied for one
+ *		of the directories in the path prefix of pathname.  Still, this function treats EACCES
+ *		as a "yes" because this is devops code (but prints a DEBUG warning).
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to check.
+ *
+ *  Returns:
+ *      True if pathname exists.  False otherwise.
+ */
+bool is_path_there(const char *pathname);
+
+/*
+ *  Description:
  *      Use mknod() to create a named pipe.
  *
  *  Args:

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -149,6 +149,7 @@ mode_t get_shell_file_perms(const char *pathname, int *errnum);
  *          stat -c %g <pathname>
  *      This is intended as a double-do to validate the results of skid_file_metadata_read's
  *      get_group() without having to hard-code brittle expected return values.
+ *		This usage of the stat command does *not* follow symbolic links.
  *
  *  Args:
  *      pathname: The pathname, relative or absolute, to fetch the group ID for.
@@ -265,6 +266,7 @@ char *get_shell_my_username(int *errnum);
  *          stat -c %u <pathname>
  *      This is intended as a double-do to validate the results of skid_file_metadata_read's
  *      get_owner() without having to hard-code brittle expected return values.
+ *		This usage of the stat command does *not* follow symbolic links.
  *
  *  Args:
  *      pathname: The pathname, relative or absolute, to fetch the owner ID for.

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -189,6 +189,38 @@ time_t get_shell_mtime(const char *pathname, int *errnum);
 
 /*
  *  Description:
+ *      Get the current user's GID by executing the following command in a shell:
+ *          id -g
+ *      This is intended as a double-do to facilitate testing of skid_file_metadata_write's
+ *      set_ownership() without having to hard-code brittle expected return values.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      GID on success, 0 on error.  The only true indication of an error is the errnum value
+ *      since 0 is a valid GID.
+ */
+gid_t get_shell_my_gid(int *errnum);
+
+/*
+ *  Description:
+ *      Get the current user's UID by executing the following command in a shell:
+ *          id -u
+ *      This is intended as a double-do to facilitate testing of skid_file_metadata_write's
+ *      set_ownership() without having to hard-code brittle expected return values.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      UID on success, 0 on error.  The only true indication of an error is the errnum value
+ *      since 0 is a valid UID.
+ */
+uid_t get_shell_my_uid(int *errnum);
+
+/*
+ *  Description:
  *      Get the current user's username by executing the following command in a shell:
  *          whoami
  *      This is intended as a double-do and not meant to be "production code".

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -312,6 +312,23 @@ gid_t get_shell_user_gid(const char *username, int *errnum);
 
 /*
  *  Description:
+ *      Get the username's UID by executing the following command in a shell:
+ *          id -u <username>
+ *      This is intended as a double-do to facilitate testing of skid_file_metadata_write's
+ *      set_ownership() without having to hard-code brittle expected return values.
+ *
+ *  Args:
+ *      username: The name to fetch the UID for.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      UID on success, 0 on error.  The only true indication of an error is the errnum value
+ *      since 0 is a valid UID.
+ */
+uid_t get_shell_user_uid(const char *username, int *errnum);
+
+/*
+ *  Description:
  *      Get the actual block size of the filesystem mounted in current directory by executing:
  *          stat -fc %s .
  *      This is intended as a double-do to validate the results of skid_file_metadata_read's

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -6,7 +6,8 @@
 #define __SKID_DEVOPS__
 
 #include <stdbool.h>    // bool, false, true
-#include <stddef.h>		// size_t
+#include <stddef.h>     // size_t
+#include <unistd.h>     // useconds_t
 
 // Baseline dir level to standardize file-based test input paths
 #define SKID_REPO_NAME (const char *)"sketchy-idea"  // The name of this repo
@@ -25,7 +26,7 @@
  *		Caller is respsonsible for freeing the return value with free_devops_mem().
  *		NULL on error (check errnum).
  */
-char *alloc_devops_mem(size_t num_elem, size_t size_elem, int *errnum);
+void *alloc_devops_mem(size_t num_elem, size_t size_elem, int *errnum);
 
 /*
  *  Description:
@@ -37,7 +38,7 @@ char *alloc_devops_mem(size_t num_elem, size_t size_elem, int *errnum);
  *  Returns:
  *      0 on success, errno on error.
  */
-int free_devops_mem(char **old_array);
+int free_devops_mem(void **old_array);
 
 /*
  *  Description:

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -505,4 +505,20 @@ int run_command_append(const char *base_cmd, const char *cmd_suffix, char *outpu
  */
 int run_path_command(const char *command, const char *pathname, char *output, size_t output_len);
 
+/*
+ *  Description:
+ *      Set pathname's permissions by executing the following command in a shell:
+ *          chmod <new_perms> <pathname>
+ *      This is intended as a double-do to facilitate testing of skid_file_metadata_write's
+ *      set_mode()-family of functions.
+ *
+ *  Args:
+ *      pathname: The pathname, absolute or relative, to set the permissions for.
+ *      new_perms: The new permissions, as an octal number, to set for pathname.
+ *
+ *  Returns:
+ *      0 on success, errno on error.
+ */
+int set_shell_perms(const char *pathname, mode_t new_perms);
+
 #endif  /* __SKID_DEVOPS__ */

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -327,6 +327,25 @@ int run_command(const char *command, char *output, size_t output_len);
 
 /*
  *  Description:
+ *      Uses popen to execute base_cmd + cmd_suffix in a read-only process and read the results
+ *      into output.  If there needs to be a space between base_cmd and cmd_suffix, ensure
+ *      base_cmd has a trailing space.
+ *
+ *  Args:
+ *      base_cmd: The preface command to execute.
+ *      cmd_suffix: Optional; The suffix to add to base_cmd prior to execution.  If NULL or
+ *          empty, just the base_cmd will be executed.
+ *      output: Optional; [Out] The output from command will be read into this buffer, if a valid
+ *          pointer.
+ *      output_len: Optional; If output is to be used, this value indicates the size of output.
+ *
+ *  Returns:
+ *      0 on success, errno on error.
+ */
+int run_command_append(const char *base_cmd, const char *cmd_suffix, char *output, size_t output_len);
+
+/*
+ *  Description:
  *      Uses popen to execute command + pathname in a read-only process and read the results
  *      into output.  If there needs to be a space between command and pathname, ensure
  *      command has a trailing space.

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -265,6 +265,18 @@ int make_a_socket(const char *filename);
 
 /*
  *  Description:
+ *      Call usleep() to sleep for a number of microseconds.
+ *
+ *  Args:
+ *      num_microsecs: The number of microseconds to sleep.
+ *
+ *  Returns:
+ *      0 on success, errno on error.
+ */
+int micro_sleep(useconds_t num_microsecs);
+
+/*
+ *  Description:
  *      Use remove() to delete a file.
  *
  *  Args:

--- a/code/include/skid_debug.h
+++ b/code/include/skid_debug.h
@@ -15,6 +15,7 @@
 #endif  /* __FUNCTION_NAME__ */
 
 #ifdef SKID_DEBUG
+#include <stdio.h>   // fprintf()
 #include <string.h>  // strerror()
 #define PRINT_ERRNO(errorNum) if (errorNum) { fprintf(stderr, "<<<ERROR>>> - %s - %s() - %d - Returned errno: %s\n", __FILE__, __FUNCTION_NAME__, __LINE__, strerror(errorNum)); };
 #define PRINT_ERROR(msg) do { fprintf(stderr, "<<<ERROR>>> - %s - %s() - %d - %s!\n", __FILE__, __FUNCTION_NAME__, __LINE__, #msg); } while (0);

--- a/code/include/skid_debug.h
+++ b/code/include/skid_debug.h
@@ -17,11 +17,15 @@
 #ifdef SKID_DEBUG
 #include <stdio.h>   // fprintf()
 #include <string.h>  // strerror()
-#define PRINT_ERRNO(errorNum) if (errorNum) { fprintf(stderr, "<<<ERROR>>> - %s - %s() - %d - Returned errno: %s\n", __FILE__, __FUNCTION_NAME__, __LINE__, strerror(errorNum)); };
-#define PRINT_ERROR(msg) do { fprintf(stderr, "<<<ERROR>>> - %s - %s() - %d - %s!\n", __FILE__, __FUNCTION_NAME__, __LINE__, #msg); } while (0);
-#define PRINT_WARNG(msg) do { fprintf(stderr, "¿¿¿WARNING??? - %s - %s() - %d - %s!\n", __FILE__, __FUNCTION_NAME__, __LINE__, #msg); } while (0);
+#define DEBUG_ERROR_STR "<<<ERROR>>>"
+#define DEBUG_WARNG_STR "¿¿¿WARNING???"
+#define PRINT_ERRNO(errorNum) if (errorNum) { fprintf(stderr, "%s - %s - %s() - %d - Returned errno: %s\n", DEBUG_ERROR_STR, __FILE__, __FUNCTION_NAME__, __LINE__, strerror(errorNum)); };
+#define PRINT_ERROR(msg) do { fprintf(stderr, "%s - %s - %s() - %d - %s!\n", DEBUG_ERROR_STR, __FILE__, __FUNCTION_NAME__, __LINE__, #msg); } while (0);
+#define PRINT_WARNG(msg) do { fprintf(stderr, "%s - %s - %s() - %d - %s!\n", DEBUG_WARNG_STR, __FILE__, __FUNCTION_NAME__, __LINE__, #msg); } while (0);
 #define FPRINTF_ERR(...) do { fprintf(stderr, __VA_ARGS__); } while (0);
 #else
+#define DEBUG_ERROR_STR ""
+#define DEBUG_WARNG_STR ""
 #define PRINT_ERRNO(errorNum) ;;;
 #define PRINT_ERROR(msg) ;;;
 #define PRINT_WARNG(msg) ;;;

--- a/code/include/skid_file_metadata_read.h
+++ b/code/include/skid_file_metadata_read.h
@@ -9,7 +9,7 @@
 
 /*
  *  Description:
- *		Fetches the access time (atime) for pathname by reading the st_atim member from the
+ *		Fetches the access time (atime) for pathname by reading the st_atime member from the
  *		stat struct.
  *
  *  Args:
@@ -20,6 +20,39 @@
  *		The access time, on success.  0 on error, and errnum is set.
  */
 time_t get_access_time(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *		Fetches the access time (atime) for pathname by reading the stat struct's st_atim
+ *		member and then reading that timespec struct's tv_nsec member.
+ *		This value is virtually meaningless without the context of the st_atime
+ *		(AKA st_atim.tv_sec) member value.  Use the nanoseconds to "break ties" when
+ *		comparing filestamps.
+ *
+ *  Args:
+ *		pathname: Absolute or relative pathname to fetch the access time nanoseconds for.
+ *		errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *
+ *  Returns:
+ *		The access time nanoseconds, on success.  0 on error, and errnum is set.
+ */
+long get_access_time_nsecs(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *		Fetches the access time (atime) seconds and nanoseconds for pathname by reading
+ *		the stat struct's st_atim member values.  Any value found in seconds or nseconds is
+ *		indeterminate if this function fails.
+ *
+ *  Args:
+ *		pathname: Absolute or relative pathname to fetch the access timestamp for.
+ *		seconds: [Out] Pointer to store the epoch seconds time in.
+ *		nseconds: [Out] Pointer to store the nanoseconds in.
+ *
+ *  Returns:
+ *		0 on success.  Errno value on failure.
+ */
+int get_access_timestamp(const char *pathname, time_t *seconds, long *nseconds);
 
 /*
  *  Description:
@@ -56,7 +89,7 @@ blksize_t get_block_size(const char *filename, int *errnum);
 
 /*
  *  Description:
- *		Fetches the status change time (ctime) for pathname by reading the st_ctim member from the
+ *		Fetches the status change time (ctime) for pathname by reading the st_ctime member from the
  *		stat struct.
  *
  *  Args:
@@ -67,6 +100,39 @@ blksize_t get_block_size(const char *filename, int *errnum);
  *		The status change time, on success.  0 on error, and errnum is set.
  */
 time_t get_change_time(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *		Fetches the status change time (ctime) for pathname by reading the stat struct's st_ctim
+ *		member and then reading that timespec struct's tv_nsec member.
+ *		This value is virtually meaningless without the context of the st_ctime
+ *		(AKA st_ctim.tv_sec) member value.  Use the nanoseconds to "break ties" when
+ *		comparing filestamps.
+ *
+ *  Args:
+ *		pathname: Absolute or relative pathname to fetch the change time nanoseconds for.
+ *		errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *
+ *  Returns:
+ *		The change time nanoseconds, on success.  0 on error, and errnum is set.
+ */
+long get_change_time_nsecs(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *		Fetches the status change time (ctime) seconds and nanoseconds for pathname by reading
+ *		the stat struct's st_ctim member values.  Any value found in seconds or nseconds is
+ *		indeterminate if this function fails.
+ *
+ *  Args:
+ *		pathname: Absolute or relative pathname to fetch the change timestamp for.
+ *		seconds: [Out] Pointer to store the epoch seconds time in.
+ *		nseconds: [Out] Pointer to store the nanoseconds in.
+ *
+ *  Returns:
+ *		0 on success.  Errno value on failure.
+ */
+int get_change_timestamp(const char *pathname, time_t *seconds, long *nseconds);
 
 /*
  *  Description:
@@ -176,7 +242,7 @@ nlink_t get_hard_link_num(const char *pathname, int *errnum);
 
 /*
  *  Description:
- *		Fetches the modification time (mtime) for pathname by reading the st_mtim member from the
+ *		Fetches the modification time (mtime) for pathname by reading the st_mtime member from the
  *		stat struct.
  *
  *  Args:
@@ -187,6 +253,39 @@ nlink_t get_hard_link_num(const char *pathname, int *errnum);
  *		The modification time, on success.  0 on error, and errnum is set.
  */
 time_t get_mod_time(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *		Fetches the modification time (mtime) for pathname by reading the stat struct's st_mtim
+ *		member and then reading that timespec struct's tv_nsec member.
+ *		This value is virtually meaningless without the context of the st_mtime
+ *		(AKA st_mtim.tv_sec) member value.  Use the nanoseconds to "break ties" when
+ *		comparing filestamps.
+ *
+ *  Args:
+ *		pathname: Absolute or relative pathname to fetch the modification time nanoseconds for.
+ *		errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *
+ *  Returns:
+ *		The modification time nanoseconds, on success.  0 on error, and errnum is set.
+ */
+long get_mod_time_nsecs(const char *pathname, int *errnum);
+
+/*
+ *  Description:
+ *		Fetches the status modification time (mtime) seconds and nanoseconds for pathname by reading
+ *		the stat struct's st_mtim member values.  Any value found in seconds or nseconds is
+ *		indeterminate if this function fails.
+ *
+ *  Args:
+ *		pathname: Absolute or relative pathname to fetch the modification timestamp for.
+ *		seconds: [Out] Pointer to store the epoch seconds time in.
+ *		nseconds: [Out] Pointer to store the nanoseconds in.
+ *
+ *  Returns:
+ *		0 on success.  Errno value on failure.
+ */
+int get_mod_timestamp(const char *pathname, time_t *seconds, long *nseconds);
 
 /*
  *  Description:

--- a/code/include/skid_file_metadata_read.h
+++ b/code/include/skid_file_metadata_read.h
@@ -185,14 +185,14 @@ dev_t get_file_device_id(const char *pathname, int *errnum);
  *		important, use is_sym_link() and lstat() instead.
  *
  *  Args:
- *      filename: Absolute or relative filename to check.
+ *      pathname: Absolute or relative pathname to check.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
  *      
  *  Returns:
- *		Just the file permission bits from filename's mode on success.  Returns 0 on failure
+ *		Just the file permission bits from pathname's mode on success.  Returns 0 on failure
  *		and updates errnum.
  */
-mode_t get_file_perms(const char *filename, int *errnum);
+mode_t get_file_perms(const char *pathname, int *errnum);
 
 /*
  *  Description:

--- a/code/include/skid_file_metadata_read.h
+++ b/code/include/skid_file_metadata_read.h
@@ -15,11 +15,12 @@
  *  Args:
  *      pathname: Absolute or relative pathname to fetch the access time for.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The access time, on success.  0 on error, and errnum is set.
  */
-time_t get_access_time(const char *pathname, int *errnum);
+time_t get_access_time(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -32,11 +33,12 @@ time_t get_access_time(const char *pathname, int *errnum);
  *  Args:
  *		pathname: Absolute or relative pathname to fetch the access time nanoseconds for.
  *		errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The access time nanoseconds, on success.  0 on error, and errnum is set.
  */
-long get_access_time_nsecs(const char *pathname, int *errnum);
+long get_access_time_nsecs(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -48,11 +50,12 @@ long get_access_time_nsecs(const char *pathname, int *errnum);
  *		pathname: Absolute or relative pathname to fetch the access timestamp for.
  *		seconds: [Out] Pointer to store the epoch seconds time in.
  *		nseconds: [Out] Pointer to store the nanoseconds in.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		0 on success.  Errno value on failure.
  */
-int get_access_timestamp(const char *pathname, time_t *seconds, long *nseconds);
+int get_access_timestamp(const char *pathname, time_t *seconds, long *nseconds, bool follow_sym);
 
 /*
  *  Description:
@@ -95,11 +98,12 @@ blksize_t get_block_size(const char *filename, int *errnum);
  *  Args:
  *      pathname: Absolute or relative pathname to fetch the status change time for.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The status change time, on success.  0 on error, and errnum is set.
  */
-time_t get_change_time(const char *pathname, int *errnum);
+time_t get_change_time(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -112,11 +116,12 @@ time_t get_change_time(const char *pathname, int *errnum);
  *  Args:
  *		pathname: Absolute or relative pathname to fetch the change time nanoseconds for.
  *		errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The change time nanoseconds, on success.  0 on error, and errnum is set.
  */
-long get_change_time_nsecs(const char *pathname, int *errnum);
+long get_change_time_nsecs(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -128,11 +133,12 @@ long get_change_time_nsecs(const char *pathname, int *errnum);
  *		pathname: Absolute or relative pathname to fetch the change timestamp for.
  *		seconds: [Out] Pointer to store the epoch seconds time in.
  *		nseconds: [Out] Pointer to store the nanoseconds in.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		0 on success.  Errno value on failure.
  */
-int get_change_timestamp(const char *pathname, time_t *seconds, long *nseconds);
+int get_change_timestamp(const char *pathname, time_t *seconds, long *nseconds, bool follow_sym);
 
 /*
  *  Description:
@@ -248,11 +254,12 @@ nlink_t get_hard_link_num(const char *pathname, int *errnum);
  *  Args:
  *      pathname: Absolute or relative pathname to fetch the modification time for.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The modification time, on success.  0 on error, and errnum is set.
  */
-time_t get_mod_time(const char *pathname, int *errnum);
+time_t get_mod_time(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -265,11 +272,12 @@ time_t get_mod_time(const char *pathname, int *errnum);
  *  Args:
  *		pathname: Absolute or relative pathname to fetch the modification time nanoseconds for.
  *		errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The modification time nanoseconds, on success.  0 on error, and errnum is set.
  */
-long get_mod_time_nsecs(const char *pathname, int *errnum);
+long get_mod_time_nsecs(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -281,11 +289,12 @@ long get_mod_time_nsecs(const char *pathname, int *errnum);
  *		pathname: Absolute or relative pathname to fetch the modification timestamp for.
  *		seconds: [Out] Pointer to store the epoch seconds time in.
  *		nseconds: [Out] Pointer to store the nanoseconds in.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		0 on success.  Errno value on failure.
  */
-int get_mod_timestamp(const char *pathname, time_t *seconds, long *nseconds);
+int get_mod_timestamp(const char *pathname, time_t *seconds, long *nseconds, bool follow_sym);
 
 /*
  *  Description:

--- a/code/include/skid_file_metadata_read.h
+++ b/code/include/skid_file_metadata_read.h
@@ -222,12 +222,13 @@ mode_t get_file_type(const char *filename, int *errnum);
  *  Args:
  *      pathname: Absolute or relative pathname to the group's ID for.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		Returns the owner's UID on success.  Error conditions are indicated by non-zero values
  *		in errnum.
  */
-gid_t get_group(const char *pathname, int *errnum);
+gid_t get_group(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:
@@ -306,12 +307,13 @@ int get_mod_timestamp(const char *pathname, time_t *seconds, long *nseconds, boo
  *  Args:
  *      pathname: Absolute or relative pathname to the owner's user ID for.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		Returns the owner's UID on success.  Error conditions are indicated by non-zero values
  *		in errnum.
  */
-uid_t get_owner(const char *pathname, int *errnum);
+uid_t get_owner(const char *pathname, int *errnum, bool follow_sym);
 
 /*
  *  Description:

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -45,6 +45,25 @@ int add_mode(const char *pathname, mode_t more_mode);
 
 /*
  *  Description:
+ *		Removes the less_mode permission bits from pathname by fetching the current mode,
+ *		removing less_mode bits, and then calling set_mode() with the new mode.
+ *		Symbolic links are always dereferenced.  The additional permissions for pathname are
+ *		specified in less_mode, which is a bit mask created by ORing together zero or more
+ *		SKID_MODE_* macros (or S_I* macros from chmod(2)).
+ *
+ *		See set_mode() for important notes.
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the group of.
+ *		less_mode: The permission flags to remove from pathname's mode.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int remove_mode(const char *pathname, mode_t less_mode);
+
+/*
+ *  Description:
  *		Changes the file metadata of pathname's access time to the provided values using
  *		utimensat().
  *

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -41,6 +41,24 @@ int set_atime_now(const char *pathname, bool follow_sym);
 
 /*
  *  Description:
+ *		Changes the file metadata of pathname's modification time to the provided values using
+ *		utimensat().
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the mtime of.  If pathname is relative,
+ *			pathname will be resolved against the current working directory.
+ *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
+ *			do not follow symbolic links if false.
+ *		seconds: The epoch seconds to set the mtime to.
+ *		nseconds: The nanoseconds to set the mtime to.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int set_mtime(const char *pathname, bool follow_sym, time_t seconds, long nseconds);
+
+/*
+ *  Description:
  *		Changes the file metadata of pathname's modification time to the current local time using
  *		utimensat().
  *

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -56,7 +56,7 @@ int set_atime_now(const char *pathname, bool follow_sym);
  *
  *  Args:
  *      pathname: Absolute or relative pathname to modify the group of.
- *		new_group: The GID of the new group for pathname.
+ *		new_group: The GID of the new group for pathname.  If this value is -1, it will not change.
  *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
  *			do not follow symbolic links if false.
  *
@@ -113,7 +113,7 @@ int set_mtime_now(const char *pathname, bool follow_sym);
  *
  *  Args:
  *      pathname: Absolute or relative pathname to modify the group of.
- *		new_owner: The UID of the new owner for pathname.
+ *		new_owner: The UID of the new owner for pathname.  If this value is -1, it will not change.
  *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
  *			do not follow symbolic links if false.
  *
@@ -139,8 +139,8 @@ int set_owner_id(const char *pathname, uid_t new_owner, bool follow_sym);
  *
  *  Args:
  *      pathname: Absolute or relative pathname to modify the group of.
- *		new_owner: The UID of the new owner for pathname.
- *		new_group: The GID of the new group for pathname.
+ *		new_owner: The UID of the new owner for pathname.  If this value is -1, it will not change.
+ *		new_group: The GID of the new group for pathname.  If this value is -1, it will not change.
  *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
  *			do not follow symbolic links if false.
  *

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -41,6 +41,32 @@ int set_atime_now(const char *pathname, bool follow_sym);
 
 /*
  *  Description:
+ *		Changes pathname's owner by calling chown(), or lchown() if follow_sym is false.
+ *
+ *		IMPORTANT NOTES:
+ *			- Only a privileged process (Linux: one with the CAP_CHOWN capability) may change the
+ *	   		  owner of a file.
+ *			- The owner of a file may change the group of the file to any group
+ *			  of which that owner is a member.
+ *			- A privileged process (Linux: with CAP_CHOWN) may change the group arbitrarily.
+ *			- When the owner or group of an executable file is changed by an unprivileged user,
+ *			  the S_ISUID and S_ISGID mode bits are cleared.  Specific kernel implementations
+ *			  control whether or not this also happens for privileged users.
+ *			- See chown(2) for details.
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the group of.
+ *		new_group: The GID of the new group for pathname.
+ *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
+ *			do not follow symbolic links if false.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int set_group_id(const char *pathname, gid_t new_group, bool follow_sym);
+
+/*
+ *  Description:
  *		Changes the file metadata of pathname's modification time to the provided values using
  *		utimensat().
  *
@@ -72,6 +98,56 @@ int set_mtime(const char *pathname, bool follow_sym, time_t seconds, long nsecon
  *		0, on success.  On failure, an errno value.
  */
 int set_mtime_now(const char *pathname, bool follow_sym);
+
+/*
+ *  Description:
+ *		Changes pathname's owner by calling chown(), or lchown() if follow_sym is false.
+ *
+ *		IMPORTANT NOTES:
+ *			- Only a privileged process (Linux: one with the CAP_CHOWN capability) may change the
+ *	   		  owner of a file.
+ *			- When the owner or group of an executable file is changed by an unprivileged user,
+ *			  the S_ISUID and S_ISGID mode bits are cleared.  Specific kernel implementations
+ *			  control whether or not this also happens for privileged users.
+ *			- See chown(2) for details.
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the group of.
+ *		new_owner: The UID of the new owner for pathname.
+ *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
+ *			do not follow symbolic links if false.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int set_owner_id(const char *pathname, uid_t new_owner, bool follow_sym);
+
+/*
+ *  Description:
+ *		Changes pathname's owner and group by calling chown(), or lchown() if follow_sym is false.
+ *
+ *		IMPORTANT NOTES:
+ *			- Only a privileged process (Linux: one with the CAP_CHOWN capability) may change the
+ *	   		  owner of a file.
+ *			- The owner of a file may change the group of the file to any group
+ *			  of which that owner is a member.
+ *			- A privileged process (Linux: with CAP_CHOWN) may change the group arbitrarily.
+ *			- When the owner or group of an executable file is changed by an unprivileged user,
+ *			  the S_ISUID and S_ISGID mode bits are cleared.  Specific kernel implementations
+ *			  control whether or not this also happens for privileged users.
+ *			- See chown(2) for details.
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the group of.
+ *		new_owner: The UID of the new owner for pathname.
+ *		new_group: The GID of the new group for pathname.
+ *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
+ *			do not follow symbolic links if false.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int set_ownership(const char *pathname, uid_t new_owner, gid_t new_group, bool follow_sym);
 
 /*
  *  Description:

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -4,7 +4,25 @@
 #include <errno.h>		// errno
 #include <stdbool.h>    // bool, false, true
 #include <sys/types.h>	// time_t
-// #define _POSIX_C_SOURCE 200809L
+
+/*
+ *  Description:
+ *		Changes the file metadata of pathname's access time to the provided values using
+ *		utimensat().
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the atime of.  If pathname is relative,
+ *			pathname will be resolved against the current working directory.
+ *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
+ *			do not follow symbolic links if false.
+ *		seconds: The epoch seconds to set the atime to.
+ *		nseconds: The nanoseconds to set the atime to.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int set_atime(const char *pathname, bool follow_sym, time_t seconds, long nseconds);
+
 /*
  *  Description:
  *		Changes the file metadata of pathname's access time to the current local time using

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -75,6 +75,24 @@ int set_mtime_now(const char *pathname, bool follow_sym);
 
 /*
  *  Description:
+ *		Changes the file metadata of pathname's access and modification times to both match
+ *		the provided values using utimensat().
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the mtime of.  If pathname is relative,
+ *			pathname will be resolved against the current working directory.
+ *		follow_sym: Controls how symbolic links are handled: follow symbolic links if true,
+ *			do not follow symbolic links if false.
+ *		seconds: The epoch seconds to set the mtime to.
+ *		nseconds: The nanoseconds to set the mtime to.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int set_times(const char *pathname, bool follow_sym, time_t seconds, long nseconds);
+
+/*
+ *  Description:
  *		Changes the file metadata of pathname's access and modification times to the current local
  *		time using utimensat().
  *

--- a/code/include/skid_file_metadata_write.h
+++ b/code/include/skid_file_metadata_write.h
@@ -26,6 +26,25 @@
 
 /*
  *  Description:
+ *		Adds to pathname's permission bits by fetching the current mode, ORing more_mode,
+ *		and then calling set_mode() with the new mode.  Symbolic links are always dereferenced.
+ *		The additional permissions for pathname are specified in more_mode, which is
+ *		a bit mask created by ORing together zero or more SKID_MODE_* macros (or S_I* macros from
+ *		chmod(2)).
+ *
+ *		See set_mode() for important notes.
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to modify the group of.
+ *		more_mode: The additional permission flags to add to pathname's mode.
+ *
+ *  Returns:
+ *		0, on success.  On failure, an errno value.
+ */
+int add_mode(const char *pathname, mode_t more_mode);
+
+/*
+ *  Description:
  *		Changes the file metadata of pathname's access time to the provided values using
  *		utimensat().
  *

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -826,7 +826,7 @@ gid_t get_shell_user_gid(const char *username, int *errnum)
 		results = run_command_append(command, username, output, sizeof(output) / sizeof(*output));
 		if (results)
 		{
-			PRINT_ERROR(The call to run_command() failed);
+			PRINT_ERROR(The call to run_command_append() failed);
 			PRINT_ERRNO(results);
 		}
 	}
@@ -844,6 +844,42 @@ gid_t get_shell_user_gid(const char *username, int *errnum)
 	return users_gid;
 }
 
+
+uid_t get_shell_user_uid(const char *username, int *errnum)
+{
+	// LOCAL VARIABLES
+	uid_t users_uid = 0;            // Username's UID
+	int results = ENOERR;           // Local errno value
+	char command[] = { "id -u " };  // The base shell command
+	char output[512] = { 0 };       // Output from the command
+
+	// INPUT VALIDATION
+	results = validate_err(errnum);
+
+	// GET IT
+	// Execute command
+	if (ENOERR == results)
+	{
+		results = run_command_append(command, username, output, sizeof(output) / sizeof(*output));
+		if (results)
+		{
+			PRINT_ERROR(The call to run_command_append() failed);
+			PRINT_ERRNO(results);
+		}
+	}
+	// Convert results
+	if (ENOERR == results)
+	{
+		users_uid = atoi(output);
+	}
+
+	// DONE
+	if (errnum)
+	{
+		*errnum = results;
+	}
+	return users_uid;
+}
 
 
 long get_sys_block_size(int *errnum)

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -541,7 +541,7 @@ int make_a_pipe(const char *pathname)
 	int result = validate_name(pathname);  // Errno value
 
 	// INPUT VALIDATION
-	if (ENOERR == result && mknod(pathname, S_IFIFO | 640, 0))
+	if (ENOERR == result && mknod(pathname, S_IFIFO | 0664, 0))
 	{
 		result = errno;
 		PRINT_ERROR(The call to mknod() failed);

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -607,6 +607,24 @@ int make_a_socket(const char *filename)
 }
 
 
+int micro_sleep(useconds_t num_microsecs)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno values
+
+	// SLEEP
+	if (usleep(num_microsecs))
+	{
+		errnum = errno;
+		PRINT_ERROR(The call to usleep() failed);
+		PRINT_ERRNO(errnum);
+	}
+
+	// DONE
+	return errnum;
+}
+
+
 int remove_a_file(const char *filename, bool ignore_missing)
 {
 	// LOCAL VARIABLES

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -440,6 +440,80 @@ time_t get_shell_mtime(const char *pathname, int *errnum)
 }
 
 
+gid_t get_shell_my_gid(int *errnum)
+{
+	// LOCAL VARIABLES
+	gid_t my_gid = 0;              // My GID
+	int results = ENOERR;          // Local errno value
+	char command[] = { "id -g" };  // The shell command
+	char output[512] = { 0 };      // Output from the command
+
+	// INPUT VALIDATION
+	results = validate_err(errnum);
+
+	// GET IT
+	// Execute command
+	if (ENOERR == results)
+	{
+		results = run_command(command, output, sizeof(output) / sizeof(*output));
+		if (results)
+		{
+			PRINT_ERROR(The call to run_command() failed);
+			PRINT_ERRNO(results);
+		}
+	}
+	// Convert results
+	if (ENOERR == result)
+	{
+		my_gid = atoi(output);
+	}
+
+	// DONE
+	if (errnum)
+	{
+		*errnum = results;
+	}
+	return my_gid;
+}
+
+
+uid_t get_shell_my_uid(int *errnum)
+{
+	// LOCAL VARIABLES
+	uid_t my_uid = 0;              // My UID
+	int results = ENOERR;          // Local errno value
+	char command[] = { "id -u" };  // The shell command
+	char output[512] = { 0 };      // Output from the command
+
+	// INPUT VALIDATION
+	results = validate_err(errnum);
+
+	// GET IT
+	// Execute command
+	if (ENOERR == results)
+	{
+		results = run_command(command, output, sizeof(output) / sizeof(*output));
+		if (results)
+		{
+			PRINT_ERROR(The call to run_command() failed);
+			PRINT_ERRNO(results);
+		}
+	}
+	// Convert results
+	if (ENOERR == result)
+	{
+		my_uid = atoi(output);
+	}
+
+	// DONE
+	if (errnum)
+	{
+		*errnum = results;
+	}
+	return my_uid;
+}
+
+
 char *get_shell_my_username(int *errnum)
 {
 	// LOCAL VARIABLES

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -1406,6 +1406,43 @@ int run_path_command(const char *command, const char *pathname, char *output, si
 }
 
 
+int set_shell_perms(const char *pathname, mode_t new_perms)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;                     // Errno value
+	char base_cmd[64] = { "chmod " };        // The base command
+	size_t base_cmd_len = strlen(base_cmd);  // Default length of the base command
+
+	// INPUT VALIDATION
+	result = validate_name(pathname);
+
+	// FORMAT BASE COMMAND
+	if (ENOERR == result)
+	{
+		result = snprintf(base_cmd + base_cmd_len,
+			              (sizeof(base_cmd) / sizeof(*base_cmd)) - base_cmd_len, "%o ", new_perms);
+		if (result < 0)
+		{
+			PRINT_ERROR(The call to snprintf() encountered an unspecified error);
+		}
+		else
+		{
+			result = ENOERR;  // snprintf() was just reporting on the characters it printed
+		}
+	}
+
+	// EXECUTE COMMAND
+	if (ENOERR == result)
+	{
+		FPRINTF_ERR("The set_shell_perms(%s, %o) created the '%s' base command\n", pathname, new_perms, base_cmd);  // DEBUGGING
+		result = run_path_command(base_cmd, pathname, NULL, 0);  // Ignore the output
+	}
+
+	// DONE
+	return result;
+}
+
+
 /**************************************************************************************************/
 /********************************** PRIVATE FUNCTION DEFINITIONS **********************************/
 /**************************************************************************************************/

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -1268,7 +1268,6 @@ int run_command(const char *command, char *output, size_t output_len)
 	// Setup read-only pipe
 	if (ENOERR == result)
 	{
-		FPRINTF_ERR("About to call popen(%s)\n", command);  // DEBUGGING
 		process = popen(command, "r");
 		if (NULL == process)
 		{
@@ -1538,17 +1537,14 @@ gid_t *parse_compatible_groups(char *username, int *errnum)
 				*tmp_next = '\0';  // Truncate that entry
 				tmp_next++;  // Advance to the next entry
 			}
-			// FPRINTF_ERR("LINE N: %s\nLINE N+1: %s\n", tmp_curr, tmp_next);  // DEBUGGING
 			// At this point, tmp_curr is line N and tmp_next is line N+1 (if there is one)
 			if (true == parse_group_user_list(username, tmp_curr, &tmp_gid))
 			{
-				FPRINTF_ERR("parse_group_user_list(%s, %s, %p) just returned true and provided a GID of %u\n", username, tmp_curr, &tmp_gid, tmp_gid);  // DEBUGGING
 				if (gid_index < (sizeof(local_gids) / sizeof(*local_gids)))
 				{
 					// Save the user's GID for the last index
 					if (tmp_gid != users_gid)
 					{
-						FPRINTF_ERR("About to store %u in local_gids[%d]\n", tmp_gid, gid_index);  // DEBUGGING
 						local_gids[gid_index] = tmp_gid;
 						gid_index++;  // Advance to next index
 					}
@@ -1564,10 +1560,8 @@ gid_t *parse_compatible_groups(char *username, int *errnum)
 		}
 	}
 	// Truncate the local array
-	FPRINTF_ERR("About to truncate the local array and results is [%d] %s\n", results, strerror(results));  // DEBUGGING
 	if (!results)
 	{
-		FPRINTF_ERR("The tmp_gid is %u\n", tmp_gid);  // DEBUGGING
 		if (gid_index < (sizeof(local_gids) / sizeof(*local_gids)))
 		{
 			// Save the user's GID for the last index
@@ -1587,10 +1581,8 @@ gid_t *parse_compatible_groups(char *username, int *errnum)
 	// Store those GIDs in a heap-allocated array of gid_t values
 	if (!results)
 	{
-		FPRINTF_ERR("Storing GIDs in the heap buffer and gid_index is currently %d\n", gid_index);  // DEBUGGING
 		for (int i = 0; i < gid_index; i++)
 		{
-			FPRINTF_ERR("Storing %u in gid_arr[%d]\n", local_gids[i], i);  // DEBUGGING
 			gid_arr[i] = local_gids[i];
 		}
 	}
@@ -1652,15 +1644,12 @@ bool parse_group_user_list(char *username, char *group_entry, gid_t *found_gid)
 		if (strlen(tmp_ptr) >= name_len)
 		{
 			found_ptr = strstr(tmp_ptr, username);
-			FPRINTF_ERR("strstr('%s', '%s') returned '%s'\n", tmp_ptr, username, found_ptr);  // DEBUGGING
 			if (found_ptr)
 			{
-				FPRINTF_ERR("The character value following '%s' is %d\n", username, found_ptr[name_len]);  // DEBUGGING
 				// Attempting to avoid false positives (e.g., "phil" in ":phillip")
 				if ('\0' == found_ptr[name_len] || '\n' == found_ptr[name_len]
 					|| ',' == found_ptr[name_len])
 				{
-					FPRINTF_ERR("FOUND ONE!\n");  // DEBUGGING
 					found_one = true;
 				}
 			}
@@ -1670,13 +1659,11 @@ bool parse_group_user_list(char *username, char *group_entry, gid_t *found_gid)
 	if (!results && true == found_one)
 	{
 		results = read_group_field(group_entry, 2, gid_str, SKID_MAX_ID_LEN);
-		FPRINTF_ERR("The call to read_group_field(%s, %d, %s, %d) resulted in [%d] '%s'\n", group_entry, 2, gid_str, SKID_MAX_ID_LEN, results, strerror(results));  // DEBUGGING
 	}
 	// Store the matching GID
 	if (!results && true == found_one)
 	{
 		*found_gid = atoi(gid_str);
-		FPRINTF_ERR("Just stored %u in *found_gid\n", *found_gid);  // DEBUGGING
 	}
 
 	// DONE

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -1,19 +1,19 @@
 /*
- *	This library contains non-releasable, unit-test-specific, miscellaneous helper code.
+ *  This library contains non-releasable, unit-test-specific, miscellaneous helper code.
  */
 
-#include <errno.h>      	// errno
-#include <limits.h>			// PATH_MAX
-#include <stdio.h>			// remove()
-#include <stdlib.h>			// calloc(), free()
-#include <string.h>			// strstr()
-#include <sys/socket.h>		// AF_UNIX, socket()
-#include <sys/stat.h>		// stat()
-#include <sys/un.h>			// struct sockaddr_un
-#include <unistd.h>			// getcwd()
+#include <errno.h>          // errno
+#include <limits.h>         // PATH_MAX
+#include <stdio.h>          // remove()
+#include <stdlib.h>         // calloc(), free()
+#include <string.h>         // strstr()
+#include <sys/socket.h>     // AF_UNIX, socket()
+#include <sys/stat.h>       // stat()
+#include <sys/un.h>         // struct sockaddr_un
+#include <unistd.h>         // getcwd()
 // Local includes
-#include "devops_code.h"	// Headers
-#include "skid_debug.h"		// PRINT_ERRNO()
+#include "devops_code.h"    // Headers
+#include "skid_debug.h"     // PRINT_ERRNO()
 
 
 #ifndef ENOERR
@@ -22,6 +22,8 @@
 
 // The useradd utility may only support 32 but Linux supports more
 #define SKID_MAX_USERNAME_LEN 256  // Maximum username length
+// The maximum lenth of an ID (e.g., UID, GID)
+#define SKID_MAX_ID_LEN 10  // strlen("4294967295")
 
 /**************************************************************************************************/
 /********************************* PRIVATE FUNCTION DECLARATIONS **********************************/
@@ -40,17 +42,107 @@ int convert_octal_to_decimal(int octal_value);
 
 /*
  *  Description:
+ *      Parser group_entry's colon-delimited fields for a particular field.
+ *      This function is very fault tolerant.
+ *
+ *  Args:
+ *      group_entry: One nul-terminated /etc/group line.  This line must be in the format
+ *          specified by group(5).
+ *      field_num: 0 for group_name, 1 for password, 2 for GID, or 3 for user_list.
+ *
+ *  Returns:
+ *      A pointer into group_entry on success, NULL on invalid input.
+ */
+char *extract_group_field(char *group_entry, int field_num);
+
+/*
+ *  Description:
+ *      Parser group_entry's colon-delimited fields for the user_list.
+ *      This function is very fault tolerant.
+ *
+ *  Args:
+ *      group_entry: One nul-terminated /etc/group line.  This line must be in the format
+ *          specified by group(5).
+ *
+ *  Returns:
+ *      A pointer into group_entry on success, NULL on invalid input.
+ */
+char *extract_group_user_list(char *group_entry);
+
+/*
+ *  Description:
+ *      Return a heap-allocated array of all the GIDs, found in /etc/group, where username
+ *      is a member.  Terminate the array with username's GID.  The return value should contain
+ *      all of the "groups" entries from the `id <username>` command.
+ *
+ *  Args:
+ *      username: The name to check for compatibility.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      A heap-allocated array of compatible GIDs 0 on success.  Returns NULL on failure and
+ *      errnum is updated with the relevant errno value.
+ */
+gid_t *parse_compatible_groups(char *username, int *errnum);
+
+/*
+ *  Description:
+ *      Parser group_entry's user list for username.  This function is very fault tolerant.
+ *      Trailing newlines are ignored.  Example results (sans found_gid for brevity):
+ *          p_g_u_l("hark", "docker:x:134:hark") returns true
+ *          p_g_u_l("hark", "nogroup:x:65534:") returns false
+ *          p_g_u_l("hark", "hark:x:1337:") returns false (because the user_list is empty)
+ *          p_g_u_l("hark", "docker:x:134:hark\n") returns true
+ *          p_g_u_l("hark", "docker:x:134:joe,hark") returns true
+ *          p_g_u_l("hark", "docker:x:134:hark,eddie") returns true
+ *          p_g_u_l(NULL, "docker:x:134:hark") returns false
+ *          p_g_u_l("hark", NULL) returns false
+ *
+ *  Args:
+ *      username: The name to search /etc/group's user lists for.
+ *      group_entry: One nul-terminated /etc/group line.  This line must be in the format
+ *          specified by group(5).
+ *      found_gid: [Out] Storage location for a compatible GID.  This value may or may not
+ *          be zeroized during execution.  Ignore the value found here if this function returns
+ *          false.
+ *
+ *  Returns:
+ *      True if username if found in group_entry's properly formatted "user_list" section.
+ *      False if username is not found, invalid input was received, or an error occurred.
+ */
+bool parse_group_user_list(char *username, char *group_entry, gid_t *found_gid);
+
+/*
+ *  Description:
+ *      Read a particular colon-delimited field from group_entry into field_value.  No more than
+ *      fv_len characters will be read in to field_value.  This function will nul-terminate
+ *      field_value (if there's room).
+ *
+ *  Args:
+ *      group_entry: One nul-terminated /etc/group line.  This line must be in the format
+ *          specified by group(5).
+ *      field_num: 0 for group_name, 1 for password, 2 for GID, or 3 for user_list.
+ *      field_value: [Out] A buffer to read the group_entry field into.
+ *      fv_len: The length of the buffer found at field_value.
+ *
+ *  Returns:
+ *      0 on success, errno on invalid input or error.
+ */
+int read_group_field(char *group_entry, int field_num, char *field_value, int fv_len);
+
+/*
+ *  Description:
  *      Find needle in haystack.  Truncate the rest of hastack with a trailing "/\0".
  *
  *  Args:
  *      haystack: The buffer, holding an absolute directory, to search for needle in and then
- *			modify.
- *		needle: The directory name to look for in haystack.
- *		hay_len: The number of elements in haystack, to avoid buffer overruns.
+ *          modify.
+ *      needle: The directory name to look for in haystack.
+ *      hay_len: The number of elements in haystack, to avoid buffer overruns.
  *
  *  Returns:
  *      0 on success, ENOKEY if needle is not found in haystack, ENOBUFS if haystack is not
- *		big enough to one more character, errno on error.
+ *      big enough to one more character, errno on error.
  */
 int truncate_dir(char *haystack, const char *needle, size_t hay_len);
 
@@ -59,12 +151,25 @@ int truncate_dir(char *haystack, const char *needle, size_t hay_len);
  *      Validate standard errno [Out] args on behalf of the library.  No values are changed.
  *
  *  Args:
- *		err: This must be a valid pointer.
+ *      err: This must be a valid pointer.
  *
  *  Returns:
  *      0 on success, EINVAL for bad input.
  */
 int validate_err(int *err);
+
+/*
+ *  Description:
+ *      Validate one entry from /etc/group against the format specified in group(5).  Trailing
+ *      newlines are ignored.
+ *
+ *  Args:
+ *      name: The /etc/group entry to validate.
+ *
+ *  Returns:
+ *      0 on success, EINVAL for bad input.
+ */
+int validate_group_entry(char *group_entry);
 
 /*
  *  Description:
@@ -84,7 +189,7 @@ int validate_name(const char *name);
  *
  *  Args:
  *      name: This must be a valid pointer to a string that is not empty.
- *		err: This must be a valid pointer.
+ *      err: This must be a valid pointer.
  *
  *  Returns:
  *      0 on success, EINVAL for bad input.
@@ -213,6 +318,54 @@ blkcnt_t get_shell_block_count(const char *pathname, int *errnum)
 		*errnum = err_num;
 	}
 	return retval;
+}
+
+
+gid_t *get_shell_compatible_gid(int *errnum)
+{
+	// LOCAL VARIABLES
+	int results = ENOERR;  // Results of this function's execution
+	gid_t *gid_arr = NULL;  // "My GID"-terminated, heap-allocated array of compatible GIDs
+	char *my_name = NULL;   // My username
+
+	// INPUT VALIDATION
+	results = validate_err(errnum);
+
+	// GET IT
+	// 1. Get the current user's username (using get_shell_my_username())
+	if (ENOERR == results)
+	{
+		my_name = get_shell_my_username(&results);
+	}
+	// 2. Parse /etc/group for all GIDs "my username" is a member of
+	// 3. Store those GIDs in a heap-allocated array of gid_t values
+	// 4. Terminate the array with "my username"'s GID
+	if (ENOERR == results)
+	{
+		gid_arr = parse_compatible_groups(my_name, &results);
+		if (ENOERR != results)
+		{
+			PRINT_ERROR(The call to parse_compatible_groups() failed);
+			PRINT_ERRNO(results);
+		}
+	}
+
+	// CLEANUP
+	if (my_name)
+	{
+		free_devops_mem(&my_name);  // Ignore errors
+	}
+	if (ENOERR != results && gid_arr)
+	{
+		free_devops_mem(&gid_arr);  // Ignore errors
+	}
+
+	// DONE
+	if (errnum)
+	{
+		*errnum = results;
+	}
+	return gid_arr;
 }
 
 
@@ -635,6 +788,44 @@ off_t get_shell_size(const char *pathname, int *errnum)
 }
 
 
+gid_t get_shell_user_gid(const char *username, int *errnum)
+{
+	// LOCAL VARIABLES
+	gid_t users_gid = 0;            // Username's GID
+	int results = ENOERR;           // Local errno value
+	char command[] = { "id -g " };  // The base shell command
+	char output[512] = { 0 };       // Output from the command
+
+	// INPUT VALIDATION
+	results = validate_err(errnum);
+
+	// GET IT
+	// Execute command
+	if (ENOERR == results)
+	{
+		results = run_command_append(command, usernanme, output, sizeof(output) / sizeof(*output));
+		if (results)
+		{
+			PRINT_ERROR(The call to run_command() failed);
+			PRINT_ERRNO(results);
+		}
+	}
+	// Convert results
+	if (ENOERR == result)
+	{
+		users_gid = atoi(output);
+	}
+
+	// DONE
+	if (errnum)
+	{
+		*errnum = results;
+	}
+	return users_gid;
+}
+
+
+
 long get_sys_block_size(int *errnum)
 {
 	// LOCAL VARIABLES
@@ -1031,7 +1222,8 @@ int run_command(const char *command, char *output, size_t output_len)
 }
 
 
-int run_command_append(const char *base_cmd, const char *cmd_suffix, char *output, size_t output_len)
+int run_command_append(const char *base_cmd, const char *cmd_suffix, char *output,
+	                   size_t output_len)
 {
 	// LOCAL VARIABLES
 	char *full_cmd = NULL;     // command + cmd_suffix in a heap-allocated buffer
@@ -1057,7 +1249,7 @@ int run_command_append(const char *base_cmd, const char *cmd_suffix, char *outpu
 			PRINT_ERROR(The call to alloc_devops_mem() encountered an error);
 			if (ENOERR != result)
 			{
-				PRINT_ERRNO(result);	
+				PRINT_ERRNO(result);
 			}
 			else
 			{
@@ -1150,6 +1342,288 @@ int convert_octal_to_decimal(int octal_value)
 }
 
 
+char *extract_group_field(char *group_entry, int field_num)
+{
+	// LOCAL VARIABLES
+	int results = ENOERR;             // Errno value
+	int count = 0;                    // Field count
+	char *entry_field = group_entry;  // Pointer to the given field_num
+
+	// INPUT VALIDATION
+	results = validate_group_entry(group_entry);
+	if (!results)
+	{
+		if (field_num < 0 || field_num > 3)
+		{
+			results = EINVAL;  // Bad field number
+		}
+	}
+
+	// EXTRACT IT
+	if (!results)
+	{
+		// Advance to the user_list
+		while (count < field_num && *entry_field != '\0')
+		{
+			if (':' == *entry_field)
+			{
+				count++;
+			}
+			entry_field++;  // Advance to next character
+		}
+	}
+
+	// DONE
+	if (results)
+	{
+		entry_field = NULL;
+	}
+	return entry_field;
+}
+
+
+char *extract_group_user_list(char *group_entry)
+{
+	// LOCAL VARIABLES
+	int results = ENOERR;      // Errno value
+	char *entry_field = NULL;  // Pointer to the given field_num
+
+	// INPUT VALIDATION
+	results = validate_group_entry(group_entry);
+
+	// EXTRACT IT
+	if (!results)
+	{
+		entry_field = extract_group_field(group_entry, 3);
+	}
+
+	// DONE
+	return entry_field;
+}
+
+
+gid_t *parse_compatible_groups(char *username, int *errnum)
+{
+	// LOCAL VARIABLES
+	int results = ENOERR;             // Errno value
+	gid_t local_gids[1024] = { 0 };   // Local array of GIDs
+	int gid_index = 0;                // Temporary pointer into local_gids
+	gid_t tmp_gid = 0;                // Temporary GID
+	gid_t *gid_arr = NULL;            // Array of compatible gid_t's
+	gid_t users_gid = 0;              // The GID for username
+	char *group_cont = NULL;          // Contents of /etc/group
+	char *tmp_curr = NULL;            // Temporary "current" line
+	char *tmp_next = NULL;            // Temporary "next" line
+
+	// INPUT VALIDATION
+	results = validate_standard_args(username, errnum);
+
+	// SETUP
+	if (!results)
+	{
+		users_gid = get_shell_user_gid(username, &results);
+	}
+
+	// PARSE IT
+	// Read /etc/group
+	if (!results)
+	{
+		group_cont = read_a_file("/etc/group", &results);
+	}
+	// Parse /etc/group for all GIDs "my username" is a member of
+	if (!results)
+	{
+		tmp_curr = group_cont;
+		while (NULL != tmp_curr && '\0' != *tmp_curr)
+		{
+			tmp_next = strstr(tmp_curr, "\n");
+			if (tmp_next)
+			{
+				// Separate the lines
+				*tmp_next = '\0';  // Truncate that entry
+				tmp_next++;  // Advance to the next entry
+			}
+			// At this point, tmp_curr is line N and tmp_next is line N+1 (if there is one)
+			if (true == parse_group_user_list(username, tmp_curr, &tmp_gid))
+			{
+				if (gid_index < (sizeof(local_gids) / sizeof(*local_gids)))
+				{
+					// Save the user's GID for the last index
+					if (tmp_gid != users_gid)
+					{
+						local_gids[gid_index] = tmp_gid;
+						gid_index++;  // Advance to next index
+					}
+				}
+				else
+				{
+					results = ENOBUFS;  // local_gids ran out of room?!
+				}
+			}
+			// Advance the pointers to their next lines
+			tmp_curr = tmp_next;  // Now pointing at N+1 (because line N has been parsed)
+			tmp_next = NULL;
+		}
+	}
+	// Truncate the local array
+	if (!results)
+	{
+		if (gid_index < (sizeof(local_gids) / sizeof(*local_gids)))
+		{
+			// Save the user's GID for the last index
+			local_gids[gid_index] = tmp_gid;
+			gid_index++;  // Now this becomes the index count for the GID array
+		}
+		else
+		{
+			results = ENOBUFS;  // local_gids ran out of room?!
+		}
+	}
+	// Allocate a heap buffer to store all the GIDs
+	if (!results)
+	{
+		gid_arr = alloc_devops_mem(gid_index, sizeof(*local_gids), &results);
+	}
+	// Store those GIDs in a heap-allocated array of gid_t values
+	if (!results)
+	{
+		for (int i = 0; i < gid_index; i++)
+		{
+			gid_arr[i] = local_gids[i];
+		}
+	}
+
+	// CLEANUP
+	// Always free the /etc/group file contents
+	if (group_cont)
+	{
+		free_devops_mem(&group_cont);  // Ignore errors
+	}
+	// Free the GID array if it was allocated and there was an error
+	if (ENOERR != results && gid_arr)
+	{
+		free_devops_mem(&gid_arr);  // Ignore errors
+	}
+
+	// DONE
+	if (errnum)
+	{
+		*errnum = results;
+	}
+	return gid_arr;
+}
+
+
+bool parse_group_user_list(char *username, char *group_entry, gid_t *found_gid)
+{
+	// LOCAL VARIABLES
+	bool found_one = false;                     // Username was found in group_entry's user_list
+	int results = ENOERR;                       // Control flow
+	int count = 0;                              // Colon count
+	char *tmp_ptr = group_entry;                // Iterating pointer variable into group_entry
+	char *found_ptr = NULL;                     // Pointer to an username in the user_list
+	size_t name_len = 0;                        // Length of username
+	char gid_str[SKID_MAX_ID_LEN + 1] = { 0 };  // The GID field read from group_entry
+
+	// INPUT VALIDATION
+	results = validate_name(username);
+	if (!results)
+	{
+		results = validate_group_entry(group_entry);
+	}
+	if (!results && NULL == found_gid)
+	{
+		results = EINVAL;  // NULL gid_t pointer
+	}
+	else
+	{
+		name_len = strlen(username);
+		*found_gid = 0;  // Zeroize it
+	}
+
+	// PARSE IT
+	// Find a match
+	if (!results)
+	{
+		// Advance to the user_list
+		tmp_ptr = extract_group_field(group_entry, 3);
+		// Check the user_list for username
+		if (strlen(tmp_ptr) >= name_len)
+		{
+			found_ptr = strstr(tmp_ptr, username);
+			if (found_ptr)
+			{
+				// Attempting to avoid false positives (e.g., "phil" in ":phillip")
+				if ('\0' == found_ptr[name_len] || '\n' == found_ptr[name_len]
+					|| ',' == found_ptr[name_len])
+				{
+					found_one = true;
+				}
+			}
+		}
+	}
+	// Read the matching GID
+	if (!results && true == found_one)
+	{
+		results = read_group_field(group_entry, 2, gid_str, SKID_MAX_ID_LEN);
+	}
+	// Store the matching GID
+	if (!results && true == found_one)
+	{
+		*found_gid = atoi(gid_str);
+	}
+
+	// DONE
+	return found_one;
+}
+
+
+int read_group_field(char *group_entry, int field_num, char *field_value, int fv_len)
+{
+	// LOCAL VARIABLES
+	int results = ENOERR;      // Errno value
+	char *entry_field = NULL;  // Pointer to the given field_num
+	int curr_index = 0;        // Index into group_entry field number field_num
+
+	// INPUT VALIDATION
+	results = validate_group_entry(group_entry);
+
+	// DO IT
+	// Extract it
+	if (!results)
+	{
+		entry_field = extract_group_field(group_entry, field_num);
+		if (NULL == entry_field)
+		{
+			results = -1;  // Unspecified error
+		}
+	}
+	// Read it
+	if (!results)
+	{
+		while (curr_index < fv_len)
+		{
+			// Store it
+			field_value[curr_index] = entry_field[curr_index];
+			// Check it
+			if (':' == field_value[curr_index] || '\n' == field_value[curr_index])
+			{
+				field_value[curr_index] = '\0';  // That's the end of the field
+			}
+			if ('\0' == field_value[curr_index])
+			{
+				break;  // The end
+			}
+			// Next
+			curr_index++;  // Next group field character
+		}
+	}
+
+	// DONE
+	return results;
+}
+
+
 int truncate_dir(char *haystack, const char *needle, size_t hay_len)
 {
 	// LOCAL VARIABLES
@@ -1218,6 +1692,41 @@ int validate_err(int *err)
 	if (!err)
 	{
 		result = EINVAL;  // Bad input
+	}
+
+	// DONE
+	return result;
+}
+
+
+int validate_group_entry(char *group_entry)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;          // Errno value
+	int count = 0;                // Count of colon characters (of which there must be 3)
+	char *tmp_ptr = group_entry;  // Iterating pointer
+
+	// INPUT VALIDATION
+	if (!group_entry || !(*group_entry))
+	{
+		result = EINVAL;  // Bad input
+	}
+	else
+	{
+		// Count colons
+		while (*tmp_ptr != '\0' && *tmp_ptr != '\n')
+		{
+			if (':' == *tmp_ptr)
+			{
+				count++;
+			}
+			tmp_ptr++;  // Next character
+		}
+		// Validate colons
+		if (3 != count)
+		{
+			result = EINVAL;
+		}
 	}
 
 	// DONE

--- a/code/src/devops_code.c
+++ b/code/src/devops_code.c
@@ -881,6 +881,43 @@ long get_sys_block_size(int *errnum)
 }
 
 
+bool is_path_there(const char *pathname)
+{
+	// LOCAL VARIABLES
+	bool is_there = false;  // Does pathname exist?
+	int errnum = ENOERR;    // Errno value
+	struct stat statbuf;    // Used in the call to stat()
+
+	// INPUT VALIDATION
+	if (pathname && *pathname)
+	{
+		if(stat(pathname, &statbuf))
+		{
+			errnum = errno;
+			// ENOENT is obvious... file flat out doesn't exist.
+			// ENAMETOOLONG means pathname is too long to it *can't* exist.
+			// ENOTDIR means part of the path prefix of pathname is not a dir so it *can't* exist.
+			if (ENOENT != errnum && ENAMETOOLONG != errnum && ENOTDIR != errnum)
+			{
+				if (EACCES == errnum)
+				{
+					// Permission denied might refer to a directory in pathname's path prefix
+					PRINT_WARNG(The errno value of EACCESS is inconclusive);  // Just a warning
+				}
+				is_there = true;  // Other errors means it's there, even if there's a problem
+			}
+		}
+		else
+		{
+			is_there = true;  // Found it
+		}
+	}
+
+	// DONE
+	return is_there;
+}
+
+
 int make_a_pipe(const char *pathname)
 {
 	// LOCAL VARIABLES

--- a/code/src/skid_file_metadata_read.c
+++ b/code/src/skid_file_metadata_read.c
@@ -399,7 +399,7 @@ mode_t get_file_type(const char *filename, int *errnum)
 }
 
 
-gid_t get_group(const char *pathname, int *errnum)
+gid_t get_group(const char *pathname, int *errnum, bool follow_sym)
 {
 	// LOCAL VARIABLES
 	gid_t retval = 0;                                 // GUID
@@ -410,7 +410,14 @@ gid_t get_group(const char *pathname, int *errnum)
 	// Fetch metadata
 	if (!err)
 	{
-		err = call_stat(pathname, &stat_struct, errnum);
+		if (true == follow_sym)
+		{
+			err = call_stat(pathname, &stat_struct, errnum);
+		}
+		else
+		{
+			err = call_lstat(pathname, &stat_struct, errnum);
+		}
 	}
 	// Get it
 	if (!err)
@@ -520,7 +527,7 @@ int get_mod_timestamp(const char *pathname, time_t *seconds, long *nseconds, boo
 }
 
 
-uid_t get_owner(const char *pathname, int *errnum)
+uid_t get_owner(const char *pathname, int *errnum, bool follow_sym)
 {
 	// LOCAL VARIABLES
 	uid_t retval = 0;                                 // UID
@@ -531,7 +538,14 @@ uid_t get_owner(const char *pathname, int *errnum)
 	// Fetch metadata
 	if (!err)
 	{
-		err = call_stat(pathname, &stat_struct, errnum);
+		if (true == follow_sym)
+		{
+			err = call_stat(pathname, &stat_struct, errnum);
+		}
+		else
+		{
+			err = call_lstat(pathname, &stat_struct, errnum);
+		}
 	}
 	// Get it
 	if (!err)

--- a/code/src/skid_file_metadata_read.c
+++ b/code/src/skid_file_metadata_read.c
@@ -349,19 +349,19 @@ dev_t get_file_device_id(const char *pathname, int *errnum)
 }
 
 
-mode_t get_file_perms(const char *filename, int *errnum)
+mode_t get_file_perms(const char *pathname, int *errnum)
 {
 	// LOCAL VARIABLES
 	mode_t perm_mask = S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO;  // Perm bitmask
 	mode_t retval = 0;                                                             // File perms
-	int err = validate_sfmr_input(filename, errnum);                               // Errno value
+	int err = validate_sfmr_input(pathname, errnum);                               // Errno value
 	struct stat stat_struct;                                                       // stat struct
 
 	// GET IT
 	// Fetch metadata
 	if (!err)
 	{
-		err = call_stat(filename, &stat_struct, errnum);
+		err = call_stat(pathname, &stat_struct, errnum);
 	}
 	// Get it
 	if (!err)

--- a/code/src/skid_file_metadata_read.c
+++ b/code/src/skid_file_metadata_read.c
@@ -18,7 +18,7 @@
 /*
  *  Description:
  *      Calls one of the stat-family functions based on caller arguments.  Defaults to stat().
- *		If pathname is a symbolic link and follow_sym is true, uses lstat() instead.
+ *		If pathname is a symbolic link and follow_sym is false, uses lstat() instead.
  *  Args:
  *      pathname: Absolute or relative pathname to check with lstat().
  *		statbuf: [Out] Pointer to a stat struct to update with the results of the call to stat().

--- a/code/src/skid_file_metadata_read.c
+++ b/code/src/skid_file_metadata_read.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to read, parse, and report on Linux file metadata.
  */
 
-#define SKID_DEBUG  // Enable DEBUGGING output
+// #define SKID_DEBUG  // Enable DEBUGGING output
 
 #include "skid_debug.h"				  // PRINT_ERRNO()
 #include "skid_file_metadata_read.h"
@@ -167,13 +167,11 @@ int get_access_timestamp(const char *pathname, time_t *seconds, long *nseconds, 
 	if (ENOERR == result)
 	{
 		*seconds = get_access_time(pathname, &result, follow_sym);
-		fprintf(stderr, "%s ATIME SECONDS: %ld\n", pathname, *seconds);  // DEBUGGING
 	}
 	// nseconds
 	if (ENOERR == result)
 	{
 		*nseconds = get_access_time_nsecs(pathname, &result, follow_sym);
-		fprintf(stderr, "%s ATIME NSECONDS: %ld\n", pathname, *nseconds );  // DEBUGGING
 	}
 
 	// DONE
@@ -807,6 +805,10 @@ int call_a_stat(const char *pathname, struct stat *statbuf, int *errnum, bool fo
 	}
 
 	// DONE
+	if (errnum)
+	{
+		*errnum = result;
+	}
 	return result;
 }
 

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -242,6 +242,37 @@ int set_mtime_now(const char *pathname, bool follow_sym)
 }
 
 
+int set_times(const char *pathname, bool follow_sym, time_t seconds, long nseconds)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;            // 0 on success, errno on failure
+	struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
+
+	// INPUT VALIDATION
+	result = validate_pathname(pathname);
+
+	// SET IT
+	// Prepare atime
+	if (ENOERR == result)
+	{
+		result = set_timespec(&(times[SFMW_ATIME_INDEX]), seconds, nseconds);
+	}
+	// Prepare mtime
+	if (ENOERR == result)
+	{
+		result = set_timespec(&(times[SFMW_MTIME_INDEX]), seconds, nseconds);
+	}
+	// Call call_utnsat()
+	if (ENOERR == result)
+	{
+		result = call_utnsat(pathname, times, follow_sym);
+	}
+
+	// DONE
+	return result;
+}
+
+
 int set_times_now(const char *pathname, bool follow_sym)
 {
 	// LOCAL VARIABLES

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -217,9 +217,7 @@ int call_utnsat(const char *pathname, const struct timespec times[2], bool follo
 		{
 			// If pathname specifies a symbolic link, then update the timestamps of the link,
 			// rather than the file to which it refers.
-			fprintf(stderr, "BEFORE FLAGS: 0x%X\n", flags);  // DEBUGGING
 			flags |= AT_SYMLINK_NOFOLLOW;
-			fprintf(stderr, "AFTER FLAGS:  0x%X\n", flags);  // DEBUGGING
 		}
 	}
 	// Call utimensat()

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -239,6 +239,30 @@ int set_group_id(const char *pathname, gid_t new_group, bool follow_sym)
 }
 
 
+int set_mode(const char *pathname, mode_t new_mode)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;  // 0 on success, errno on failure
+
+	// INPUT VALIDATION
+	result = validate_pathname(pathname);
+
+	// SET IT
+	if (ENOERR == result)
+	{
+		if (chmod(pathname, new_mode))
+		{
+			result = errno;
+			PRINT_ERROR(The call to chmod() failed);
+			PRINT_ERRNO(result);
+		}
+	}
+
+	// DONE
+	return result;
+}
+
+
 int set_mtime(const char *pathname, bool follow_sym, time_t seconds, long nseconds)
 {
 	// LOCAL VARIABLES

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -3,7 +3,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L		  // Expose utimensat()
-#define SKID_DEBUG                    // Enable DEBUGGING output
+// #define SKID_DEBUG                    // Enable DEBUGGING output
 
 #include <fcntl.h>					  // AT_FDCWD
 #include "skid_debug.h"				  // PRINT_ERRNO()

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -2,12 +2,13 @@
  *	This library defines functionality to modify Linux file metadata.
  */
 
-#define _POSIX_C_SOURCE 200809L		  // Expose utimensat()
+#define _POSIX_C_SOURCE 200809L		  	// Expose utimensat()
 // #define SKID_DEBUG                    // Enable DEBUGGING output
 
-#include <fcntl.h>					  // AT_FDCWD
-#include "skid_debug.h"				  // PRINT_ERRNO()
-#include "skid_file_metadata_read.h"
+#include <fcntl.h>					  	// AT_FDCWD
+#include "skid_debug.h"				  	// PRINT_ERRNO()
+#include "skid_file_metadata_read.h"	// get_file_perms()
+#include "skid_file_metadata_write.h"	// set_mode()
 #ifndef ENOERR
 #define ENOERR ((int)0)
 #endif  /* ENOERR */
@@ -157,6 +158,40 @@ int validate_timespec(struct timespec *time);
 /**************************************************************************************************/
 /********************************** PUBLIC FUNCTION DEFINITIONS ***********************************/
 /**************************************************************************************************/
+
+
+int add_mode(const char *pathname, mode_t more_mode)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;  // 0 on success, errno on failure
+	mode_t old_mode = 0;  // Read this with get_file_perms()
+	mode_t new_mode = 0;  // Set this with set_mode()
+
+	// INPUT VALIDATION
+	result = validate_pathname(pathname);
+
+	// ADD IT UP
+	// 1. Get current mode
+	if (ENOERR == result)
+	{
+		old_mode = get_file_perms(pathname, &result);
+	}
+	// 2. Add more_mode
+	if (ENOERR == result)
+	{
+		new_mode = old_mode | more_mode;
+	}
+	// 3. Call set_mode()
+	if (ENOERR == result)
+	{
+		result = set_mode(pathname, new_mode);
+	}
+
+	// DONE
+	return result;
+}
+
+
 int set_atime(const char *pathname, bool follow_sym, time_t seconds, long nseconds)
 {
 	// LOCAL VARIABLES

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -3,6 +3,8 @@
  */
 
 #define _POSIX_C_SOURCE 200809L		  // Expose utimensat()
+#define SKID_DEBUG                    // Enable DEBUGGING output
+
 #include <fcntl.h>					  // AT_FDCWD
 #include "skid_debug.h"				  // PRINT_ERRNO()
 #include "skid_file_metadata_read.h"
@@ -215,12 +217,15 @@ int call_utnsat(const char *pathname, const struct timespec times[2], bool follo
 		{
 			// If pathname specifies a symbolic link, then update the timestamps of the link,
 			// rather than the file to which it refers.
+			fprintf(stderr, "BEFORE FLAGS: 0x%X\n", flags);  // DEBUGGING
 			flags |= AT_SYMLINK_NOFOLLOW;
+			fprintf(stderr, "AFTER FLAGS:  0x%X\n", flags);  // DEBUGGING
 		}
 	}
 	// Call utimensat()
 	if (ENOERR == retval)
 	{
+		FPRINTF_ERR("Calling utimensat(%s)\n", pathname);  // DEBUGGING
 		if(utimensat(dirfd, pathname, times, flags))
 		{
 			retval = errno;

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -180,6 +180,37 @@ int set_atime_now(const char *pathname, bool follow_sym)
 }
 
 
+int set_mtime(const char *pathname, bool follow_sym, time_t seconds, long nseconds)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;            // 0 on success, errno on failure
+	struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
+
+	// INPUT VALIDATION
+	result = validate_pathname(pathname);
+
+	// SET IT
+	// Prepare atime
+	if (ENOERR == result)
+	{
+		result = set_timespec_omit(&(times[SFMW_ATIME_INDEX]));
+	}
+	// Prepare mtime
+	if (ENOERR == result)
+	{
+		result = set_timespec(&(times[SFMW_MTIME_INDEX]), seconds, nseconds);
+	}
+	// Call call_utnsat()
+	if (ENOERR == result)
+	{
+		result = call_utnsat(pathname, times, follow_sym);
+	}
+
+	// DONE
+	return result;
+}
+
+
 int set_mtime_now(const char *pathname, bool follow_sym)
 {
 	// LOCAL VARIABLES

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -192,6 +192,38 @@ int add_mode(const char *pathname, mode_t more_mode)
 }
 
 
+int remove_mode(const char *pathname, mode_t less_mode)
+{
+	// LOCAL VARIABLES
+	int result = ENOERR;  // 0 on success, errno on failure
+	mode_t old_mode = 0;  // Read this with get_file_perms()
+	mode_t new_mode = 0;  // Set this with set_mode()
+
+	// INPUT VALIDATION
+	result = validate_pathname(pathname);
+
+	// ADD IT UP
+	// 1. Get current mode
+	if (ENOERR == result)
+	{
+		old_mode = get_file_perms(pathname, &result);
+	}
+	// 2. Remove less_mode
+	if (ENOERR == result)
+	{
+		new_mode = old_mode & (~less_mode);
+	}
+	// 3. Call set_mode()
+	if (ENOERR == result)
+	{
+		result = set_mode(pathname, new_mode);
+	}
+
+	// DONE
+	return result;
+}
+
+
 int set_atime(const char *pathname, bool follow_sym, time_t seconds, long nseconds)
 {
 	// LOCAL VARIABLES

--- a/code/test/check_sfmr_get_access_time.c
+++ b/code/test/check_sfmr_get_access_time.c
@@ -63,8 +63,6 @@ time_t get_expected_return(const char *pathname)
 	// VALIDATION
 	ck_assert_msg(0 == errnum, "get_shell_atime(%s) failed with [%d] %s",
 				  pathname, errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_atime(%s) provided an invalid value of %ld",
-				  pathname, exp_result);
 
 	// DONE
 	return exp_result;

--- a/code/test/check_sfmr_get_access_time.c
+++ b/code/test/check_sfmr_get_access_time.c
@@ -24,257 +24,274 @@ code/dist/check_sfmr_get_access_time.bin && CK_FORK=no valgrind --leak-check=ful
 
 
 /**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+
+/*
+ *	Get the expected return value for pathname.
+ */
+time_t get_expected_return(const char *pathname);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+
+time_t get_expected_return(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                 // Errno from the function call
+	time_t exp_result = get_shell_atime(pathname, &errnum);  // Expected result
+
+	// VALIDATION
+	ck_assert_msg(0 == errnum, "get_shell_atime(%s) failed with [%d] %s",
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_atime(%s) provided an invalid value of %ld",
+				  pathname, exp_result);
+
+	// DONE
+	return exp_result;
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                      // Errno values
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };  // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };  // Default test input: socket
+
+	// SET IT UP
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Pipe
+	remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+}
+
+
+/**************************************************************************************************/
 /*************************************** NORMAL TEST CASES ****************************************/
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    time_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    time_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	time_t result = 0;                         // Return value from function call
+	int errnum = CANARY_INT;                   // Errno from the function call
+	time_t exp_result = 0;                     // Expected results
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_atime(input_path, &errnum);
+	// SETUP
+	exp_result = get_expected_return(input_abs_path);
 
-    // VALIDATION
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
-
-    // TEST START
-    result = get_access_time(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_access_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    time_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    time_t exp_result = 0;                // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	time_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                  // Errno from the function call
+	time_t exp_result = 0;                    // Expected results
+	char input_abs_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_atime(input_path, &errnum);
+	// SETUP
+	exp_result = get_expected_return(input_abs_path);
 
-    // VALIDATION
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
-
-    // TEST START
-    result = get_access_time(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_access_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function calls
+	time_t exp_result = 0;    // Expected results
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/");
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_atime(input_abs_path, &errnum);
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// SETUP
+	exp_result = get_expected_return(input_abs_path);
 
-    // TEST START
-    result = get_access_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_access_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function calls
+	time_t exp_result = 0;    // Expected results
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_atime(input_abs_path, &errnum);
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// SETUP
+	exp_result = get_expected_return(test_pipe_path);
 
-    // TEST START
-    result = get_access_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
-
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// TEST START
+	result = get_access_time(test_pipe_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function calls
+	time_t exp_result = 0;    // Expected results
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_atime(input_abs_path, &errnum);
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// SETUP
+	exp_result = get_expected_return(input_abs_path);
 
-    // TEST START
-    result = get_access_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_access_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/raw_socket" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function calls
+	time_t exp_result = 0;    // Expected results
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_socket() succeeds
-    errnum = make_a_socket(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_atime(input_abs_path, &errnum);
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// SETUP
+	exp_result = get_expected_return(test_socket_path);
 
-    // TEST START
-    result = get_access_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
-
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// TEST START
+	result = get_access_time(test_socket_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function calls
+	time_t exp_result = 0;    // Expected results
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_atime(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_atime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_atime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_atime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// SETUP
+	exp_result = get_expected_return(actual_abs_path);
 
-    // TEST START
-    result = get_access_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_access_time(input_abs_path, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
 }
 END_TEST
 
@@ -284,37 +301,37 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    time_t exp_result = 0;    // Expected results
-    result = get_access_time(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	time_t exp_result = 0;    // Expected results
+	result = get_access_time(NULL, &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    time_t exp_result = 0;    // Expected results
-    result = get_access_time("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	time_t exp_result = 0;    // Expected results
+	result = get_access_time("\0 NOT HERE!", &errnum);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    time_t result = 0;        // Return value from function call
-    time_t exp_result = 0;    // Expected results
-    result = get_access_time("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
-                  result, exp_result);
+	time_t result = 0;        // Return value from function call
+	time_t exp_result = 0;    // Expected results
+	result = get_access_time("/dev/loop0", NULL);
+	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
+				  result, exp_result);
 }
 END_TEST
 
@@ -324,67 +341,67 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_access_time("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	result = get_access_time("/does/not/exist.txt", &errnum);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
 }
 END_TEST
 
  
 Suite *get_access_time_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_Access_Time");
+	suite = suite_create("SFMR_Get_Access_Time");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
+	tcase_add_checked_fixture(tc_core, setup, teardown);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
-
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_access_time.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_access_time.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_access_time_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_access_time_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_access_time.c
+++ b/code/test/check_sfmr_get_access_time.c
@@ -150,12 +150,13 @@ START_TEST(test_n01_block_device)
 	int errnum = CANARY_INT;                   // Errno from the function call
 	time_t exp_result = 0;                     // Expected results
 	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+	bool follow_sym = true;                    // Test case input
 
 	// SETUP
 	exp_result = get_expected_return(input_abs_path);
 
 	// TEST START
-	result = get_access_time(input_abs_path, &errnum);
+	result = get_access_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -170,12 +171,13 @@ START_TEST(test_n02_character_device)
 	int errnum = CANARY_INT;                  // Errno from the function call
 	time_t exp_result = 0;                    // Expected results
 	char input_abs_path[] = { "/dev/null" };  // Test case input
+	bool follow_sym = true;                    // Test case input
 
 	// SETUP
 	exp_result = get_expected_return(input_abs_path);
 
 	// TEST START
-	result = get_access_time(input_abs_path, &errnum);
+	result = get_access_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -189,6 +191,7 @@ START_TEST(test_n03_directory)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function calls
 	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
 	// Absolute path for input_rel_path as resolved against the repo name
 	char *input_abs_path = resolve_test_input("./code/test/test_input/");
 
@@ -196,7 +199,7 @@ START_TEST(test_n03_directory)
 	exp_result = get_expected_return(input_abs_path);
 
 	// TEST START
-	result = get_access_time(input_abs_path, &errnum);
+	result = get_access_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -213,12 +216,13 @@ START_TEST(test_n04_named_pipe)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function calls
 	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
 
 	// SETUP
 	exp_result = get_expected_return(test_pipe_path);
 
 	// TEST START
-	result = get_access_time(test_pipe_path, &errnum);
+	result = get_access_time(test_pipe_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -232,6 +236,7 @@ START_TEST(test_n05_regular_file)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function calls
 	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
 	// Absolute path for input_rel_path as resolved against the repo name
 	char *input_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
 
@@ -239,7 +244,7 @@ START_TEST(test_n05_regular_file)
 	exp_result = get_expected_return(input_abs_path);
 
 	// TEST START
-	result = get_access_time(input_abs_path, &errnum);
+	result = get_access_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -256,12 +261,13 @@ START_TEST(test_n06_socket)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function calls
 	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
 
 	// SETUP
 	exp_result = get_expected_return(test_socket_path);
 
 	// TEST START
-	result = get_access_time(test_socket_path, &errnum);
+	result = get_access_time(test_socket_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -275,6 +281,7 @@ START_TEST(test_n07_symbolic_link)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function calls
 	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
 	// Absolute path for input_rel_path as resolved against the repo name
 	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
 	// Absolute path for actual_rel_path as resolved against the repo name
@@ -284,7 +291,7 @@ START_TEST(test_n07_symbolic_link)
 	exp_result = get_expected_return(actual_abs_path);
 
 	// TEST START
-	result = get_access_time(input_abs_path, &errnum);
+	result = get_access_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -304,7 +311,8 @@ START_TEST(test_e01_null_filename)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function call
 	time_t exp_result = 0;    // Expected results
-	result = get_access_time(NULL, &errnum);
+	bool follow_sym = true;   // Test case input
+	result = get_access_time(NULL, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
@@ -317,7 +325,8 @@ START_TEST(test_e02_empty_filename)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function call
 	time_t exp_result = 0;    // Expected results
-	result = get_access_time("\0 NOT HERE!", &errnum);
+	bool follow_sym = true;   // Test case input
+	result = get_access_time("\0 NOT HERE!", &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
@@ -329,7 +338,8 @@ START_TEST(test_e03_null_errnum)
 {
 	time_t result = 0;        // Return value from function call
 	time_t exp_result = 0;    // Expected results
-	result = get_access_time("/dev/loop0", NULL);
+	bool follow_sym = true;   // Test case input
+	result = get_access_time("/dev/loop0", NULL, follow_sym);
 	ck_assert_msg(exp_result == result, "get_access_time() returned %ld instead of %ld",
 				  result, exp_result);
 }
@@ -343,7 +353,8 @@ START_TEST(test_s01_missing_filename)
 {
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function call
-	result = get_access_time("/does/not/exist.txt", &errnum);
+	bool follow_sym = true;   // Test case input
+	result = get_access_time("/does/not/exist.txt", &errnum, follow_sym);
 	ck_assert(0 == result);
 	ck_assert_int_eq(ENOENT, errnum);
 }

--- a/code/test/check_sfmr_get_access_time.c
+++ b/code/test/check_sfmr_get_access_time.c
@@ -86,7 +86,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -131,10 +131,10 @@ void teardown(void)
 {
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 }
 
 
@@ -203,7 +203,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -248,7 +248,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -295,8 +295,8 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -409,7 +409,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_block_count.c
+++ b/code/test/check_sfmr_get_block_count.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -235,7 +235,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -275,8 +275,8 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+    free_devops_mem((void **)&input_abs_path);
+    free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -385,7 +385,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_block_size.c
+++ b/code/test/check_sfmr_get_block_size.c
@@ -111,7 +111,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -153,7 +153,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -189,7 +189,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -231,7 +231,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -267,7 +267,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -376,7 +376,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_change_time.c
+++ b/code/test/check_sfmr_get_change_time.c
@@ -42,8 +42,6 @@ START_TEST(test_n01_block_device)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -71,8 +69,6 @@ START_TEST(test_n02_character_device)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -105,8 +101,6 @@ START_TEST(test_n03_directory)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -147,8 +141,6 @@ START_TEST(test_n04_named_pipe)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -185,8 +177,6 @@ START_TEST(test_n05_regular_file)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -227,8 +217,6 @@ START_TEST(test_n06_socket)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -269,8 +257,6 @@ START_TEST(test_n07_symbolic_link)
 	// It is important get_shell_ctime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_ctime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_ctime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START

--- a/code/test/check_sfmr_get_change_time.c
+++ b/code/test/check_sfmr_get_change_time.c
@@ -110,7 +110,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -151,7 +151,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -186,7 +186,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -227,7 +227,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -266,8 +266,8 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -380,7 +380,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_change_time.c
+++ b/code/test/check_sfmr_get_change_time.c
@@ -32,6 +32,7 @@ START_TEST(test_n01_block_device)
 	time_t result = 0;                     // Return value from function call
 	int errnum = CANARY_INT;               // Errno from the function call
 	time_t exp_result = 0;                 // Expected results
+	bool follow_sym = true;                // Test case input
 	char input_path[] = { "/dev/loop0" };  // Test case input
 
 	// SETUP
@@ -46,7 +47,7 @@ START_TEST(test_n01_block_device)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_path, &errnum);
+	result = get_change_time(input_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -60,6 +61,7 @@ START_TEST(test_n02_character_device)
 	time_t result = 0;                    // Return value from function call
 	int errnum = CANARY_INT;              // Errno from the function call
 	time_t exp_result = 0;                // Expected results
+	bool follow_sym = true;               // Test case input
 	char input_path[] = { "/dev/null" };  // Test case input
 
 	// SETUP
@@ -74,7 +76,7 @@ START_TEST(test_n02_character_device)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_path, &errnum);
+	result = get_change_time(input_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -89,6 +91,7 @@ START_TEST(test_n03_directory)
 	time_t result = 0;                       // Return value from function call
 	int errnum = CANARY_INT;                 // Errno from the function calls
 	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
 	// Relative path for this test case's input
 	char input_rel_path[] = { "./code/test/test_input/" };
 	// Absolute path for input_rel_path as resolved against the repo name
@@ -107,7 +110,7 @@ START_TEST(test_n03_directory)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_abs_path, &errnum);
+	result = get_change_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -125,6 +128,7 @@ START_TEST(test_n04_named_pipe)
 	time_t result = 0;                       // Return value from function call
 	int errnum = CANARY_INT;                 // Errno from the function calls
 	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
 	// Relative path for this test case's input
 	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
 	// Absolute path for input_rel_path as resolved against the repo name
@@ -148,7 +152,7 @@ START_TEST(test_n04_named_pipe)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_abs_path, &errnum);
+	result = get_change_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -167,6 +171,7 @@ START_TEST(test_n05_regular_file)
 	time_t result = 0;                       // Return value from function call
 	int errnum = CANARY_INT;                 // Errno from the function calls
 	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
 	// Relative path for this test case's input
 	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
 	// Absolute path for input_rel_path as resolved against the repo name
@@ -185,7 +190,7 @@ START_TEST(test_n05_regular_file)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_abs_path, &errnum);
+	result = get_change_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -203,6 +208,7 @@ START_TEST(test_n06_socket)
 	time_t result = 0;                       // Return value from function call
 	int errnum = CANARY_INT;                 // Errno from the function calls
 	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
 	// Relative path for this test case's input
 	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
 	// Absolute path for input_rel_path as resolved against the repo name
@@ -226,7 +232,7 @@ START_TEST(test_n06_socket)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_abs_path, &errnum);
+	result = get_change_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -245,6 +251,7 @@ START_TEST(test_n07_symbolic_link)
 	time_t result = 0;                       // Return value from function call
 	int errnum = CANARY_INT;                 // Errno from the function calls
 	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
 	// Relative path for this test case's input
 	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
 	// Relative path for this test case's input
@@ -267,7 +274,7 @@ START_TEST(test_n07_symbolic_link)
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
-	result = get_change_time(input_abs_path, &errnum);
+	result = get_change_time(input_abs_path, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
@@ -287,7 +294,8 @@ START_TEST(test_e01_null_filename)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function call
 	time_t exp_result = 0;    // Expected results
-	result = get_change_time(NULL, &errnum);
+	bool follow_sym = true;   // Test case input
+	result = get_change_time(NULL, &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
@@ -300,7 +308,8 @@ START_TEST(test_e02_empty_filename)
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function call
 	time_t exp_result = 0;    // Expected results
-	result = get_change_time("\0 NOT HERE!", &errnum);
+	bool follow_sym = true;   // Test case input
+	result = get_change_time("\0 NOT HERE!", &errnum, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
@@ -312,7 +321,8 @@ START_TEST(test_e03_null_errnum)
 {
 	time_t result = 0;        // Return value from function call
 	time_t exp_result = 0;    // Expected results
-	result = get_change_time("/dev/loop0", NULL);
+	bool follow_sym = true;   // Test case input
+	result = get_change_time("/dev/loop0", NULL, follow_sym);
 	ck_assert_msg(exp_result == result, "get_change_time() returned %ld instead of %ld",
 				  result, exp_result);
 }
@@ -326,7 +336,8 @@ START_TEST(test_s01_missing_filename)
 {
 	time_t result = 0;        // Return value from function call
 	int errnum = CANARY_INT;  // Errno from the function call
-	result = get_change_time("/does/not/exist.txt", &errnum);
+	bool follow_sym = true;   // Test case input
+	result = get_change_time("/does/not/exist.txt", &errnum, follow_sym);
 	ck_assert(0 == result);
 	ck_assert_int_eq(ENOENT, errnum);
 }

--- a/code/test/check_sfmr_get_container_device_id.c
+++ b/code/test/check_sfmr_get_container_device_id.c
@@ -86,7 +86,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -121,7 +121,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -150,7 +150,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -185,7 +185,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -214,7 +214,7 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -323,7 +323,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_file_device_id.c
+++ b/code/test/check_sfmr_get_file_device_id.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_file_perms.c
+++ b/code/test/check_sfmr_get_file_perms.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_file_type.c
+++ b/code/test/check_sfmr_get_file_type.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_get_group.c
+++ b/code/test/check_sfmr_get_group.c
@@ -9,13 +9,13 @@ code/dist/check_sfmr_get_group.bin && CK_FORK=no valgrind --leak-check=full --sh
  *
  */
 
-#include <check.h>                    // START_TEST(), END_TEST
-#include <limits.h>                   // PATH_MAX
-#include <stdio.h>                    // printf()
+#include <check.h>					// START_TEST(), END_TEST
+#include <limits.h>				   // PATH_MAX
+#include <stdio.h>					// printf()
 #include <stdlib.h>
-#include <unistd.h>                   // get_current_dir_name()
+#include <unistd.h>				   // get_current_dir_name()
 // Local includes
-#include "devops_code.h"              // resolve_to_repo(), SKID_REPO_NAME
+#include "devops_code.h"			  // resolve_to_repo(), SKID_REPO_NAME
 #include "skid_file_metadata_read.h"  // get_group()
 
 
@@ -26,255 +26,264 @@ code/dist/check_sfmr_get_group.bin && CK_FORK=no valgrind --leak-check=full --sh
 /**************************************************************************************************/
 /*************************************** NORMAL TEST CASES ****************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    uid_t result = 0;                      // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    uid_t exp_result = 0;                  // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	uid_t result = 0;						   // Return value from function call
+	int errnum = CANARY_INT;				   // Errno from the function calls
+	bool follow = true;			 		   	   // Test case input
+	uid_t exp_result = 0;					   // Expected results
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_group(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_group(input_abs_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    uid_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    uid_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	uid_t result = 0;						  // Return value from function call
+	int errnum = CANARY_INT;				  // Errno from the function calls
+	bool follow = true;			 		   	  // Test case input
+	uid_t exp_result = 0;					  // Expected results
+	char input_abs_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_group(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_group(input_abs_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+			   exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;						 // Return value from function call
+	int errnum = CANARY_INT;				 // Errno from the function calls
+	bool follow = true;			 		   	 // Test case input
+	uid_t exp_result = 0;					 // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_group(input_abs_path, &errnum);
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+			   input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_group(input_abs_path, &errnum);
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+			   exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;						 // Return value from function call
+	int errnum = CANARY_INT;				 // Errno from the function calls
+	bool follow = true;			 		   	 // Test case input
+	uid_t exp_result = 0;					 // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_group(input_abs_path, &errnum);
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+			   input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+			   errnum, strerror(errnum));
+	exp_result = get_shell_group(input_abs_path, &errnum);
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+			   exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;						 // Return value from function call
+	int errnum = CANARY_INT;				 // Errno from the function calls
+	bool follow = true;			 		   	 // Test case input
+	uid_t exp_result = 0;					 // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_group(input_abs_path, &errnum);
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+			   input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_group(input_abs_path, &errnum);
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+			   exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;                     // Repo name
-    uid_t result = 0;                                           // Return value from function call
-    int errnum = CANARY_INT;                                    // Errno from the function call
-    uid_t exp_result = 0;                                       // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/raw_socket" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;						 // Return value from function call
+	int errnum = CANARY_INT;				 // Errno from the function calls
+	bool follow = true;			 		   	 // Test case input
+	uid_t exp_result = 0;					 // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_socket() succeeds
-    errnum = make_a_socket(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_group(input_abs_path, &errnum);
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+			   input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+			   errnum, strerror(errnum));
+	exp_result = get_shell_group(input_abs_path, &errnum);
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+			   exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;						 // Return value from function call
+	int errnum = CANARY_INT;				 // Errno from the function calls
+	bool follow = true;			 		   	 // Test case input
+	uid_t exp_result = 0;					 // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Relative path for this test case's input
+	char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_group(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_group() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+			   input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_group(actual_abs_path, &errnum);  // Special because of sym link
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group() failed with [%d] %s",
+			   errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group() provided an invalid value of %u",
+			   exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_group(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem((void **)&input_abs_path);
-    free_devops_mem((void **)&actual_abs_path);
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -282,39 +291,44 @@ END_TEST
 /**************************************************************************************************/
 /**************************************** ERROR TEST CASES ****************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_e01_null_filename)
 {
-    uid_t result = 0;         // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    uid_t exp_result = 0;     // Expected results
-    result = get_group(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	uid_t result = 0;		  // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow = true;		  // Test case input
+	uid_t exp_result = 0;	  // Expected results
+	result = get_group(NULL, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    uid_t result = 0;         // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    uid_t exp_result = 0;     // Expected results
-    result = get_group("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	uid_t result = 0;		  // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow = true;		  // Test case input
+	uid_t exp_result = 0;	  // Expected results
+	result = get_group("\0 NOT HERE!", &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    uid_t result = 0;         // Return value from function call
-    uid_t exp_result = 0;     // Expected results
-    result = get_group("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
-                  result, exp_result);
+	uid_t result = 0;	   // Return value from function call
+	uid_t exp_result = 0;  // Expected results
+	bool follow = true;	   // Test case input
+	result = get_group("/dev/loop0", NULL, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
 }
 END_TEST
 
@@ -322,69 +336,110 @@ END_TEST
 /**************************************************************************************************/
 /*************************************** SPECIAL TEST CASES ***************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_s01_missing_filename)
 {
-    uid_t result = 0;     // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_group("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	uid_t result = 0;	 	  // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow = true;		  // Test case input
+	result = get_group("/does/not/exist.txt", &errnum, follow);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
+}
+END_TEST
+
+
+START_TEST(test_s02_no_follow_sym_link)
+{
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;						 // Return value from function call
+	int errnum = CANARY_INT;				 // Errno from the function calls
+	bool follow = false;			 		 // Test case input
+	uid_t exp_result = 0;					 // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+			      input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_group(input_abs_path, &errnum);  // Do not follow the symlink
+	// It is important get_shell_group() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_group(%s) failed with [%d] %s",
+				  input_abs_path, errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_group(%s) provided an invalid value of %u",
+				  input_abs_path, exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = get_group(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_group() returned %u instead of %u",
+			   result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
  
 Suite *get_group_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_Group");
+	suite = suite_create("SFMR_Get_Group");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	tcase_add_test(tc_core, test_s02_no_follow_sym_link);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_group.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_group.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_group_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_group_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem((void **)&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem((void **)&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_group.c
+++ b/code/test/check_sfmr_get_group.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+    free_devops_mem((void **)&input_abs_path);
+    free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_hard_link_num.c
+++ b/code/test/check_sfmr_get_hard_link_num.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+    free_devops_mem((void **)&input_abs_path);
+    free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_mod_time.c
+++ b/code/test/check_sfmr_get_mod_time.c
@@ -42,8 +42,6 @@ START_TEST(test_n01_block_device)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -71,8 +69,6 @@ START_TEST(test_n02_character_device)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -105,8 +101,6 @@ START_TEST(test_n03_directory)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -147,8 +141,6 @@ START_TEST(test_n04_named_pipe)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -185,8 +177,6 @@ START_TEST(test_n05_regular_file)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -227,8 +217,6 @@ START_TEST(test_n06_socket)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START
@@ -269,8 +257,6 @@ START_TEST(test_n07_symbolic_link)
 	// It is important get_shell_mtime() succeeds
 	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
 				  errnum, strerror(errnum));
-	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-				  exp_result);
 	errnum = CANARY_INT;  // Reset this temp var
 
 	// TEST START

--- a/code/test/check_sfmr_get_mod_time.c
+++ b/code/test/check_sfmr_get_mod_time.c
@@ -28,253 +28,260 @@ code/dist/check_sfmr_get_mod_time.bin && CK_FORK=no valgrind --leak-check=full -
 /**************************************************************************************************/
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    time_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    time_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	time_t result = 0;                     // Return value from function call
+	int errnum = CANARY_INT;               // Errno from the function call
+	time_t exp_result = 0;                 // Expected results
+	bool follow_sym = true;                // Test case input
+	char input_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_mtime(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_mtime(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    time_t result = 0;                    // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    time_t exp_result = 0;                // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	time_t result = 0;                    // Return value from function call
+	int errnum = CANARY_INT;              // Errno from the function call
+	time_t exp_result = 0;                // Expected results
+	bool follow_sym = true;               // Test case input
+	char input_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_mtime(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_mtime(input_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_mtime(input_abs_path, &errnum);
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_mtime(input_abs_path, &errnum);
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_abs_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_mtime(input_abs_path, &errnum);
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_mtime(input_abs_path, &errnum);
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_abs_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_mtime(input_abs_path, &errnum);
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_mtime(input_abs_path, &errnum);
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_abs_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/raw_socket" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_socket() succeeds
-    errnum = make_a_socket(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_mtime(input_abs_path, &errnum);
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_mtime(input_abs_path, &errnum);
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_abs_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem(&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    time_t result = 0;                       // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    time_t exp_result = 0;                   // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	time_t result = 0;                       // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	time_t exp_result = 0;                   // Expected results
+	bool follow_sym = true;                  // Test case input
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Relative path for this test case's input
+	char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_mtime(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_mtime() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_mtime(actual_abs_path, &errnum);  // Special because of sym link
+	// It is important get_shell_mtime() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_mtime() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_mtime() provided an invalid value of %ld",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_mod_time(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_mod_time(input_abs_path, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
 }
 END_TEST
 
@@ -284,37 +291,40 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_e01_null_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    time_t exp_result = 0;    // Expected results
-    result = get_mod_time(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
+	result = get_mod_time(NULL, &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    time_t exp_result = 0;    // Expected results
-    result = get_mod_time("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
+	result = get_mod_time("\0 NOT HERE!", &errnum, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    time_t result = 0;        // Return value from function call
-    time_t exp_result = 0;    // Expected results
-    result = get_mod_time("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
-                  result, exp_result);
+	time_t result = 0;        // Return value from function call
+	time_t exp_result = 0;    // Expected results
+	bool follow_sym = true;   // Test case input
+	result = get_mod_time("/dev/loop0", NULL, follow_sym);
+	ck_assert_msg(exp_result == result, "get_mod_time() returned %ld instead of %ld",
+				  result, exp_result);
 }
 END_TEST
 
@@ -324,67 +334,68 @@ END_TEST
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
 {
-    time_t result = 0;        // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_mod_time("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	time_t result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow_sym = true;   // Test case input
+	result = get_mod_time("/does/not/exist.txt", &errnum, follow_sym);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
 }
 END_TEST
 
  
 Suite *get_mod_time_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_Mod_Time");
+	suite = suite_create("SFMR_Get_Mod_Time");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_mod_time.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_mod_time.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_mod_time_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_mod_time_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_mod_time.c
+++ b/code/test/check_sfmr_get_mod_time.c
@@ -110,7 +110,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -151,7 +151,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -186,7 +186,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -227,7 +227,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -266,8 +266,8 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -380,7 +380,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_owner.c
+++ b/code/test/check_sfmr_get_owner.c
@@ -26,255 +26,264 @@ code/dist/check_sfmr_get_owner.bin && CK_FORK=no valgrind --leak-check=full --sh
 /**************************************************************************************************/
 /*************************************** NORMAL TEST CASES ****************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_n01_block_device)
 {
-    // LOCAL VARIABLES
-    uid_t result = 0;                      // Return value from function call
-    int errnum = CANARY_INT;               // Errno from the function call
-    uid_t exp_result = 0;                  // Expected results
-    char input_path[] = { "/dev/loop0" };  // Test case input
+	// LOCAL VARIABLES
+	uid_t result = 0;                          // Return value from function call
+	int errnum = CANARY_INT;                   // Errno from the function call
+	bool follow = true;                        // Test case input
+	uid_t exp_result = 0;                      // Expected results
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_owner(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_owner(input_abs_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n02_character_device)
 {
-    // LOCAL VARIABLES
-    uid_t result = 0;                     // Return value from function call
-    int errnum = CANARY_INT;              // Errno from the function call
-    uid_t exp_result = 0;                 // Expected results
-    char input_path[] = { "/dev/null" };  // Test case input
+	// LOCAL VARIABLES
+	uid_t result = 0;                         // Return value from function call
+	int errnum = CANARY_INT;                  // Errno from the function call
+	bool follow = true;                       // Test case input
+	uid_t exp_result = 0;                     // Expected results
+	char input_abs_path[] = { "/dev/null" };  // Test case input
 
-    // SETUP
-    exp_result = get_shell_owner(input_path, &errnum);
+	// SETUP
+	exp_result = get_shell_owner(input_abs_path, &errnum);
 
-    // VALIDATION
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_n03_directory)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	bool follow = true;                      // Test case input
+	uid_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_owner(input_abs_path, &errnum);
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_owner(input_abs_path, &errnum);
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n04_named_pipe)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/named_pipe" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	bool follow = true;                      // Test case input
+	uid_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/named_pipe" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_pipe() succeeds
-    errnum = make_a_pipe(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_owner(input_abs_path, &errnum);
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_pipe() succeeds
+	errnum = make_a_pipe(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_owner(input_abs_path, &errnum);
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n05_regular_file)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	bool follow = true;                      // Test case input
+	uid_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_owner(input_abs_path, &errnum);
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_owner(input_abs_path, &errnum);
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n06_socket)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;                     // Repo name
-    uid_t result = 0;                                           // Return value from function call
-    int errnum = CANARY_INT;                                    // Errno from the function call
-    uid_t exp_result = 0;                                       // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/raw_socket" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function call
+	bool follow = true;                      // Test case input
+	uid_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/raw_socket" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, false, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
-    // It is important make_a_socket() succeeds
-    errnum = make_a_socket(input_abs_path);
-    ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
-                  errnum, strerror(errnum));
-    exp_result = get_shell_owner(input_abs_path, &errnum);
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	remove_a_file(input_abs_path, true);  // Remove leftovers and ignore errors
+	// It is important make_a_socket() succeeds
+	errnum = make_a_socket(input_abs_path);
+	ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", input_abs_path,
+				  errnum, strerror(errnum));
+	exp_result = get_shell_owner(input_abs_path, &errnum);
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    remove_a_file(input_abs_path, true);
-    free_devops_mem((void **)&input_abs_path);
+	// CLEANUP
+	remove_a_file(input_abs_path, true);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
 
 START_TEST(test_n07_symbolic_link)
 {
-    // LOCAL VARIABLES
-    const char *repo_name = SKID_REPO_NAME;  // Repo name
-    uid_t result = 0;                        // Return value from function call
-    int errnum = CANARY_INT;                 // Errno from the function calls
-    uid_t exp_result = 0;                    // Expected results
-    // Relative path for this test case's input
-    char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
-    // Relative path for this test case's input
-    char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
-    // Absolute path for input_rel_path as resolved against the repo name
-    char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
-    // Absolute path for actual_rel_path as resolved against the repo name
-    char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	bool follow = true;                      // Test case input
+	uid_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Relative path for this test case's input
+	char actual_rel_path[] = { "./code/test/test_input/regular_file.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_to_repo(repo_name, actual_rel_path, true, &errnum);
 
-    // VALIDATION
-    // It is important resolve_to_repo() succeeds
-    ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
-                  input_rel_path, errnum, strerror(errnum));
-    exp_result = get_shell_owner(actual_abs_path, &errnum);  // Special because of sym link
-    // It is important get_shell_owner() succeeds
-    ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
-                  errnum, strerror(errnum));
-    ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
-                  exp_result);
-    errnum = CANARY_INT;  // Reset this temp var
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_owner(actual_abs_path, &errnum);  // Special because of sym link
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
 
-    // TEST START
-    result = get_owner(input_abs_path, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
-    // CLEANUP
-    free_devops_mem((void **)&input_abs_path);
-    free_devops_mem((void **)&actual_abs_path);
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -282,39 +291,44 @@ END_TEST
 /**************************************************************************************************/
 /**************************************** ERROR TEST CASES ****************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_e01_null_filename)
 {
-    uid_t result = 0;         // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    uid_t exp_result = 0;     // Expected results
-    result = get_owner(NULL, &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	uid_t result = 0;         // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow = true;       // Test case input
+	uid_t exp_result = 0;     // Expected results
+	result = get_owner(NULL, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e02_empty_filename)
 {
-    uid_t result = 0;         // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    uid_t exp_result = 0;     // Expected results
-    result = get_owner("\0 NOT HERE!", &errnum);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
-    ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
+	uid_t result = 0;         // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow = true;       // Test case input
+	uid_t exp_result = 0;     // Expected results
+	result = get_owner("\0 NOT HERE!", &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(EINVAL, errnum);  // The out param should be zeroized on success
 }
 END_TEST
 
 
 START_TEST(test_e03_null_errnum)
 {
-    uid_t result = 0;         // Return value from function call
-    uid_t exp_result = 0;     // Expected results
-    result = get_owner("/dev/loop0", NULL);
-    ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
-                  result, exp_result);
+	uid_t result = 0;      // Return value from function call
+	uid_t exp_result = 0;  // Expected results
+	bool follow = true;    // Test case input
+	result = get_owner("/dev/loop0", NULL, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
 }
 END_TEST
 
@@ -322,69 +336,110 @@ END_TEST
 /**************************************************************************************************/
 /*************************************** SPECIAL TEST CASES ***************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_s01_missing_filename)
 {
-    uid_t result = 0;     // Return value from function call
-    int errnum = CANARY_INT;  // Errno from the function call
-    result = get_owner("/does/not/exist.txt", &errnum);
-    ck_assert(0 == result);
-    ck_assert_int_eq(ENOENT, errnum);
+	uid_t result = 0;         // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function call
+	bool follow = true;       // Test case input
+	result = get_owner("/does/not/exist.txt", &errnum, follow);
+	ck_assert(0 == result);
+	ck_assert_int_eq(ENOENT, errnum);
+}
+END_TEST
+
+
+START_TEST(test_s02_no_follow_sym_link)
+{
+	// LOCAL VARIABLES
+	const char *repo_name = SKID_REPO_NAME;  // Repo name
+	uid_t result = 0;                        // Return value from function call
+	int errnum = CANARY_INT;                 // Errno from the function calls
+	bool follow = false;                     // Test case input
+	uid_t exp_result = 0;                    // Expected results
+	// Relative path for this test case's input
+	char input_rel_path[] = { "./code/test/test_input/sym_link.txt" };
+	// Absolute path for input_rel_path as resolved against the repo name
+	char *input_abs_path = resolve_to_repo(repo_name, input_rel_path, true, &errnum);
+
+	// VALIDATION
+	// It is important resolve_to_repo() succeeds
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  input_rel_path, errnum, strerror(errnum));
+	exp_result = get_shell_owner(input_abs_path, &errnum);
+	// It is important get_shell_owner() succeeds
+	ck_assert_msg(0 == errnum, "get_shell_owner() failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(exp_result >= 0, "get_shell_owner() provided an invalid value of %u",
+				  exp_result);
+	errnum = CANARY_INT;  // Reset this temp var
+
+	// TEST START
+	result = get_owner(input_abs_path, &errnum, follow);
+	ck_assert_msg(exp_result == result, "get_owner() returned %u instead of %u",
+				  result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
  
 Suite *get_owner_suite(void)
 {
-    Suite *suite = NULL;
-    TCase *tc_core = NULL;
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
 
-    suite = suite_create("SFMR_Get_Owner");
+	suite = suite_create("SFMR_Get_Owner");
 
-    /* Core test case */
-    tc_core = tcase_create("Core");
+	/* Core test case */
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_n01_block_device);
-    tcase_add_test(tc_core, test_n02_character_device);
-    tcase_add_test(tc_core, test_n03_directory);
-    tcase_add_test(tc_core, test_n04_named_pipe);
-    tcase_add_test(tc_core, test_n05_regular_file);
-    tcase_add_test(tc_core, test_n06_socket);
-    tcase_add_test(tc_core, test_n07_symbolic_link);
-    tcase_add_test(tc_core, test_e01_null_filename);
-    tcase_add_test(tc_core, test_e02_empty_filename);
-    tcase_add_test(tc_core, test_e03_null_errnum);
-    tcase_add_test(tc_core, test_s01_missing_filename);
-    suite_add_tcase(suite, tc_core);
+	tcase_add_test(tc_core, test_n01_block_device);
+	tcase_add_test(tc_core, test_n02_character_device);
+	tcase_add_test(tc_core, test_n03_directory);
+	tcase_add_test(tc_core, test_n04_named_pipe);
+	tcase_add_test(tc_core, test_n05_regular_file);
+	tcase_add_test(tc_core, test_n06_socket);
+	tcase_add_test(tc_core, test_n07_symbolic_link);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_e03_null_errnum);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	tcase_add_test(tc_core, test_s02_no_follow_sym_link);
+	suite_add_tcase(suite, tc_core);
 
-    return suite;
+	return suite;
 }
 
 
 int main(void)
 {
-    // LOCAL VARIABLES
-    int errnum = 0;  // Errno from the function call
-    // Relative path for this test case's input
-    char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_owner.log" };
-    // Absolute path for log_rel_path as resolved against the repo name
-    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
-    int number_failed = 0;
-    Suite *suite = NULL;
-    SRunner *suite_runner = NULL;
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmr_get_owner.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
 
-    // SETUP
-    suite = get_owner_suite();
-    suite_runner = srunner_create(suite);
-    srunner_set_log(suite_runner, log_abs_path);
+	// SETUP
+	suite = get_owner_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
 
-    // RUN IT
-    srunner_run_all(suite_runner, CK_NORMAL);
-    number_failed = srunner_ntests_failed(suite_runner);
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
 
-    // CLEANUP
-    srunner_free(suite_runner);
-    free_devops_mem((void **)&log_abs_path);
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem((void **)&log_abs_path);
 
-    // DONE
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/code/test/check_sfmr_get_owner.c
+++ b/code/test/check_sfmr_get_owner.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+    free_devops_mem((void **)&input_abs_path);
+    free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_serial_num.c
+++ b/code/test/check_sfmr_get_serial_num.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+    free_devops_mem((void **)&input_abs_path);
+    free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_get_size.c
+++ b/code/test/check_sfmr_get_size.c
@@ -113,7 +113,7 @@ START_TEST(test_n03_directory)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -155,7 +155,7 @@ START_TEST(test_n04_named_pipe)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_n05_regular_file)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(test_n06_socket)
 
     // CLEANUP
     remove_a_file(input_abs_path, true);
-    free_devops_mem(&input_abs_path);
+    free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -273,8 +273,8 @@ START_TEST(test_n07_symbolic_link)
     ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
     // CLEANUP
-    free_devops_mem(&input_abs_path);
-    free_devops_mem(&actual_abs_path);
+    free_devops_mem((void **)&input_abs_path);
+    free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -383,7 +383,7 @@ int main(void)
 
     // CLEANUP
     srunner_free(suite_runner);
-    free_devops_mem(&log_abs_path);
+    free_devops_mem((void **)&log_abs_path);
 
     // DONE
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmr_is_block_device.c
+++ b/code/test/check_sfmr_is_block_device.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_is_character_device.c
+++ b/code/test/check_sfmr_is_character_device.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_is_directory.c
+++ b/code/test/check_sfmr_is_directory.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_is_named_pipe.c
+++ b/code/test/check_sfmr_is_named_pipe.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_is_regular_file.c
+++ b/code/test/check_sfmr_is_regular_file.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_is_socket.c
+++ b/code/test/check_sfmr_is_socket.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmr_is_sym_link.c
+++ b/code/test/check_sfmr_is_sym_link.c
@@ -71,7 +71,7 @@ START_TEST(test_n03_directory)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -104,7 +104,7 @@ START_TEST(test_n04_named_pipe)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -132,7 +132,7 @@ START_TEST(test_n05_regular_file)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -166,7 +166,7 @@ START_TEST(test_n06_socket)
 
 	// CLEANUP
 	remove_a_file(input_abs_path, true);
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -194,7 +194,7 @@ START_TEST(test_n07_symbolic_link)
 	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 

--- a/code/test/check_sfmw_add_mode.c
+++ b/code/test/check_sfmw_add_mode.c
@@ -1,0 +1,732 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's add_mode() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_add_mode.bin && \
+code/dist/check_sfmw_add_mode.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_add_mode.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+ *
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_add_mode.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_add_mode.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_add_mode.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_add_mode.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ *
+ */
+
+#include <check.h>						// START_TEST(), END_TEST
+#include <stdlib.h>
+// Local includes
+#include "devops_code.h"				// resolve_to_repo(), SKID_REPO_NAME
+#ifndef SKID_DEBUG
+#define SKID_DEBUG
+#endif  /* SKID_DEBUG */
+#include "skid_debug.h"     			// FPRINTF_ERR()
+#include "skid_file_metadata_read.h"	// get_group(), get_owner()
+#include "skid_file_metadata_write.h"	// add_mode()
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Common Mode Macros
+#define TEST_MODE_0444 (SKID_MODE_OWNER_R | \
+                        SKID_MODE_GROUP_R | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0644 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | \
+					    SKID_MODE_GROUP_R | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0764 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
+                        SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0777 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
+                        SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | SKID_MODE_GROUP_X | \
+                        SKID_MODE_OTHER_R | SKID_MODE_OTHER_W | SKID_MODE_OTHER_X)
+#define TEST_MODE_7000 (SKID_MODE_SET_UID | SKID_MODE_SET_GID | SKID_MODE_STICKYB)
+#define TEST_MODE_7764 (TEST_MODE_7000 | TEST_MODE_0764)
+#define TEST_MODE_7777 (TEST_MODE_7000 | TEST_MODE_0777)
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+// This struct defines details about test files to aid in test execution and teardown() recovery.
+typedef struct _cssmTestPathDetails
+{
+	char *pathname;    // Heap-allocated buffer containing the pathname resolved to the repo dir
+	mode_t orig_mode;  // The original mode
+} testPathDetails, *testPathDetails_ptr;
+
+testPathDetails_ptr test_dir_details;  // Heap-allocated struct containing test directory details
+testPathDetails_ptr test_file_details;  // Heap-allocated struct containing test filename details
+testPathDetails_ptr test_pipe_details;  // Heap-allocated struct containing test pipe details
+testPathDetails_ptr test_socket_details;  // Heap-allocated struct containing test socket details
+testPathDetails_ptr test_symlink_details;  // Heap-allocated struct with test symbolic link details
+testPathDetails_ptr test_bad_path_details;  // Heap-allocated struct with a bad path
+
+/*
+ *	Reset the permissions of the test_*_details globals back to their original mode values.
+ */
+void reset_global_modes(void);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	Call add_mode(), get the new perms, and validate the results.  If pathname is a symbolic link,
+ *	provide the sym_link's target as target_name.  If target_name is NULL, it will be ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, mode_t test_mode, int exp_return);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Allocate memory for a testPathDetails struct and populate it.  Ignores ENOENT errors.
+ */
+testPathDetails_ptr setup_struct(const char *pathname);
+
+/*
+ *	Update new_struct with the new_struct->pathname's current mode.  Does not ignore errors
+ *	if must_succeed is true.  Always returns the error received.
+ */
+int setup_struct_mode(testPathDetails_ptr new_struct, bool must_succeed);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Free all allocate memory in the testPathDetails struct in a gently tolerant way.
+ */
+void teardown_struct(testPathDetails_ptr* old_struct);
+
+
+void reset_global_modes(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	// Array of the global pointers to iterate over
+	testPathDetails_ptr test_structs[] = {test_dir_details, test_file_details, test_pipe_details,
+										  test_socket_details, test_symlink_details};
+
+	// RESET PERMISSIONS
+	for (int i = 0; i < (sizeof(test_structs) / sizeof(test_structs[0])); i++)
+	{
+		if (test_structs[i])
+		{
+			// Reset mode
+			errnum = set_shell_perms(test_structs[i]->pathname, test_structs[i]->orig_mode);
+			if (EPERM == errnum)
+			{
+				FPRINTF_ERR("%s You may need to reset the owner of '%s' to %o\n",
+					        DEBUG_WARNG_STR, test_structs[i]->pathname, test_structs[i]->orig_mode);
+			}
+			else
+			{
+				ck_assert_msg(0 == errnum, "set_shell_perms(%s, %o) failed with [%d] %s",
+					          test_structs[i]->pathname, test_structs[i]->orig_mode,
+					          errnum, strerror(errnum));
+			}
+		}
+	}
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem((void **)&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, mode_t test_mode, int exp_return)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;                     // Errno values
+	int actual_ret = 0;                 // Return value of the tested function
+	mode_t old_mode = 0;                // Pre-execution mode
+	mode_t new_mode = 0;                // Post-execution mode
+	const char *check_mode = pathname;  // Filename to verify pre/post-test permissions
+
+	// SETUP
+	if (true == is_sym_link(pathname, &errnum) && target_name && *target_name)
+	{
+		check_mode = target_name;
+	}
+	if (0 == exp_return)
+	{
+		old_mode = get_shell_file_perms(check_mode, &errnum);
+		ck_assert_msg(0 == errnum, "The first get_shell_file_perms(%s) errored with [%d] '%s'\n",
+					  check_mode, errnum, strerror(errnum));
+	}
+
+	// RUN IT
+	actual_ret = add_mode(pathname, test_mode);
+
+	// POST-TEST
+	// Compare actual results to expected results
+	ck_assert_msg(exp_return == actual_ret, "add_mode(%s, %o) returned [%d] '%s' "
+				  "instead of [%d] '%s'\n", pathname, test_mode, actual_ret, strerror(actual_ret),
+				  exp_return, strerror(exp_return));
+	// No need to compare new_mode against test_mode if the expected result is "error"
+	if (0 == exp_return)
+	{
+		// Get the current permissions
+		new_mode = get_shell_file_perms(check_mode, &errnum);
+		ck_assert_msg(0 == errnum, "The second get_shell_file_perms(%s) errored with [%d] '%s'\n",
+					  check_mode, errnum, strerror(errnum));
+		// Compare actual permissions to the test_mode (while ignoring unused test input bits)
+		ck_assert_msg(new_mode == (old_mode | (test_mode & 07777)),
+			          "add_mode(%s, %o) failed to add the mode %o to %o (saw %o instead)\n",
+					  check_mode, test_mode, test_mode, old_mode, new_mode);
+	}
+
+	// DONE
+	return;
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                             // Errno values
+	char directory[] = { "./code/test/test_input/" };                    // Default input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };         // Default input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };         // Default input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };     // Default input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };         // Default input: symlink
+	char bad_path[] = { "./code/test/test_input/named_pipe/bad_path" };  // Default input: bad path
+
+	// SET IT UP
+	// Allocate structs
+	test_dir_details = setup_struct(directory);
+	test_pipe_details = setup_struct(named_pipe);
+	test_socket_details = setup_struct(raw_socket);
+	test_file_details = setup_struct(reg_file);
+	test_symlink_details = setup_struct(sym_link);
+	test_bad_path_details = setup_struct(bad_path);
+	// Create files
+	if (test_pipe_details && test_pipe_details->pathname)
+	{
+		remove_a_file(test_pipe_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+		errnum = setup_struct_mode(test_pipe_details, true);
+		ck_assert_msg(0 == errnum, "setup_struct_owners(%s struct) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+	}
+	else
+	{
+		ck_abort_msg("The setup() test fixture did not make the named pipe");
+	}
+	// Raw Socket
+	if (test_socket_details && test_socket_details->pathname)
+	{
+		remove_a_file(test_socket_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+		errnum = setup_struct_mode(test_socket_details, true);
+		ck_assert_msg(0 == errnum, "setup_struct_owners(%s struct) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+	}
+	else
+	{
+		ck_abort_msg("The setup() test fixture did not make the socket");
+	}
+
+	// RESET OWNERSHIP
+	reset_global_modes();
+
+	// DONE
+	return;
+}
+
+
+testPathDetails_ptr setup_struct(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	char *temp_pathname = NULL;              // Holds the resolve_test_input() return value
+	testPathDetails_ptr temp_struct = NULL;  // Function return value
+
+	// SET IT UP
+	// pathname
+	temp_pathname = resolve_test_input(pathname);
+	// testPathDetails struct
+	temp_struct = alloc_devops_mem(1, sizeof(testPathDetails), &errnum);
+	ck_assert_msg(0 == errnum, "alloc_devops_mem(testPathDetails) failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(NULL != temp_struct,
+				  "alloc_devops_mem(testPathDetails) memory allocation failed");
+
+	// STORE IT
+	// pathname
+	if (!errnum)
+	{
+		temp_struct->pathname = temp_pathname;
+		errnum = setup_struct_mode(temp_struct, false);
+		if (ENOENT == errnum)
+		{
+			errnum = 0;  // Ignore "file/dir missing" errors
+		}
+		ck_assert_msg(0 == errnum, "setup_struct_mode(%s struct) failed with [%d] %s",
+					  temp_pathname, errnum, strerror(errnum));
+	}
+
+	// DONE
+	if (errnum && temp_struct)
+	{
+		teardown_struct(&temp_struct);  // Something failed so undo it
+	}
+	return temp_struct;
+}
+
+
+int setup_struct_mode(testPathDetails_ptr new_struct, bool must_succeed)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;              // Errno values
+	char *temp_pathname = NULL;  // Temp storage for new_struct->pathname
+
+	// INPUT VALIDATION
+	if (!new_struct)
+	{
+		errnum = EINVAL;  // NULL struct pointer
+	}
+	else
+	{
+		temp_pathname = new_struct->pathname;
+	}
+
+	// SETUP MODE
+	// orig_mode
+	if (!errnum)
+	{
+		new_struct->orig_mode = get_file_perms(temp_pathname, &errnum);
+		if (true == must_succeed)
+		{
+			ck_assert_msg(0 == errnum, "get_file_perms(%s) failed with [%d] %s",
+						  temp_pathname, errnum, strerror(errnum));
+		}
+	}
+
+	// DONE
+	return errnum;
+}
+
+
+void teardown(void)
+{
+	// RESET OWNERSHIP
+	reset_global_modes();
+
+	// CLEANUP
+	// Directory
+	teardown_struct(&test_dir_details);  // Ignore any errors
+	// File
+	teardown_struct(&test_file_details);  // Ignore any errors
+	// Pipe
+	remove_a_file(test_pipe_details->pathname, true);  // Best effort
+	teardown_struct(&test_pipe_details);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_details->pathname, true);  // Best effort
+	teardown_struct(&test_socket_details);  // Ignore any errors
+	// Symbolic Link
+	teardown_struct(&test_symlink_details);  // Ignore any errors
+	// Bad Path
+	teardown_struct(&test_bad_path_details);  // Ignore any errors
+}
+
+
+void teardown_struct(testPathDetails_ptr *old_struct)
+{
+	// LOCAL VARIABLES
+	int results = 0;                        // Check the results
+	testPathDetails_ptr struct_ptr = NULL;  // The actual struct pointer to free
+
+	// INPUT VALIDATION
+	if (old_struct)
+	{
+		struct_ptr = *old_struct;
+	}
+
+	// TEAR IT DOWN
+	if (struct_ptr)
+	{
+		// pathname
+		if (struct_ptr->pathname)
+		{
+			results = free_devops_mem((void **)&(struct_ptr->pathname));
+			ck_assert_msg(0 == results, "free_devops_mem(struct_ptr->pathname) failed with [%d] %s",
+						  results, strerror(results));
+		}
+		// The old struct
+		results = free_devops_mem((void **)old_struct);
+		ck_assert_msg(0 == results, "free_devops_mem(struct_ptr) failed with [%d] %s",
+					  results, strerror(results));
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_dir_details->pathname;
+	mode_t test_mode = SKID_MODE_OTHER_X;  // Test case input
+	int exp_return = 0;                    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_details->pathname;
+	mode_t test_mode = SKID_MODE_OTHER_X;  // Test case input
+	int exp_return = 0;                    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	mode_t test_mode = SKID_MODE_OTHER_X;  // Test case input
+	int exp_return = 0;                    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_details->pathname;
+	mode_t test_mode = SKID_MODE_OTHER_X;  // Test case input
+	int exp_return = 0;                    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_symlink_details->pathname;
+	mode_t test_mode = SKID_MODE_OTHER_X;  // Test case input
+	int exp_return = 0;                    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, test_file_details->pathname, test_mode, exp_return);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0644;  // Test case input
+	int exp_return = EINVAL;            // Expected return value for this test input
+	char *input_abs_path = NULL;        // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0644;           // Test case input
+	int exp_return = EINVAL;                     // Expected return value for this test input
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_e03_missing_filename)
+{
+	// LOCAL VARIABLES
+	mode_t test_mode = TEST_MODE_0644;              // Test case input
+	int exp_return = ENOENT;                        // Expected return value for this test input
+	char input_abs_path[] = { "/file/not/found" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_b01_smallest_mode)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 0;  // Test case input
+	int exp_return = 0;    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_b02_largest_mode)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7777;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+
+
+// Observed behavior is that, in invalid mode values, "don't care about those" bits are ignored.
+START_TEST(test_s01_all_flags_enabled)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 0xFF;  // Test case input
+	int exp_return = 0;       // Expected return value for this test input
+
+	// SETUP
+	for (int i = 1; i < sizeof(mode_t); i++)
+	{
+		test_mode <<= 8;  // Make room for the next byte
+		test_mode |= 0xFF;  // Turn on one byte's worth of bits
+	}
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s02_path_contains_non_dir)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_bad_path_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0764;  // Test case input
+	int exp_return = ENOTDIR;           // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s03_no_change)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	int errnum = CANARY_INT;                                     // Errno values
+	mode_t test_mode = get_file_perms(input_abs_path, &errnum);  // Test case input
+	int exp_return = 0;                                          // Expected return value
+
+	// VALIDATE
+	ck_assert_msg(0 == errnum, "get_file_perms(%s) failed with [%d] %s",
+		          input_abs_path, errnum, strerror(errnum));
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s04_special_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7764;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s05_just_the_special_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7000;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+// Observed behavior is that, in invalid mode values, "don't care about those" bits are ignored.
+START_TEST(test_s06_bit_field_ignores_invalid_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 077777;  // Test case input
+	int exp_return = 0;         // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+Suite *add_mode_suite(void)
+{
+	// LOCAL VARIABLES
+	Suite *suite = suite_create("SFMW_Add_Mode");   // Test suite
+	TCase *tc_normal = tcase_create("Normal");      // Normal test cases
+	TCase *tc_error = tcase_create("Error");        // Error test cases
+	TCase *tc_boundary = tcase_create("Boundary");  // Boundary test cases
+	TCase *tc_special = tcase_create("Special");    // Special test cases
+
+	// SETUP TEST CASES
+	tcase_add_checked_fixture(tc_normal, setup, teardown);
+	tcase_add_checked_fixture(tc_error, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_test(tc_normal, test_n01_directory);
+	tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_test(tc_normal, test_n03_regular_file);
+	tcase_add_test(tc_normal, test_n04_socket);
+	tcase_add_test(tc_normal, test_n05_symbolic_link);
+	tcase_add_test(tc_error, test_e01_null_filename);
+	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_error, test_e03_missing_filename);
+	tcase_add_test(tc_boundary, test_b01_smallest_mode);
+	tcase_add_test(tc_boundary, test_b02_largest_mode);
+	tcase_add_test(tc_special, test_s01_all_flags_enabled);
+	tcase_add_test(tc_special, test_s02_path_contains_non_dir);
+	tcase_add_test(tc_special, test_s03_no_change);
+	tcase_add_test(tc_special, test_s04_special_bits);
+	tcase_add_test(tc_special, test_s05_just_the_special_bits);
+	tcase_add_test(tc_special, test_s06_bit_field_ignores_invalid_bits);
+	suite_add_tcase(suite, tc_normal);
+	suite_add_tcase(suite, tc_error);
+	suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_add_mode.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = add_mode_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem((void **)&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_remove_mode.c
+++ b/code/test/check_sfmw_remove_mode.c
@@ -1,0 +1,731 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's remove_mode() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_remove_mode.bin && \
+code/dist/check_sfmw_remove_mode.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_remove_mode.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+ *
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_remove_mode.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_remove_mode.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_remove_mode.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_remove_mode.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ *
+ */
+
+#include <check.h>						// START_TEST(), END_TEST
+#include <stdlib.h>
+// Local includes
+#include "devops_code.h"				// resolve_to_repo(), SKID_REPO_NAME
+#ifndef SKID_DEBUG
+#define SKID_DEBUG
+#endif  /* SKID_DEBUG */
+#include "skid_debug.h"     			// FPRINTF_ERR()
+#include "skid_file_metadata_read.h"	// get_group(), get_owner()
+#include "skid_file_metadata_write.h"	// remove_mode()
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Common Mode Macros
+#define TEST_MODE_0111 (SKID_MODE_OWNER_X | SKID_MODE_GROUP_X | SKID_MODE_OTHER_X)
+#define TEST_MODE_0222 (SKID_MODE_OWNER_W | SKID_MODE_GROUP_W | SKID_MODE_OTHER_W)
+#define TEST_MODE_0333 (TEST_MODE_0222 | TEST_MODE_0111)
+#define TEST_MODE_0444 (SKID_MODE_OWNER_R | SKID_MODE_GROUP_R | SKID_MODE_OTHER_R)
+#define TEST_MODE_0644 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | \
+					    SKID_MODE_GROUP_R | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0764 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
+                        SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0777 (TEST_MODE_0444 | TEST_MODE_0222 | TEST_MODE_0111)
+#define TEST_MODE_7000 (SKID_MODE_SET_UID | SKID_MODE_SET_GID | SKID_MODE_STICKYB)
+#define TEST_MODE_7764 (TEST_MODE_7000 | TEST_MODE_0764)
+#define TEST_MODE_7777 (TEST_MODE_7000 | TEST_MODE_0777)
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+// This struct defines details about test files to aid in test execution and teardown() recovery.
+typedef struct _cssmTestPathDetails
+{
+	char *pathname;    // Heap-allocated buffer containing the pathname resolved to the repo dir
+	mode_t orig_mode;  // The original mode
+} testPathDetails, *testPathDetails_ptr;
+
+testPathDetails_ptr test_dir_details;  // Heap-allocated struct containing test directory details
+testPathDetails_ptr test_file_details;  // Heap-allocated struct containing test filename details
+testPathDetails_ptr test_pipe_details;  // Heap-allocated struct containing test pipe details
+testPathDetails_ptr test_socket_details;  // Heap-allocated struct containing test socket details
+testPathDetails_ptr test_symlink_details;  // Heap-allocated struct with test symbolic link details
+testPathDetails_ptr test_bad_path_details;  // Heap-allocated struct with a bad path
+
+/*
+ *	Reset the permissions of the test_*_details globals back to their original mode values.
+ */
+void reset_global_modes(void);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	Call remove_mode(), get the new perms, and validate the results.  If pathname is a symbolic link,
+ *	provide the sym_link's target as target_name.  If target_name is NULL, it will be ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, mode_t test_mode, int exp_return);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Allocate memory for a testPathDetails struct and populate it.  Ignores ENOENT errors.
+ */
+testPathDetails_ptr setup_struct(const char *pathname);
+
+/*
+ *	Update new_struct with the new_struct->pathname's current mode.  Does not ignore errors
+ *	if must_succeed is true.  Always returns the error received.
+ */
+int setup_struct_mode(testPathDetails_ptr new_struct, bool must_succeed);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Free all allocate memory in the testPathDetails struct in a gently tolerant way.
+ */
+void teardown_struct(testPathDetails_ptr* old_struct);
+
+
+void reset_global_modes(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	// Array of the global pointers to iterate over
+	testPathDetails_ptr test_structs[] = {test_dir_details, test_file_details, test_pipe_details,
+										  test_socket_details, test_symlink_details};
+
+	// RESET PERMISSIONS
+	for (int i = 0; i < (sizeof(test_structs) / sizeof(test_structs[0])); i++)
+	{
+		if (test_structs[i])
+		{
+			// Reset mode
+			errnum = set_shell_perms(test_structs[i]->pathname, test_structs[i]->orig_mode);
+			if (EPERM == errnum)
+			{
+				FPRINTF_ERR("%s You may need to reset the owner of '%s' to %o\n",
+					        DEBUG_WARNG_STR, test_structs[i]->pathname, test_structs[i]->orig_mode);
+			}
+			else
+			{
+				ck_assert_msg(0 == errnum, "set_shell_perms(%s, %o) failed with [%d] %s",
+					          test_structs[i]->pathname, test_structs[i]->orig_mode,
+					          errnum, strerror(errnum));
+			}
+		}
+	}
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem((void **)&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, mode_t test_mode, int exp_return)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;                     // Errno values
+	int actual_ret = 0;                 // Return value of the tested function
+	mode_t old_mode = 0;                // Pre-execution mode
+	mode_t new_mode = 0;                // Post-execution mode
+	const char *check_mode = pathname;  // Filename to verify pre/post-test permissions
+
+	// SETUP
+	if (true == is_sym_link(pathname, &errnum) && target_name && *target_name)
+	{
+		check_mode = target_name;
+	}
+	if (0 == exp_return)
+	{
+		old_mode = get_shell_file_perms(check_mode, &errnum);
+		ck_assert_msg(0 == errnum, "The first get_shell_file_perms(%s) errored with [%d] '%s'\n",
+					  check_mode, errnum, strerror(errnum));
+	}
+
+	// RUN IT
+	actual_ret = remove_mode(pathname, test_mode);
+
+	// POST-TEST
+	// Compare actual results to expected results
+	ck_assert_msg(exp_return == actual_ret, "remove_mode(%s, %o) returned [%d] '%s' "
+				  "instead of [%d] '%s'\n", pathname, test_mode, actual_ret, strerror(actual_ret),
+				  exp_return, strerror(exp_return));
+	// No need to compare new_mode against test_mode if the expected result is "error"
+	if (0 == exp_return)
+	{
+		// Get the current permissions
+		new_mode = get_shell_file_perms(check_mode, &errnum);
+		ck_assert_msg(0 == errnum, "The second get_shell_file_perms(%s) errored with [%d] '%s'\n",
+					  check_mode, errnum, strerror(errnum));
+		// Compare actual permissions to the test_mode (while ignoring unused test input bits)
+		ck_assert_msg(new_mode == (old_mode & (~(test_mode & 07777))),
+			          "remove_mode(%s, %o) failed to add the mode %o to %o (saw %o instead)\n",
+					  check_mode, test_mode, test_mode, old_mode, new_mode);
+	}
+
+	// DONE
+	return;
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                             // Errno values
+	char directory[] = { "./code/test/test_input/" };                    // Default input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };         // Default input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };         // Default input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };     // Default input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };         // Default input: symlink
+	char bad_path[] = { "./code/test/test_input/named_pipe/bad_path" };  // Default input: bad path
+
+	// SET IT UP
+	// Allocate structs
+	test_dir_details = setup_struct(directory);
+	test_pipe_details = setup_struct(named_pipe);
+	test_socket_details = setup_struct(raw_socket);
+	test_file_details = setup_struct(reg_file);
+	test_symlink_details = setup_struct(sym_link);
+	test_bad_path_details = setup_struct(bad_path);
+	// Create files
+	if (test_pipe_details && test_pipe_details->pathname)
+	{
+		remove_a_file(test_pipe_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+		errnum = setup_struct_mode(test_pipe_details, true);
+		ck_assert_msg(0 == errnum, "setup_struct_owners(%s struct) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+	}
+	else
+	{
+		ck_abort_msg("The setup() test fixture did not make the named pipe");
+	}
+	// Raw Socket
+	if (test_socket_details && test_socket_details->pathname)
+	{
+		remove_a_file(test_socket_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+		errnum = setup_struct_mode(test_socket_details, true);
+		ck_assert_msg(0 == errnum, "setup_struct_owners(%s struct) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+	}
+	else
+	{
+		ck_abort_msg("The setup() test fixture did not make the socket");
+	}
+
+	// RESET OWNERSHIP
+	reset_global_modes();
+
+	// DONE
+	return;
+}
+
+
+testPathDetails_ptr setup_struct(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	char *temp_pathname = NULL;              // Holds the resolve_test_input() return value
+	testPathDetails_ptr temp_struct = NULL;  // Function return value
+
+	// SET IT UP
+	// pathname
+	temp_pathname = resolve_test_input(pathname);
+	// testPathDetails struct
+	temp_struct = alloc_devops_mem(1, sizeof(testPathDetails), &errnum);
+	ck_assert_msg(0 == errnum, "alloc_devops_mem(testPathDetails) failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(NULL != temp_struct,
+				  "alloc_devops_mem(testPathDetails) memory allocation failed");
+
+	// STORE IT
+	// pathname
+	if (!errnum)
+	{
+		temp_struct->pathname = temp_pathname;
+		errnum = setup_struct_mode(temp_struct, false);
+		if (ENOENT == errnum)
+		{
+			errnum = 0;  // Ignore "file/dir missing" errors
+		}
+		ck_assert_msg(0 == errnum, "setup_struct_mode(%s struct) failed with [%d] %s",
+					  temp_pathname, errnum, strerror(errnum));
+	}
+
+	// DONE
+	if (errnum && temp_struct)
+	{
+		teardown_struct(&temp_struct);  // Something failed so undo it
+	}
+	return temp_struct;
+}
+
+
+int setup_struct_mode(testPathDetails_ptr new_struct, bool must_succeed)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;              // Errno values
+	char *temp_pathname = NULL;  // Temp storage for new_struct->pathname
+
+	// INPUT VALIDATION
+	if (!new_struct)
+	{
+		errnum = EINVAL;  // NULL struct pointer
+	}
+	else
+	{
+		temp_pathname = new_struct->pathname;
+	}
+
+	// SETUP MODE
+	// orig_mode
+	if (!errnum)
+	{
+		new_struct->orig_mode = get_file_perms(temp_pathname, &errnum);
+		if (true == must_succeed)
+		{
+			ck_assert_msg(0 == errnum, "get_file_perms(%s) failed with [%d] %s",
+						  temp_pathname, errnum, strerror(errnum));
+		}
+	}
+
+	// DONE
+	return errnum;
+}
+
+
+void teardown(void)
+{
+	// RESET OWNERSHIP
+	reset_global_modes();
+
+	// CLEANUP
+	// Directory
+	teardown_struct(&test_dir_details);  // Ignore any errors
+	// File
+	teardown_struct(&test_file_details);  // Ignore any errors
+	// Pipe
+	remove_a_file(test_pipe_details->pathname, true);  // Best effort
+	teardown_struct(&test_pipe_details);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_details->pathname, true);  // Best effort
+	teardown_struct(&test_socket_details);  // Ignore any errors
+	// Symbolic Link
+	teardown_struct(&test_symlink_details);  // Ignore any errors
+	// Bad Path
+	teardown_struct(&test_bad_path_details);  // Ignore any errors
+}
+
+
+void teardown_struct(testPathDetails_ptr *old_struct)
+{
+	// LOCAL VARIABLES
+	int results = 0;                        // Check the results
+	testPathDetails_ptr struct_ptr = NULL;  // The actual struct pointer to free
+
+	// INPUT VALIDATION
+	if (old_struct)
+	{
+		struct_ptr = *old_struct;
+	}
+
+	// TEAR IT DOWN
+	if (struct_ptr)
+	{
+		// pathname
+		if (struct_ptr->pathname)
+		{
+			results = free_devops_mem((void **)&(struct_ptr->pathname));
+			ck_assert_msg(0 == results, "free_devops_mem(struct_ptr->pathname) failed with [%d] %s",
+						  results, strerror(results));
+		}
+		// The old struct
+		results = free_devops_mem((void **)old_struct);
+		ck_assert_msg(0 == results, "free_devops_mem(struct_ptr) failed with [%d] %s",
+					  results, strerror(results));
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_dir_details->pathname;
+	mode_t test_mode = TEST_MODE_0333;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_details->pathname;
+	mode_t test_mode = TEST_MODE_0333;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	mode_t test_mode = TEST_MODE_0333;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_details->pathname;
+	mode_t test_mode = TEST_MODE_0333;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_symlink_details->pathname;
+	mode_t test_mode = TEST_MODE_0333;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, test_file_details->pathname, test_mode, exp_return);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0111;  // Test case input
+	int exp_return = EINVAL;            // Expected return value for this test input
+	char *input_abs_path = NULL;        // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0111;           // Test case input
+	int exp_return = EINVAL;                     // Expected return value for this test input
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_e03_missing_filename)
+{
+	// LOCAL VARIABLES
+	mode_t test_mode = TEST_MODE_0111;              // Test case input
+	int exp_return = ENOENT;                        // Expected return value for this test input
+	char input_abs_path[] = { "/file/not/found" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_b01_smallest_mode)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 0;  // Test case input
+	int exp_return = 0;    // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_b02_largest_mode)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7777;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+
+
+// Observed behavior is that, in invalid mode values, "don't care about those" bits are ignored.
+START_TEST(test_s01_all_flags_enabled)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 0xFF;  // Test case input
+	int exp_return = 0;       // Expected return value for this test input
+
+	// SETUP
+	for (int i = 1; i < sizeof(mode_t); i++)
+	{
+		test_mode <<= 8;  // Make room for the next byte
+		test_mode |= 0xFF;  // Turn on one byte's worth of bits
+	}
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s02_path_contains_non_dir)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_bad_path_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0111;  // Test case input
+	int exp_return = ENOTDIR;           // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s03_everything_changes)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	int errnum = CANARY_INT;                                     // Errno values
+	mode_t test_mode = get_file_perms(input_abs_path, &errnum);  // Test case input
+	int exp_return = 0;                                          // Expected return value
+
+	// VALIDATE
+	ck_assert_msg(0 == errnum, "get_file_perms(%s) failed with [%d] %s",
+		          input_abs_path, errnum, strerror(errnum));
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s04_special_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7764;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_s05_just_the_special_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7000;  // Test case input
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+// Observed behavior is that, in invalid mode values, "don't care about those" bits are ignored.
+START_TEST(test_s06_bit_field_ignores_invalid_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 077777;  // Test case input
+	int exp_return = 0;         // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+Suite *remove_mode_suite(void)
+{
+	// LOCAL VARIABLES
+	Suite *suite = suite_create("SFMW_Remove_Mode");  // Test suite
+	TCase *tc_normal = tcase_create("Normal");        // Normal test cases
+	TCase *tc_error = tcase_create("Error");          // Error test cases
+	TCase *tc_boundary = tcase_create("Boundary");    // Boundary test cases
+	TCase *tc_special = tcase_create("Special");      // Special test cases
+
+	// SETUP TEST CASES
+	tcase_add_checked_fixture(tc_normal, setup, teardown);
+	tcase_add_checked_fixture(tc_error, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_test(tc_normal, test_n01_directory);
+	tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_test(tc_normal, test_n03_regular_file);
+	tcase_add_test(tc_normal, test_n04_socket);
+	tcase_add_test(tc_normal, test_n05_symbolic_link);
+	tcase_add_test(tc_error, test_e01_null_filename);
+	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_error, test_e03_missing_filename);
+	tcase_add_test(tc_boundary, test_b01_smallest_mode);
+	tcase_add_test(tc_boundary, test_b02_largest_mode);
+	tcase_add_test(tc_special, test_s01_all_flags_enabled);
+	tcase_add_test(tc_special, test_s02_path_contains_non_dir);
+	tcase_add_test(tc_special, test_s03_everything_changes);
+	tcase_add_test(tc_special, test_s04_special_bits);
+	tcase_add_test(tc_special, test_s05_just_the_special_bits);
+	tcase_add_test(tc_special, test_s06_bit_field_ignores_invalid_bits);
+	suite_add_tcase(suite, tc_normal);
+	suite_add_tcase(suite, tc_error);
+	suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_remove_mode.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = remove_mode_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem((void **)&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_atime.c
+++ b/code/test/check_sfmw_set_atime.c
@@ -32,6 +32,8 @@ export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_atime.bin; unset CK_R
 #define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
 // Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
 #define MICRO_SEC_SLEEP (useconds_t)10000  // Give the file timestamp 0.01 second to update
+#define UTIME_NSEC_MIN 0l          // Minimum allowed value for tv_nsec (see: utimensat(2))
+#define UTIME_NSEC_MAX 999999999l  // Maximum allowed value for tv_nsec (see: utimensat(2))
 
 
 /**************************************************************************************************/
@@ -383,6 +385,189 @@ END_TEST
 
 
 /**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_b01_sec_min_value)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MIN + 1;           // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b02_sec_almost_epoch)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = -1;                    // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b03_sec_epoch_time)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0;                     // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b04_sec_barely_past_epoch)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 1;                     // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b05_sec_static_now)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x66197EA4;            // Seconds test input: 4/12/2024, 1:34:12 PM
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b06_sec_max_value)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MAX;               // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b07_nsec_low_very_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = LONG_MIN;               // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b08_nsec_low_barely_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MIN - 1l;    // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b09_nsec_low_barely_good)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MIN;         // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b10_nsec_high_barely_good)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MAX;         // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b11_nsec_high_barely_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MAX + 1l;    // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b12_nsec_high_very_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = LONG_MAX;               // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
 /*************************************** SPECIAL TEST CASES ***************************************/
 /**************************************************************************************************/
 START_TEST(test_s01_missing_filename)
@@ -448,12 +633,30 @@ START_TEST(test_s04_character_device)
 END_TEST
 
 
+/*
+ *	NOTE: If the seconds are set to INT_MIN, the nanoseconds appear to always be set to 0.
+ */
+START_TEST(test_s05_sec_min_value_edge_case)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MIN;               // Seconds test input
+	long new_nsec = 0;                      // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
 Suite *set_atime_suite(void)
 {
 	Suite *suite = NULL;
 	TCase *tc_normal = NULL;
 	TCase *tc_error = NULL;
-	// TCase *tc_boundary = NULL;
+	TCase *tc_boundary = NULL;
 	TCase *tc_special = NULL;
 
 	suite = suite_create("SFMW_Set_Atime");
@@ -461,11 +664,11 @@ Suite *set_atime_suite(void)
 	/* Core test case */
 	tc_normal = tcase_create("Normal");
 	tc_error = tcase_create("Error");
-	// tc_boundary = tcase_create("Boundary");
+	tc_boundary = tcase_create("Boundary");
 	tc_special = tcase_create("Special");
 	tcase_add_checked_fixture(tc_normal, setup, teardown);
 	tcase_add_checked_fixture(tc_error, setup, teardown);
-	// tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
 	tcase_add_checked_fixture(tc_special, setup, teardown);
 	tcase_add_test(tc_normal, test_n01_directory);
 	tcase_add_test(tc_normal, test_n02_named_pipe);
@@ -474,13 +677,26 @@ Suite *set_atime_suite(void)
 	tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
 	tcase_add_test(tc_error, test_e01_null_filename);
 	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_boundary, test_b01_sec_min_value);
+	tcase_add_test(tc_boundary, test_b02_sec_almost_epoch);
+	tcase_add_test(tc_boundary, test_b03_sec_epoch_time);
+	tcase_add_test(tc_boundary, test_b04_sec_barely_past_epoch);
+	tcase_add_test(tc_boundary, test_b05_sec_static_now);
+	tcase_add_test(tc_boundary, test_b06_sec_max_value);
+	tcase_add_test(tc_boundary, test_b07_nsec_low_very_bad);
+	tcase_add_test(tc_boundary, test_b08_nsec_low_barely_bad);
+	tcase_add_test(tc_boundary, test_b09_nsec_low_barely_good);
+	tcase_add_test(tc_boundary, test_b10_nsec_high_barely_good);
+	tcase_add_test(tc_boundary, test_b11_nsec_high_barely_bad);
+	tcase_add_test(tc_boundary, test_b12_nsec_high_very_bad);
 	tcase_add_test(tc_special, test_s01_missing_filename);
 	tcase_add_test(tc_special, test_s02_symbolic_link_nofollow);
 	tcase_add_test(tc_special, test_s03_block_device);
 	tcase_add_test(tc_special, test_s04_character_device);
+	tcase_add_test(tc_special, test_s05_sec_min_value_edge_case);
 	suite_add_tcase(suite, tc_normal);
 	suite_add_tcase(suite, tc_error);
-	// suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_boundary);
 	suite_add_tcase(suite, tc_special);
 
 	return suite;

--- a/code/test/check_sfmw_set_atime.c
+++ b/code/test/check_sfmw_set_atime.c
@@ -124,7 +124,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -231,19 +231,19 @@ void teardown(void)
 {
 	// Directory
 	set_times_now(test_dir_path, false);  // Ignore any errors
-	free_devops_mem(&test_dir_path);  // Ignore any errors
+	free_devops_mem((void **)&test_dir_path);  // Ignore any errors
 	// File
 	set_times_now(test_file_path, false);  // Ignore any errors
-	free_devops_mem(&test_file_path);  // Ignore any errors
+	free_devops_mem((void **)&test_file_path);  // Ignore any errors
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 	// Symbolic Link
 	set_times_now(test_sym_link, false);  // Ignore any errors
-	free_devops_mem(&test_sym_link);  // Ignore any errors
+	free_devops_mem((void **)&test_sym_link);  // Ignore any errors
 }
 
 
@@ -726,7 +726,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmw_set_atime.c
+++ b/code/test/check_sfmw_set_atime.c
@@ -1,0 +1,517 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_atime() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_atime.bin
+code/dist/check_sfmw_set_atime.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_atime.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_set_atime.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_set_atime.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_set_atime.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_atime.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ */
+
+#include <check.h>                     // START_TEST(), END_TEST
+#include <limits.h>                    // PATH_MAX
+#include <stdio.h>                     // printf()
+#include <stdlib.h>
+#include <unistd.h>                    // get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"               // resolve_to_repo(), SKID_REPO_NAME
+#include "skid_file_metadata_read.h"   // get_access_time()
+#include "skid_file_metadata_write.h"  // set_atime()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
+#define MICRO_SEC_SLEEP (useconds_t)10000  // Give the file timestamp 0.01 second to update
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+
+char *test_dir_path;  // Heap array containing the absolute directory name resolved to the repo
+char *test_file_path;  // Heap array containing the absolute filename resolved to the repo
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+char *test_sym_link;  // Heap array with the absolute symbolic link filename resolved to the repo
+
+/*
+ *	Set the atime and mtime timestamps of the test_*_path globals to "now".
+ */
+void reset_global_timestamps(void);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	1. Gets the original time, 2. Calls the tested function, 3. Gets the new time.
+ *	Verifies: actual return == exp_ret, desired time == current time
+ *	If follow_sym is true and pathname is a symbolic link, checks the before and after timestamps
+ *	of target_name instead.  Otherwise, target_name is ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret,
+	               time_t new_sec, long new_nsec);
+
+/*
+ *	Resolve all the default test filenames to the repo and store the heap memory pointer in
+ *	the globals.  Also, set the timestamps to now.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Reset the timestamps for the remaining globals.
+ *	Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Compare the desired time vs current times to verify the timestamp was updated.
+ */
+void verify_time_update(const char *pathname, const char *time_adj,
+						time_t new_time, long new_time_nsec, time_t curr_time, long curr_time_nsec);
+
+
+void reset_global_timestamps(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	// Array of the global pointers to iterate over
+	char *test_paths[] = {test_dir_path, test_file_path, test_pipe_path,
+	                      test_socket_path, test_sym_link};
+
+	// RESET TIMES
+	for (int i = 0; i < (sizeof(test_paths) / sizeof(test_paths[0])); i++)
+	{
+		errnum = set_times_now(test_paths[i], false);
+		ck_assert_msg(0 == errnum, "set_times_now(%s) failed with [%d] %s", test_paths[i],
+			          errnum, strerror(errnum));
+	}
+
+	// DONE
+	return;
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret,
+	               time_t new_sec, long new_nsec)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;            // Errno values
+	time_t old_time = 0;                // Original time
+	long old_time_nsec = 0;             // Original time nanoseconds
+	time_t curr_time = 0;               // Current time
+	long curr_time_nsec = 0;            // Current time nanoseconds
+	const char *time_check = pathname;  // Filename to gather timestamps for
+
+	// CHECK IT
+	// Should we use target_name instead?
+	if (pathname && *pathname && true == follow_sym && true == is_sym_link(pathname, &errnum))
+	{
+		ck_assert_msg(0 == errnum, "is_sym_link(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+		time_check = target_name;
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+
+	// RUN IT
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 1. Get original time
+		errnum = get_access_timestamp(time_check, &old_time, &old_time_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_access_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// 2. Call function
+	micro_sleep(MICRO_SEC_SLEEP);  // Wait before changing the timestamp
+	errnum = set_atime(pathname, follow_sym, new_sec, new_nsec);
+	ck_assert_msg(exp_ret == errnum, "set_atime(%s) returned [%d] '%s' instead of [%d] '%s'",
+				  pathname, errnum, strerror(errnum), exp_ret, strerror(exp_ret));
+	errnum = CANARY_INT;  // Reset temp variable
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 3. Get current time
+		errnum = get_access_timestamp(time_check, &curr_time, &curr_time_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_access_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+
+		// VALIDATE RESULTS
+		verify_time_update(time_check, "access", new_sec, new_nsec, curr_time, curr_time_nsec);
+	}
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                          // Errno values
+	char directory[] = { "./code/test/test_input/" };                 // Default test input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };      // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };      // Default test input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };  // Default test input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };      // Default test input: symlink
+
+	// SET IT UP
+	// Directory
+	test_dir_path = resolve_test_input(directory);
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Regular File
+	test_file_path = resolve_test_input(reg_file);
+	// Symbolic Link
+	test_sym_link = resolve_test_input(sym_link);
+
+	// RESET TIMESTAMPS
+	reset_global_timestamps();
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Directory
+	set_times_now(test_dir_path, false);  // Ignore any errors
+	free_devops_mem(&test_dir_path);  // Ignore any errors
+	// File
+	set_times_now(test_file_path, false);  // Ignore any errors
+	free_devops_mem(&test_file_path);  // Ignore any errors
+	// Pipe
+	remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+	// Symbolic Link
+	set_times_now(test_sym_link, false);  // Ignore any errors
+	free_devops_mem(&test_sym_link);  // Ignore any errors
+}
+
+
+void verify_time_update(const char *pathname, const char *time_adj,
+						time_t new_time, long new_time_nsec, time_t curr_time, long curr_time_nsec)
+{
+	// Compare times
+	if (new_time != curr_time)
+	{
+		ck_abort_msg("The %s time for %s was not updated: new sec %ld != curr sec %ld",
+					 time_adj, pathname, new_time, curr_time);
+	}
+	else if (new_time_nsec != curr_time_nsec)
+	{
+		ck_abort_msg("The %s nanoseconds for %s weren't updated: new nsec %ld != curr nsec %ld",
+					 time_adj, pathname, new_time_nsec, curr_time_nsec);
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = 0;           // Expected results
+	time_t new_sec = 0x600DC0DE;  // Seconds test input
+	long new_nsec = 0xD06F00D;    // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_dir_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	bool follow = true;         // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0xBAD71E;  // Seconds test input
+	long new_nsec = 0x347F00D;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	bool follow = true;         // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0xB00000;  // Seconds test input
+	long new_nsec = 0xC0010FF;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int exp_result = 0;       // Expected results
+	time_t new_sec = 0xD34D;  // Seconds test input
+	long new_nsec = 0xBEEF;   // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int exp_result = 0;       // Expected results
+	time_t new_sec = 0xFEED;  // Seconds test input
+	long new_nsec = 0xFACE;   // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_sym_link;
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = EINVAL;      // Expected results
+	time_t new_sec = 0x7E57;      // Seconds test input
+	long new_nsec = 0xC0DE;       // Nanoseconds test input
+	char *input_abs_path = NULL;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                          // Follow symlinks
+	int exp_result = EINVAL;                     // Expected results
+	time_t new_sec = 0x7E57;                     // Seconds test input
+	long new_nsec = 0xC0DE;                      // Nanoseconds test input
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_s01_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                                 // Follow symlinks
+	int exp_result = ENOENT;                            // Expected results
+	time_t new_sec = 0x7E57;                            // Seconds test input
+	long new_nsec = 0xC0DE;                             // Nanoseconds test input
+	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_s02_symbolic_link_nofollow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;        // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0x4B1D;    // Seconds test input
+	long new_nsec = 0xB16C0DE;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_sym_link;
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+ 
+
+START_TEST(test_s03_block_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                        // Follow symlinks
+	int exp_result = EPERM;                    // Expected results
+	time_t new_sec = 0x7E57;                   // Seconds test input
+	long new_nsec = 0xC0DE;                    // Nanoseconds test input
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_s04_character_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                       // Follow symlinks
+	int exp_result = EPERM;                   // Expected results
+	time_t new_sec = 0x7E57;                  // Seconds test input
+	long new_nsec = 0xC0DE;                   // Nanoseconds test input
+	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+Suite *set_atime_suite(void)
+{
+	Suite *suite = NULL;
+	TCase *tc_normal = NULL;
+	TCase *tc_error = NULL;
+	// TCase *tc_boundary = NULL;
+	TCase *tc_special = NULL;
+
+	suite = suite_create("SFMW_Set_Atime");
+
+	/* Core test case */
+	tc_normal = tcase_create("Normal");
+	tc_error = tcase_create("Error");
+	// tc_boundary = tcase_create("Boundary");
+	tc_special = tcase_create("Special");
+	tcase_add_checked_fixture(tc_normal, setup, teardown);
+	tcase_add_checked_fixture(tc_error, setup, teardown);
+	// tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_test(tc_normal, test_n01_directory);
+	tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_test(tc_normal, test_n03_regular_file);
+	tcase_add_test(tc_normal, test_n04_socket);
+	tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
+	tcase_add_test(tc_error, test_e01_null_filename);
+	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_special, test_s01_missing_filename);
+	tcase_add_test(tc_special, test_s02_symbolic_link_nofollow);
+	tcase_add_test(tc_special, test_s03_block_device);
+	tcase_add_test(tc_special, test_s04_character_device);
+	suite_add_tcase(suite, tc_normal);
+	suite_add_tcase(suite, tc_error);
+	// suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_atime.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = set_atime_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_atime_now.c
+++ b/code/test/check_sfmw_set_atime_now.c
@@ -83,7 +83,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -177,10 +177,10 @@ void teardown(void)
 {
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 }
 
 
@@ -218,7 +218,7 @@ START_TEST(test_n01_directory)
 	run_test_case(input_abs_path, NULL, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -249,7 +249,7 @@ START_TEST(test_n03_regular_file)
 	run_test_case(input_abs_path, NULL, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -282,8 +282,8 @@ START_TEST(test_n05_symbolic_link_follow)
 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -347,8 +347,8 @@ START_TEST(test_s02_symbolic_link_nofollow)
 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
  
@@ -429,7 +429,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmw_set_atime_now.c
+++ b/code/test/check_sfmw_set_atime_now.c
@@ -97,7 +97,6 @@ void run_test_case(const char *pathname, bool follow_sym, int exp_ret)
 		ck_assert_msg(0 == errnum, "old get_shell_atime(%s) failed with [%d] %s",
 					  pathname, errnum, strerror(errnum));
 		errnum = CANARY_INT;  // Reset temp variable
-		micro_sleep(MICRO_SEC_SLEEP);  // Wait a few microseconds
 	}
 	// 2. Call function
 	errnum = set_atime_now(pathname, follow_sym);
@@ -108,7 +107,6 @@ void run_test_case(const char *pathname, bool follow_sym, int exp_ret)
 	if (0 == exp_ret)
 	{
 		// 3. Get current time
-		micro_sleep(MICRO_SEC_SLEEP);  // Wait a few microseconds
 		new_time = get_shell_atime(pathname, &errnum);
 		ck_assert_msg(0 == errnum, "new get_shell_atime(%s) failed with [%d] %s",
 					  pathname, errnum, strerror(errnum));
@@ -161,7 +159,6 @@ void setup(void)
 					  errnum, strerror(errnum));
 		errnum = CANARY_INT;  // Reset temp variable
 	}
-	errnum = CANARY_INT;  // Reset temp variable
 	// Raw Socket
 	test_socket_path = resolve_test_input(raw_socket);
 	if (test_socket_path)
@@ -181,10 +178,10 @@ void setup(void)
 void teardown(void)
 {
 	// Pipe
-	// remove_a_file(test_pipe_path, true);  // Best effort
+	remove_a_file(test_pipe_path, true);  // Best effort
 	free_devops_mem(&test_pipe_path);  // Ignore any errors
 	// Socket
-	// remove_a_file(test_socket_path, true);  // Best effort
+	remove_a_file(test_socket_path, true);  // Best effort
 	free_devops_mem(&test_socket_path);  // Ignore any errors
 }
 
@@ -220,6 +217,8 @@ START_TEST(test_n02_named_pipe)
 	char *input_abs_path = test_pipe_path;
 
 	// RUN TEST
+	// Files created at test-time may cause false-negatives when test cases execute too quickly
+	micro_sleep(1000000);  // Wait one second before changing the atime
 	run_test_case(input_abs_path, follow, exp_result);
 }
 END_TEST
@@ -251,6 +250,8 @@ START_TEST(test_n04_socket)
 	char *input_abs_path = test_socket_path;
 
 	// RUN TEST
+	// Files created at test-time may cause false-negatives when test cases execute too quickly
+	micro_sleep(1000000);  // Wait one second before changing the atime
 	run_test_case(input_abs_path, follow, exp_result);
 }
 END_TEST

--- a/code/test/check_sfmw_set_atime_now.c
+++ b/code/test/check_sfmw_set_atime_now.c
@@ -1,0 +1,429 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_atime_now() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_atime_now.bin
+code/dist/check_sfmw_set_atime_now.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_atime_now.bin
+
+ *
+ */
+
+#include <check.h>                     // START_TEST(), END_TEST
+#include <limits.h>                    // PATH_MAX
+#include <stdio.h>                     // printf()
+#include <stdlib.h>
+#include <unistd.h>                    // get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"               // resolve_to_repo(), SKID_REPO_NAME
+#include "skid_file_metadata_read.h"   // get_access_time()
+#include "skid_file_metadata_write.h"  // set_atime_now()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
+#define MICRO_SEC_SLEEP (useconds_t)5  // Give the file time a 5 microseconds to update
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	1. Gets the original time, 2. Calls the tested function, 3. Gets the new time.
+ *	Verifies: actual return == exp_ret, original time < new time.
+ */
+void run_test_case(const char *pathname, bool follow_sym, int exp_ret);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, bool follow_sym, int exp_ret)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	time_t old_time = 0;      // Original time
+	time_t new_time = 0;      // New time
+
+	// RUN IT
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 1. Get original time
+		old_time = get_shell_atime(pathname, &errnum);
+		ck_assert_msg(0 == errnum, "old get_shell_atime(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+		micro_sleep(MICRO_SEC_SLEEP);  // Wait a few microseconds
+	}
+	// 2. Call function
+	errnum = set_atime_now(pathname, follow_sym);
+	ck_assert_msg(exp_ret == errnum, "set_atime_now(%s) returned [%d] '%s' instead of [%d] '%s",
+		          pathname, errnum, strerror(errnum), exp_ret, strerror(exp_ret));
+	errnum = CANARY_INT;  // Reset temp variable
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 3. Get current time
+		micro_sleep(MICRO_SEC_SLEEP);  // Wait a few microseconds
+		new_time = get_shell_atime(pathname, &errnum);
+		ck_assert_msg(0 == errnum, "new get_shell_atime(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+
+		// VALIDATE RESULTS
+		// Compare times
+		/*
+		 *	WARNING: Filesystems are frequently mounted with the relatime flag.  Mine certainly is.
+		 *	See: cat /proc/mounts
+		 *
+		 *	Why does that matter?  Great question.  When your filesystem is mounted with
+		 *	relatime, and you read a file or directory, the atime is only updated if:
+		 *		- the atime is older than the ctime (change time) or mtime (modification time), or
+		 *		- if the atime is more than a day in the past.
+		 *
+		 *	What does that have to do with these unit tests?  Another great question.
+		 *	I could have launched into some crazy filesytem-parsing devops code to better
+		 *	when a directory's timestamp should be updated (and when it shouldn't).  Instead,
+		 *	I decided to go 'easy' on validating directories based on what I've found.
+		 */
+		if (true == is_directory(pathname, &errnum))
+		{
+			ck_assert_msg(old_time <= new_time, "The time for dir %s was not updated", pathname);
+		}
+		else
+		{
+			ck_assert_msg(old_time < new_time, "The time for %s was not updated", pathname);
+		}
+		ck_assert_msg(0 == errnum, "new is_directory(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+	}
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                      // Errno values
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };  // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };  // Default test input: socket
+
+	// SET IT UP
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Pipe
+	// remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	// remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/");
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int result = 0;        // Return value from function call
+	int errnum = CANARY_INT;  // Errno from the function calls
+	int exp_result = 0;    // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// TEST START
+	result = set_atime_now(input_abs_path, follow);
+	ck_assert_msg(exp_result == result, "set_atime_now(%s) returned %d instead of %d",
+				  input_abs_path, result, exp_result);
+	ck_assert_int_eq(0, errnum);  // The out param should be zeroized on success
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = EINVAL;      // Expected results
+	char *input_abs_path = NULL;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                          // Follow symlinks
+	int exp_result = EINVAL;                     // Expected results
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_s01_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                                 // Follow symlinks
+	int exp_result = ENOENT;                            // Expected results
+	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_s02_symbolic_link_nofollow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;  // Follow symlinks
+	int exp_result = 0;   // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
+}
+END_TEST
+ 
+
+START_TEST(test_s03_block_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                        // Follow symlinks
+	int exp_result = EPERM;                    // Expected results
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_s04_character_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                       // Follow symlinks
+	int exp_result = EPERM;                   // Expected results
+	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, follow, exp_result);
+}
+END_TEST
+
+
+Suite *set_atime_now_suite(void)
+{
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
+
+	suite = suite_create("SFMW_Set_Atime_Now");
+
+	/* Core test case */
+	tc_core = tcase_create("Core");
+	tcase_add_checked_fixture(tc_core, setup, teardown);
+	tcase_add_test(tc_core, test_n01_directory);
+	tcase_add_test(tc_core, test_n02_named_pipe);
+	tcase_add_test(tc_core, test_n03_regular_file);
+	tcase_add_test(tc_core, test_n04_socket);
+	tcase_add_test(tc_core, test_n05_symbolic_link_follow);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	tcase_add_test(tc_core, test_s02_symbolic_link_nofollow);
+	tcase_add_test(tc_core, test_s03_block_device);
+	tcase_add_test(tc_core, test_s04_character_device);
+	suite_add_tcase(suite, tc_core);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_atime_now.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = set_atime_now_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_atime_now.c
+++ b/code/test/check_sfmw_set_atime_now.c
@@ -30,7 +30,6 @@ code/dist/check_sfmw_set_atime_now.bin && CK_FORK=no valgrind --leak-check=full 
 /***************************************** TEST FIXTURES ******************************************/
 /**************************************************************************************************/
 
-
 char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
 char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
 
@@ -109,7 +108,6 @@ void run_test_case(const char *pathname, const char *target_name, bool follow_sy
 	if (0 == exp_ret)
 	{
 		// 1. Get original time
-		// old_time = get_shell_atime(time_check, &errnum);
 		errnum = get_access_timestamp(time_check, &old_time, &old_time_nsec, follow_sym);
 		ck_assert_msg(0 == errnum, "old get_access_timestamp(%s) failed with [%d] %s",
 					  time_check, errnum, strerror(errnum));
@@ -125,7 +123,6 @@ void run_test_case(const char *pathname, const char *target_name, bool follow_sy
 	if (0 == exp_ret)
 	{
 		// 3. Get current time
-		// new_time = get_shell_atime(time_check, &errnum);
 		errnum = get_access_timestamp(time_check, &new_time, &new_time_nsec, follow_sym);
 		ck_assert_msg(0 == errnum, "new get_access_timestamp(%s) failed with [%d] %s",
 					  time_check, errnum, strerror(errnum));
@@ -261,10 +258,8 @@ END_TEST
 START_TEST(test_n05_symbolic_link_follow)
 {
 	// LOCAL VARIABLES
-	bool follow = true;       // Follow symlinks
-	// int result = 0;        // Return value from function call
-	// int errnum = CANARY_INT;  // Errno from the function calls
-	int exp_result = 0;    // Expected results
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
 	// Absolute path for test input as resolved against the repo name
 	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
 	// Absolute path for actual_rel_path as resolved against the repo name

--- a/code/test/check_sfmw_set_mode.c
+++ b/code/test/check_sfmw_set_mode.c
@@ -33,15 +33,21 @@ export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_mode.bin; unset CK_RU
 // Use this to help highlight an errnum that wasn't updated
 #define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
 // Common Mode Macros
-#define TEST_MODE_0444 SKID_MODE_OWNER_R | \
-                       SKID_MODE_GROUP_R | \
-                       SKID_MODE_OTHER_R
-#define TEST_MODE_0644 SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | \
-					   SKID_MODE_GROUP_R | \
-                       SKID_MODE_OTHER_R
-#define TEST_MODE_0754 SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
-                       SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | \
-                       SKID_MODE_OTHER_R
+#define TEST_MODE_0444 (SKID_MODE_OWNER_R | \
+                        SKID_MODE_GROUP_R | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0644 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | \
+					    SKID_MODE_GROUP_R | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0764 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
+                        SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | \
+                        SKID_MODE_OTHER_R)
+#define TEST_MODE_0777 (SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
+                        SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | SKID_MODE_GROUP_X | \
+                        SKID_MODE_OTHER_R | SKID_MODE_OTHER_W | SKID_MODE_OTHER_X)
+#define TEST_MODE_7000 (SKID_MODE_SET_UID | SKID_MODE_SET_GID | SKID_MODE_STICKYB)
+#define TEST_MODE_7764 (TEST_MODE_7000 | TEST_MODE_0764)
+#define TEST_MODE_7777 (TEST_MODE_7000 | TEST_MODE_0777)
 
 
 /**************************************************************************************************/
@@ -60,6 +66,7 @@ testPathDetails_ptr test_file_details;  // Heap-allocated struct containing test
 testPathDetails_ptr test_pipe_details;  // Heap-allocated struct containing test pipe details
 testPathDetails_ptr test_socket_details;  // Heap-allocated struct containing test socket details
 testPathDetails_ptr test_symlink_details;  // Heap-allocated struct with test symbolic link details
+testPathDetails_ptr test_bad_path_details;  // Heap-allocated struct with a bad path
 
 /*
  *	Reset the permissions of the test_*_details globals back to their original mode values.
@@ -168,6 +175,12 @@ void run_test_case(const char *pathname, const char *target_name, mode_t test_mo
 	mode_t new_mode = 0;                // Post-execution mode
 	const char *check_mode = pathname;  // Filename to verify pre/post-test permissions
 
+	// SETUP
+	if (true == is_sym_link(pathname, &errnum) && target_name && *target_name)
+	{
+		check_mode = target_name;
+	}
+
 	// RUN IT
 	actual_ret = set_mode(pathname, test_mode);
 
@@ -183,8 +196,8 @@ void run_test_case(const char *pathname, const char *target_name, mode_t test_mo
 		new_mode = get_shell_file_perms(check_mode, &errnum);
 		ck_assert_msg(0 == errnum, "The second get_shell_file_perms(%s) errored with [%d] '%s'\n",
 					  check_mode, errnum, strerror(errnum));
-		// Compare actual permissions to the test_mode
-		ck_assert_msg(new_mode == test_mode,
+		// Compare actual permissions to the test_mode (while ignoring unused test input bits)
+		ck_assert_msg(new_mode == (new_mode & test_mode),
 			          "set_mode(%s, %o) failed to set the mode (saw %o instead)\n",
 					  check_mode, test_mode, new_mode);
 	}
@@ -197,12 +210,13 @@ void run_test_case(const char *pathname, const char *target_name, mode_t test_mo
 void setup(void)
 {
 	// LOCAL VARIABLES
-	int errnum = CANARY_INT;                                          // Errno values
-	char directory[] = { "./code/test/test_input/" };                 // Default test input: dir
-	char named_pipe[] = { "./code/test/test_input/named_pipe" };      // Default test input: pipe
-	char raw_socket[] = { "./code/test/test_input/raw_socket" };      // Default test input: socket
-	char reg_file[] = { "./code/test/test_input/regular_file.txt" };  // Default test input: file
-	char sym_link[] = { "./code/test/test_input/sym_link.txt" };      // Default test input: symlink
+	int errnum = CANARY_INT;                                             // Errno values
+	char directory[] = { "./code/test/test_input/" };                    // Default input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };         // Default input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };         // Default input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };     // Default input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };         // Default input: symlink
+	char bad_path[] = { "./code/test/test_input/named_pipe/bad_path" };  // Default input: bad path
 
 	// SET IT UP
 	// Allocate structs
@@ -211,6 +225,7 @@ void setup(void)
 	test_socket_details = setup_struct(raw_socket);
 	test_file_details = setup_struct(reg_file);
 	test_symlink_details = setup_struct(sym_link);
+	test_bad_path_details = setup_struct(bad_path);
 	// Create files
 	if (test_pipe_details && test_pipe_details->pathname)
 	{
@@ -341,6 +356,8 @@ void teardown(void)
 	teardown_struct(&test_socket_details);  // Ignore any errors
 	// Symbolic Link
 	teardown_struct(&test_symlink_details);  // Ignore any errors
+	// Bad Path
+	teardown_struct(&test_bad_path_details);  // Ignore any errors
 }
 
 
@@ -374,48 +391,18 @@ void teardown_struct(testPathDetails_ptr *old_struct)
 }
 
 
-// /**************************************************************************************************/
-// /*************************************** NORMAL TEST CASES ****************************************/
-// /**************************************************************************************************/
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
 
 
-// START_TEST(test_n01_directory)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = get_new_gid();  // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_dir_details->pathname;
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
-
-
-// START_TEST(test_n02_named_pipe)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = get_new_gid();  // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_pipe_details->pathname;
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
-
-
-START_TEST(test_n03_regular_file)
+START_TEST(test_n01_directory)
 {
 	// LOCAL VARIABLES
 	// Absolute path for test input as resolved against the repo name
-	char *input_abs_path = test_file_details->pathname;
+	char *input_abs_path = test_dir_details->pathname;
 	// New mode to use as test input
-	mode_t test_mode = TEST_MODE_0754;  // rwxrw-r--
+	mode_t test_mode = TEST_MODE_0764;  // rwxrw-r--
 	int exp_return = 0;                 // Expected return value for this test input
 
 	// RUN TEST
@@ -424,36 +411,64 @@ START_TEST(test_n03_regular_file)
 END_TEST
 
 
-// START_TEST(test_n04_socket)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = get_new_gid();  // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_socket_details->pathname;
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0764;  // rwxrw-r--
+	int exp_return = 0;                 // Expected return value for this test input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// START_TEST(test_n05_symbolic_link_follow)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = get_new_gid();  // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_symlink_details->pathname;
-// 	// Absolute path for actual_rel_path as resolved against the repo name
-// 	char *actual_abs_path = test_file_details->pathname;
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0764;  // rwxrw-r--
+	int exp_return = 0;                 // Expected return value for this test input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, actual_abs_path, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0764;  // rwxrw-r--
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_symlink_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0764;  // rwxrw-r--
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, test_file_details->pathname, test_mode, exp_return);
+}
+END_TEST
 
 
 /**************************************************************************************************/
@@ -461,46 +476,45 @@ END_TEST
 /**************************************************************************************************/
 
 
-// START_TEST(test_e01_null_filename)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = get_new_gid();  // Test case input
-// 	char *input_abs_path = NULL;    // Test case input
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0644;  // Test case input
+	int exp_return = EINVAL;            // Expected return value for this test input
+	char *input_abs_path = NULL;        // Test case input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
-
-
-// START_TEST(test_e02_empty_filename)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                          // Test case input
-// 	uid_t new_uid = get_new_uid();               // Test case input
-// 	gid_t new_gid = get_new_gid();               // Test case input
-// 	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// START_TEST(test_e03_missing_filename)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                             // Test case input
-// 	uid_t new_uid = get_new_uid();                  // Test case input
-// 	gid_t new_gid = get_new_gid();                  // Test case input
-// 	char input_abs_path[] = { "/file/not/found" };  // Test case input
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0644;           // Test case input
+	int exp_return = EINVAL;                     // Expected return value for this test input
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+START_TEST(test_e03_missing_filename)
+{
+	// LOCAL VARIABLES
+	mode_t test_mode = TEST_MODE_0644;              // Test case input
+	int exp_return = ENOENT;                        // Expected return value for this test input
+	char input_abs_path[] = { "/file/not/found" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
 /**************************************************************************************************/
@@ -508,258 +522,179 @@ END_TEST
 /**************************************************************************************************/
 
 
-// // Minimum GID for a system user (e.g., root, bin, sys)
-// START_TEST(test_b01_min_good_system_user_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 0;              // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
+START_TEST(test_b01_smallest_mode)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 0;  // ---------
+	int exp_return = 0;    // Expected return value for this test input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
-
-
-// // Maximum GID for a system user (e.g., root, bin, sys)
-// START_TEST(test_b02_max_good_system_user_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 99;             // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// // Minimum GID for an application user (e.g., crontab, syslog, pulse)
-// START_TEST(test_b03_min_good_application_user_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 100;            // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
+START_TEST(test_b02_largest_mode)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7777;  // rwsrwsrwt
+	int exp_return = 0;                 // Expected return value for this test input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
-
-
-// // Maximum GID for an application user (e.g., crontab, syslog, pulse)
-// START_TEST(test_b04_max_good_system_user_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 999;            // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// // Minimum GID for a regular user (see: useradd mumu)
-// START_TEST(test_b05_min_good_regular_user_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 1000;           // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
 
 
-// // Maximum GID for Debian: https://www.baeldung.com/linux/user-ids-reserved-values
-// START_TEST(test_b06_max_good_debian_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 59999;          // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
+// Observed behavior is that, in invalid mode values, "don't care about those" bits are ignored.
+START_TEST(test_s01_all_flags_enabled)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 0xFF;  // Test case input
+	int exp_return = 0;       // Expected return value for this test input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// SETUP
+	for (int i = 1; i < sizeof(mode_t); i++)
+	{
+		test_mode <<= 8;  // Make room for the next byte
+		test_mode |= 0xFF;  // Turn on one byte's worth of bits
+	}
 
-
-// // Maximum GID for Solaris: https://docs.oracle.com/cd/E19455-01/805-7228/userconcept-35/index.html
-// START_TEST(test_b07_max_good_solaris_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 60000;          // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// // Maximum GID for Linux (see: grep ^GID_MAX /etc/login.defs)
-// START_TEST(test_b08_max_good_linux_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;             // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = 60000;          // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
+START_TEST(test_s02_path_contains_non_dir)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_bad_path_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0764;  // Test case input
+	int exp_return = ENOTDIR;           // Expected return value for this test input
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
-
-
-// /**************************************************************************************************/
-// /*************************************** SPECIAL TEST CASES ***************************************/
-// /**************************************************************************************************/
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// START_TEST(test_s01_symbolic_link_no_follow)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = false;            // Test case input
-// 	uid_t new_uid = get_new_uid();  // Test case input
-// 	gid_t new_gid = get_new_gid();  // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_symlink_details->pathname;
+START_TEST(test_s03_no_change)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	int errnum = CANARY_INT;                                     // Errno values
+	mode_t test_mode = get_file_perms(input_abs_path, &errnum);  // Test case input
+	int exp_return = 0;                                          // Expected return value
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// VALIDATE
+	ck_assert_msg(0 == errnum, "get_file_perms(%s) failed with [%d] %s",
+		          input_abs_path, errnum, strerror(errnum));
 
-
-// START_TEST(test_s02_nobody_uid)
-// {
-// 	// LOCAL VARIABLES
-// 	int errnum = 0;                                         // Errno value
-// 	bool follow = true;                                     // Test case input
-// 	uid_t new_uid = get_shell_user_uid("nobody", &errnum);  // Test case input
-// 	gid_t new_gid = CSSO_SKIP_GID;                          // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
-
-// 	// VALIDATE
-// 	ck_assert_msg(0 == errnum, "get_shell_user_uid() failed with [%d] %s",
-// 		          errnum, strerror(errnum));
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// START_TEST(test_s03_nogroup_gid)
-// {
-// 	// LOCAL VARIABLES
-// 	int errnum = 0;                                          // Errno value
-// 	bool follow = true;                                      // Test case input
-// 	uid_t new_uid = get_new_uid();                           // Test case input
-// 	gid_t new_gid = get_shell_user_gid("nobody", &errnum);  // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
+START_TEST(test_s04_special_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7764;  // rwsrwSr-T
+	int exp_return = 0;                 // Expected return value for this test input
 
-// 	// VALIDATE
-// 	ck_assert_msg(0 == errnum, "get_shell_user_gid() failed with [%d] %s",
-// 		          errnum, strerror(errnum));
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
-// START_TEST(test_s04_nobody_nogroup)
-// {
-// 	// LOCAL VARIABLES
-// 	int errnum = 0;      // Errno value
-// 	bool follow = true;  // Test case input
-// 	uid_t new_uid = 0;   // Test case input
-// 	gid_t new_gid = 0;   // Test case input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_file_details->pathname;
+START_TEST(test_s05_just_the_special_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_7000;  // ---S--S--T
+	int exp_return = 0;                 // Expected return value for this test input
 
-// 	// SETUP
-// 	// UID
-// 	new_uid = get_shell_user_uid("nobody", &errnum);
-// 	ck_assert_msg(0 == errnum, "get_shell_user_uid() failed with [%d] %s",
-// 		          errnum, strerror(errnum));
-// 	// GID
-// 	new_gid = get_shell_user_gid("nobody", &errnum);
-// 	ck_assert_msg(0 == errnum, "get_shell_user_gid() failed with [%d] %s",
-// 		          errnum, strerror(errnum));
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
-// }
-// END_TEST
+
+// Observed behavior is that, in invalid mode values, "don't care about those" bits are ignored.
+START_TEST(test_s06_bit_field_ignores_invalid_bits)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = 077777;  // rwxrwxrwx!
+	int exp_return = 0;         // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
 
 
 Suite *set_mode_suite(void)
 {
 	// LOCAL VARIABLES
-	Suite *suite = suite_create("SFMW_Set_Mode");  // Test suite
-	TCase *tc_normal = tcase_create("Normal");       // Normal test cases
-	// TCase *tc_error = tcase_create("Error");         // Error test cases
-	// TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases
-	// TCase *tc_special = tcase_create("Special");     // Special test cases
+	Suite *suite = suite_create("SFMW_Set_Mode");   // Test suite
+	TCase *tc_normal = tcase_create("Normal");      // Normal test cases
+	TCase *tc_error = tcase_create("Error");        // Error test cases
+	TCase *tc_boundary = tcase_create("Boundary");  // Boundary test cases
+	TCase *tc_special = tcase_create("Special");    // Special test cases
 
 	// SETUP TEST CASES
 	tcase_add_checked_fixture(tc_normal, setup, teardown);
-	// tcase_add_checked_fixture(tc_error, setup, teardown);
-	// tcase_add_checked_fixture(tc_boundary, setup, teardown);
-	// tcase_add_checked_fixture(tc_special, setup, teardown);
-	// tcase_add_test(tc_normal, test_n01_directory);
-	// tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_checked_fixture(tc_error, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_test(tc_normal, test_n01_directory);
+	tcase_add_test(tc_normal, test_n02_named_pipe);
 	tcase_add_test(tc_normal, test_n03_regular_file);
-	// tcase_add_test(tc_normal, test_n04_socket);
-	// tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
-	// tcase_add_test(tc_error, test_e01_null_filename);
-	// tcase_add_test(tc_error, test_e02_empty_filename);
-	// tcase_add_test(tc_error, test_e03_missing_filename);
-	// tcase_add_test(tc_boundary, test_b01_min_good_system_user_gid);
-	// tcase_add_test(tc_boundary, test_b02_max_good_system_user_gid);
-	// tcase_add_test(tc_boundary, test_b03_min_good_application_user_gid);
-	// tcase_add_test(tc_boundary, test_b04_max_good_system_user_gid);
-	// tcase_add_test(tc_boundary, test_b05_min_good_regular_user_gid);
-	// tcase_add_test(tc_boundary, test_b06_max_good_debian_gid);
-	// tcase_add_test(tc_boundary, test_b07_max_good_solaris_gid);
-	// tcase_add_test(tc_boundary, test_b08_max_good_linux_gid);
-	// tcase_add_test(tc_special, test_s01_symbolic_link_no_follow);
-	// tcase_add_test(tc_special, test_s02_nobody_uid);
-	// tcase_add_test(tc_special, test_s03_nogroup_gid);
-	// tcase_add_test(tc_special, test_s04_nobody_nogroup);
+	tcase_add_test(tc_normal, test_n04_socket);
+	tcase_add_test(tc_normal, test_n05_symbolic_link);
+	tcase_add_test(tc_error, test_e01_null_filename);
+	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_error, test_e03_missing_filename);
+	tcase_add_test(tc_boundary, test_b01_smallest_mode);
+	tcase_add_test(tc_boundary, test_b02_largest_mode);
+	tcase_add_test(tc_special, test_s01_all_flags_enabled);
+	tcase_add_test(tc_special, test_s02_path_contains_non_dir);
+	tcase_add_test(tc_special, test_s03_no_change);
+	tcase_add_test(tc_special, test_s04_special_bits);
+	tcase_add_test(tc_special, test_s05_just_the_special_bits);
+	tcase_add_test(tc_special, test_s06_bit_field_ignores_invalid_bits);
 	suite_add_tcase(suite, tc_normal);
-	// suite_add_tcase(suite, tc_error);
-	// suite_add_tcase(suite, tc_boundary);
-	// suite_add_tcase(suite, tc_special);
+	suite_add_tcase(suite, tc_error);
+	suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
 
 	return suite;
 }

--- a/code/test/check_sfmw_set_mode.c
+++ b/code/test/check_sfmw_set_mode.c
@@ -1,0 +1,795 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_mode() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_mode.bin && \
+code/dist/check_sfmw_set_mode.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_mode.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+ *
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_set_mode.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_set_mode.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_set_mode.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_mode.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ *
+ */
+
+#include <check.h>						// START_TEST(), END_TEST
+#include <stdlib.h>
+// Local includes
+#include "devops_code.h"				// resolve_to_repo(), SKID_REPO_NAME
+#ifndef SKID_DEBUG
+#define SKID_DEBUG
+#endif  /* SKID_DEBUG */
+#include "skid_debug.h"     			// FPRINTF_ERR()
+#include "skid_file_metadata_read.h"	// get_group(), get_owner()
+#include "skid_file_metadata_write.h"	// set_mode()
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Common Mode Macros
+#define TEST_MODE_0444 SKID_MODE_OWNER_R | \
+                       SKID_MODE_GROUP_R | \
+                       SKID_MODE_OTHER_R
+#define TEST_MODE_0644 SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | \
+					   SKID_MODE_GROUP_R | \
+                       SKID_MODE_OTHER_R
+#define TEST_MODE_0754 SKID_MODE_OWNER_R | SKID_MODE_OWNER_W | SKID_MODE_OWNER_X | \
+                       SKID_MODE_GROUP_R | SKID_MODE_GROUP_W | \
+                       SKID_MODE_OTHER_R
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+// This struct defines details about test files to aid in test execution and teardown() recovery.
+typedef struct _cssmTestPathDetails
+{
+	char *pathname;    // Heap-allocated buffer containing the pathname resolved to the repo dir
+	mode_t orig_mode;  // The original mode
+} testPathDetails, *testPathDetails_ptr;
+
+testPathDetails_ptr test_dir_details;  // Heap-allocated struct containing test directory details
+testPathDetails_ptr test_file_details;  // Heap-allocated struct containing test filename details
+testPathDetails_ptr test_pipe_details;  // Heap-allocated struct containing test pipe details
+testPathDetails_ptr test_socket_details;  // Heap-allocated struct containing test socket details
+testPathDetails_ptr test_symlink_details;  // Heap-allocated struct with test symbolic link details
+
+/*
+ *	Reset the permissions of the test_*_details globals back to their original mode values.
+ */
+void reset_global_modes(void);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	Call set_mode(), get the new perms, and validate the results.  If pathname is a symbolic link,
+ *	provide the sym_link's target as target_name.  If target_name is NULL, it will be ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, mode_t test_mode, int exp_return);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Allocate memory for a testPathDetails struct and populate it.  Ignores ENOENT errors.
+ */
+testPathDetails_ptr setup_struct(const char *pathname);
+
+/*
+ *	Update new_struct with the new_struct->pathname's current mode.  Does not ignore errors
+ *	if must_succeed is true.  Always returns the error received.
+ */
+int setup_struct_mode(testPathDetails_ptr new_struct, bool must_succeed);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Free all allocate memory in the testPathDetails struct in a gently tolerant way.
+ */
+void teardown_struct(testPathDetails_ptr* old_struct);
+
+
+void reset_global_modes(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	// Array of the global pointers to iterate over
+	testPathDetails_ptr test_structs[] = {test_dir_details, test_file_details, test_pipe_details,
+										  test_socket_details, test_symlink_details};
+
+	// RESET PERMISSIONS
+	for (int i = 0; i < (sizeof(test_structs) / sizeof(test_structs[0])); i++)
+	{
+		if (test_structs[i])
+		{
+			// Reset mode
+			errnum = set_shell_perms(test_structs[i]->pathname, test_structs[i]->orig_mode);
+			if (EPERM == errnum)
+			{
+				FPRINTF_ERR("%s You may need to reset the owner of '%s' to %o\n",
+					        DEBUG_WARNG_STR, test_structs[i]->pathname, test_structs[i]->orig_mode);
+			}
+			else
+			{
+				ck_assert_msg(0 == errnum, "set_shell_perms(%s, %o) failed with [%d] %s",
+					          test_structs[i]->pathname, test_structs[i]->orig_mode,
+					          errnum, strerror(errnum));
+			}
+		}
+	}
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem((void **)&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, mode_t test_mode, int exp_return)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;                     // Errno values
+	int actual_ret = 0;                 // Return value of the tested function
+	mode_t new_mode = 0;                // Post-execution mode
+	const char *check_mode = pathname;  // Filename to verify pre/post-test permissions
+
+	// RUN IT
+	actual_ret = set_mode(pathname, test_mode);
+
+	// POST-TEST
+	// Compare actual results to expected results
+	ck_assert_msg(exp_return == actual_ret, "set_mode(%s, %o) returned [%d] '%s' "
+				  "instead of [%d] '%s", pathname, test_mode, actual_ret, strerror(actual_ret),
+				  exp_return, strerror(exp_return));
+	// No need to compare new_mode against test_mode if the expected result is "error"
+	if (0 == exp_return)
+	{
+		// Get the current permissions
+		new_mode = get_shell_file_perms(check_mode, &errnum);
+		ck_assert_msg(0 == errnum, "The second get_shell_file_perms(%s) errored with [%d] '%s'\n",
+					  check_mode, errnum, strerror(errnum));
+		// Compare actual permissions to the test_mode
+		ck_assert_msg(new_mode == test_mode,
+			          "set_mode(%s, %o) failed to set the mode (saw %o instead)\n",
+					  check_mode, test_mode, new_mode);
+	}
+
+	// DONE
+	return;
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                          // Errno values
+	char directory[] = { "./code/test/test_input/" };                 // Default test input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };      // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };      // Default test input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };  // Default test input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };      // Default test input: symlink
+
+	// SET IT UP
+	// Allocate structs
+	test_dir_details = setup_struct(directory);
+	test_pipe_details = setup_struct(named_pipe);
+	test_socket_details = setup_struct(raw_socket);
+	test_file_details = setup_struct(reg_file);
+	test_symlink_details = setup_struct(sym_link);
+	// Create files
+	if (test_pipe_details && test_pipe_details->pathname)
+	{
+		remove_a_file(test_pipe_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+		errnum = setup_struct_mode(test_pipe_details, true);
+		ck_assert_msg(0 == errnum, "setup_struct_owners(%s struct) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+	}
+	else
+	{
+		ck_abort_msg("The setup() test fixture did not make the named pipe");
+	}
+	// Raw Socket
+	if (test_socket_details && test_socket_details->pathname)
+	{
+		remove_a_file(test_socket_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+		errnum = setup_struct_mode(test_socket_details, true);
+		ck_assert_msg(0 == errnum, "setup_struct_owners(%s struct) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+	}
+	else
+	{
+		ck_abort_msg("The setup() test fixture did not make the socket");
+	}
+
+	// RESET OWNERSHIP
+	reset_global_modes();
+
+	// DONE
+	return;
+}
+
+
+testPathDetails_ptr setup_struct(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	char *temp_pathname = NULL;              // Holds the resolve_test_input() return value
+	testPathDetails_ptr temp_struct = NULL;  // Function return value
+
+	// SET IT UP
+	// pathname
+	temp_pathname = resolve_test_input(pathname);
+	// testPathDetails struct
+	temp_struct = alloc_devops_mem(1, sizeof(testPathDetails), &errnum);
+	ck_assert_msg(0 == errnum, "alloc_devops_mem(testPathDetails) failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(NULL != temp_struct,
+				  "alloc_devops_mem(testPathDetails) memory allocation failed");
+
+	// STORE IT
+	// pathname
+	if (!errnum)
+	{
+		temp_struct->pathname = temp_pathname;
+		errnum = setup_struct_mode(temp_struct, false);
+		if (ENOENT == errnum)
+		{
+			errnum = 0;  // Ignore "file/dir missing" errors
+		}
+		ck_assert_msg(0 == errnum, "setup_struct_mode(%s struct) failed with [%d] %s",
+					  temp_pathname, errnum, strerror(errnum));
+	}
+
+	// DONE
+	if (errnum && temp_struct)
+	{
+		teardown_struct(&temp_struct);  // Something failed so undo it
+	}
+	return temp_struct;
+}
+
+
+int setup_struct_mode(testPathDetails_ptr new_struct, bool must_succeed)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;              // Errno values
+	char *temp_pathname = NULL;  // Temp storage for new_struct->pathname
+
+	// INPUT VALIDATION
+	if (!new_struct)
+	{
+		errnum = EINVAL;  // NULL struct pointer
+	}
+	else
+	{
+		temp_pathname = new_struct->pathname;
+	}
+
+	// SETUP MODE
+	// orig_mode
+	if (!errnum)
+	{
+		new_struct->orig_mode = get_file_perms(temp_pathname, &errnum);
+		if (true == must_succeed)
+		{
+			ck_assert_msg(0 == errnum, "get_file_perms(%s) failed with [%d] %s",
+						  temp_pathname, errnum, strerror(errnum));
+		}
+	}
+
+	// DONE
+	return errnum;
+}
+
+
+void teardown(void)
+{
+	// RESET OWNERSHIP
+	reset_global_modes();
+
+	// CLEANUP
+	// Directory
+	teardown_struct(&test_dir_details);  // Ignore any errors
+	// File
+	teardown_struct(&test_file_details);  // Ignore any errors
+	// Pipe
+	remove_a_file(test_pipe_details->pathname, true);  // Best effort
+	teardown_struct(&test_pipe_details);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_details->pathname, true);  // Best effort
+	teardown_struct(&test_socket_details);  // Ignore any errors
+	// Symbolic Link
+	teardown_struct(&test_symlink_details);  // Ignore any errors
+}
+
+
+void teardown_struct(testPathDetails_ptr *old_struct)
+{
+	// LOCAL VARIABLES
+	int results = 0;                        // Check the results
+	testPathDetails_ptr struct_ptr = NULL;  // The actual struct pointer to free
+
+	// INPUT VALIDATION
+	if (old_struct)
+	{
+		struct_ptr = *old_struct;
+	}
+
+	// TEAR IT DOWN
+	if (struct_ptr)
+	{
+		// pathname
+		if (struct_ptr->pathname)
+		{
+			results = free_devops_mem((void **)&(struct_ptr->pathname));
+			ck_assert_msg(0 == results, "free_devops_mem(struct_ptr->pathname) failed with [%d] %s",
+						  results, strerror(results));
+		}
+		// The old struct
+		results = free_devops_mem((void **)old_struct);
+		ck_assert_msg(0 == results, "free_devops_mem(struct_ptr) failed with [%d] %s",
+					  results, strerror(results));
+	}
+}
+
+
+// /**************************************************************************************************/
+// /*************************************** NORMAL TEST CASES ****************************************/
+// /**************************************************************************************************/
+
+
+// START_TEST(test_n01_directory)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = get_new_gid();  // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_dir_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_n02_named_pipe)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = get_new_gid();  // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_pipe_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+	// New mode to use as test input
+	mode_t test_mode = TEST_MODE_0754;  // rwxrw-r--
+	int exp_return = 0;                 // Expected return value for this test input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, test_mode, exp_return);
+}
+END_TEST
+
+
+// START_TEST(test_n04_socket)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = get_new_gid();  // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_socket_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_n05_symbolic_link_follow)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = get_new_gid();  // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_symlink_details->pathname;
+// 	// Absolute path for actual_rel_path as resolved against the repo name
+// 	char *actual_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, actual_abs_path, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+// START_TEST(test_e01_null_filename)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = get_new_gid();  // Test case input
+// 	char *input_abs_path = NULL;    // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_e02_empty_filename)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                          // Test case input
+// 	uid_t new_uid = get_new_uid();               // Test case input
+// 	gid_t new_gid = get_new_gid();               // Test case input
+// 	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_e03_missing_filename)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                             // Test case input
+// 	uid_t new_uid = get_new_uid();                  // Test case input
+// 	gid_t new_gid = get_new_gid();                  // Test case input
+// 	char input_abs_path[] = { "/file/not/found" };  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+/**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
+
+
+// // Minimum GID for a system user (e.g., root, bin, sys)
+// START_TEST(test_b01_min_good_system_user_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 0;              // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Maximum GID for a system user (e.g., root, bin, sys)
+// START_TEST(test_b02_max_good_system_user_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 99;             // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Minimum GID for an application user (e.g., crontab, syslog, pulse)
+// START_TEST(test_b03_min_good_application_user_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 100;            // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Maximum GID for an application user (e.g., crontab, syslog, pulse)
+// START_TEST(test_b04_max_good_system_user_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 999;            // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Minimum GID for a regular user (see: useradd mumu)
+// START_TEST(test_b05_min_good_regular_user_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 1000;           // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Maximum GID for Debian: https://www.baeldung.com/linux/user-ids-reserved-values
+// START_TEST(test_b06_max_good_debian_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 59999;          // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Maximum GID for Solaris: https://docs.oracle.com/cd/E19455-01/805-7228/userconcept-35/index.html
+// START_TEST(test_b07_max_good_solaris_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 60000;          // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// // Maximum GID for Linux (see: grep ^GID_MAX /etc/login.defs)
+// START_TEST(test_b08_max_good_linux_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;             // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = 60000;          // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// /**************************************************************************************************/
+// /*************************************** SPECIAL TEST CASES ***************************************/
+// /**************************************************************************************************/
+
+
+// START_TEST(test_s01_symbolic_link_no_follow)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = false;            // Test case input
+// 	uid_t new_uid = get_new_uid();  // Test case input
+// 	gid_t new_gid = get_new_gid();  // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_symlink_details->pathname;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_s02_nobody_uid)
+// {
+// 	// LOCAL VARIABLES
+// 	int errnum = 0;                                         // Errno value
+// 	bool follow = true;                                     // Test case input
+// 	uid_t new_uid = get_shell_user_uid("nobody", &errnum);  // Test case input
+// 	gid_t new_gid = CSSO_SKIP_GID;                          // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// VALIDATE
+// 	ck_assert_msg(0 == errnum, "get_shell_user_uid() failed with [%d] %s",
+// 		          errnum, strerror(errnum));
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_s03_nogroup_gid)
+// {
+// 	// LOCAL VARIABLES
+// 	int errnum = 0;                                          // Errno value
+// 	bool follow = true;                                      // Test case input
+// 	uid_t new_uid = get_new_uid();                           // Test case input
+// 	gid_t new_gid = get_shell_user_gid("nobody", &errnum);  // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// VALIDATE
+// 	ck_assert_msg(0 == errnum, "get_shell_user_gid() failed with [%d] %s",
+// 		          errnum, strerror(errnum));
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+// START_TEST(test_s04_nobody_nogroup)
+// {
+// 	// LOCAL VARIABLES
+// 	int errnum = 0;      // Errno value
+// 	bool follow = true;  // Test case input
+// 	uid_t new_uid = 0;   // Test case input
+// 	gid_t new_gid = 0;   // Test case input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_details->pathname;
+
+// 	// SETUP
+// 	// UID
+// 	new_uid = get_shell_user_uid("nobody", &errnum);
+// 	ck_assert_msg(0 == errnum, "get_shell_user_uid() failed with [%d] %s",
+// 		          errnum, strerror(errnum));
+// 	// GID
+// 	new_gid = get_shell_user_gid("nobody", &errnum);
+// 	ck_assert_msg(0 == errnum, "get_shell_user_gid() failed with [%d] %s",
+// 		          errnum, strerror(errnum));
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+// }
+// END_TEST
+
+
+Suite *set_mode_suite(void)
+{
+	// LOCAL VARIABLES
+	Suite *suite = suite_create("SFMW_Set_Mode");  // Test suite
+	TCase *tc_normal = tcase_create("Normal");       // Normal test cases
+	// TCase *tc_error = tcase_create("Error");         // Error test cases
+	// TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases
+	// TCase *tc_special = tcase_create("Special");     // Special test cases
+
+	// SETUP TEST CASES
+	tcase_add_checked_fixture(tc_normal, setup, teardown);
+	// tcase_add_checked_fixture(tc_error, setup, teardown);
+	// tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	// tcase_add_checked_fixture(tc_special, setup, teardown);
+	// tcase_add_test(tc_normal, test_n01_directory);
+	// tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_test(tc_normal, test_n03_regular_file);
+	// tcase_add_test(tc_normal, test_n04_socket);
+	// tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
+	// tcase_add_test(tc_error, test_e01_null_filename);
+	// tcase_add_test(tc_error, test_e02_empty_filename);
+	// tcase_add_test(tc_error, test_e03_missing_filename);
+	// tcase_add_test(tc_boundary, test_b01_min_good_system_user_gid);
+	// tcase_add_test(tc_boundary, test_b02_max_good_system_user_gid);
+	// tcase_add_test(tc_boundary, test_b03_min_good_application_user_gid);
+	// tcase_add_test(tc_boundary, test_b04_max_good_system_user_gid);
+	// tcase_add_test(tc_boundary, test_b05_min_good_regular_user_gid);
+	// tcase_add_test(tc_boundary, test_b06_max_good_debian_gid);
+	// tcase_add_test(tc_boundary, test_b07_max_good_solaris_gid);
+	// tcase_add_test(tc_boundary, test_b08_max_good_linux_gid);
+	// tcase_add_test(tc_special, test_s01_symbolic_link_no_follow);
+	// tcase_add_test(tc_special, test_s02_nobody_uid);
+	// tcase_add_test(tc_special, test_s03_nogroup_gid);
+	// tcase_add_test(tc_special, test_s04_nobody_nogroup);
+	suite_add_tcase(suite, tc_normal);
+	// suite_add_tcase(suite, tc_error);
+	// suite_add_tcase(suite, tc_boundary);
+	// suite_add_tcase(suite, tc_special);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_mode.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = set_mode_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem((void **)&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_mtime.c
+++ b/code/test/check_sfmw_set_mtime.c
@@ -1,0 +1,728 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_mtime() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_mtime.bin
+code/dist/check_sfmw_set_mtime.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_mtime.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_set_mtime.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_set_mtime.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_set_mtime.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_mtime.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ */
+
+#include <check.h>                     // START_TEST(), END_TEST
+#include <limits.h>                    // PATH_MAX
+#include <stdio.h>                     // printf()
+#include <stdlib.h>
+#include <unistd.h>                    // get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"               // resolve_to_repo(), SKID_REPO_NAME
+#include "skid_file_metadata_read.h"   // get_mod_time()
+#include "skid_file_metadata_write.h"  // set_mtime()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
+#define MICRO_SEC_SLEEP (useconds_t)10000  // Give the file timestamp 0.01 second to update
+#define UTIME_NSEC_MIN 0l          // Minimum allowed value for tv_nsec (see: utimensat(2))
+#define UTIME_NSEC_MAX 999999999l  // Maximum allowed value for tv_nsec (see: utimensat(2))
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+
+char *test_dir_path;  // Heap array containing the absolute directory name resolved to the repo
+char *test_file_path;  // Heap array containing the absolute filename resolved to the repo
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+char *test_sym_link;  // Heap array with the absolute symbolic link filename resolved to the repo
+
+/*
+ *	Set the atime and mtime timestamps of the test_*_path globals to "now".
+ */
+void reset_global_timestamps(void);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	1. Gets the original time, 2. Calls the tested function, 3. Gets the new time.
+ *	Verifies: actual return == exp_ret, desired time == current time
+ *	If follow_sym is true and pathname is a symbolic link, checks the before and after timestamps
+ *	of target_name instead.  Otherwise, target_name is ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret,
+	               time_t new_sec, long new_nsec);
+
+/*
+ *	Resolve all the default test filenames to the repo and store the heap memory pointer in
+ *	the globals.  Also, set the timestamps to now.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Reset the timestamps for the remaining globals.
+ *	Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Compare the desired time vs current times to verify the timestamp was updated.
+ */
+void verify_time_update(const char *pathname, const char *time_adj,
+						time_t new_time, long new_time_nsec, time_t curr_time, long curr_time_nsec);
+
+
+void reset_global_timestamps(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	// Array of the global pointers to iterate over
+	char *test_paths[] = {test_dir_path, test_file_path, test_pipe_path,
+	                      test_socket_path, test_sym_link};
+
+	// RESET TIMES
+	for (int i = 0; i < (sizeof(test_paths) / sizeof(test_paths[0])); i++)
+	{
+		errnum = set_times_now(test_paths[i], false);
+		ck_assert_msg(0 == errnum, "set_times_now(%s) failed with [%d] %s", test_paths[i],
+			          errnum, strerror(errnum));
+	}
+
+	// DONE
+	return;
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret,
+	               time_t new_sec, long new_nsec)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;            // Errno values
+	time_t old_time = 0;                // Original time
+	long old_time_nsec = 0;             // Original time nanoseconds
+	time_t curr_time = 0;               // Current time
+	long curr_time_nsec = 0;            // Current time nanoseconds
+	const char *time_check = pathname;  // Filename to gather timestamps for
+
+	// CHECK IT
+	// Should we use target_name instead?
+	if (pathname && *pathname && true == follow_sym && true == is_sym_link(pathname, &errnum))
+	{
+		ck_assert_msg(0 == errnum, "is_sym_link(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+		time_check = target_name;
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+
+	// RUN IT
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 1. Get original time
+		errnum = get_mod_timestamp(time_check, &old_time, &old_time_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// 2. Call function
+	micro_sleep(MICRO_SEC_SLEEP);  // Wait before changing the timestamp
+	errnum = set_mtime(pathname, follow_sym, new_sec, new_nsec);
+	ck_assert_msg(exp_ret == errnum, "set_mtime(%s) returned [%d] '%s' instead of [%d] '%s'",
+				  pathname, errnum, strerror(errnum), exp_ret, strerror(exp_ret));
+	errnum = CANARY_INT;  // Reset temp variable
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 3. Get current time
+		errnum = get_mod_timestamp(time_check, &curr_time, &curr_time_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+
+		// VALIDATE RESULTS
+		verify_time_update(time_check, "modification", new_sec, new_nsec, curr_time, curr_time_nsec);
+	}
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                          // Errno values
+	char directory[] = { "./code/test/test_input/" };                 // Default test input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };      // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };      // Default test input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };  // Default test input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };      // Default test input: symlink
+
+	// SET IT UP
+	// Directory
+	test_dir_path = resolve_test_input(directory);
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Regular File
+	test_file_path = resolve_test_input(reg_file);
+	// Symbolic Link
+	test_sym_link = resolve_test_input(sym_link);
+
+	// RESET TIMESTAMPS
+	reset_global_timestamps();
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Directory
+	set_times_now(test_dir_path, false);  // Ignore any errors
+	free_devops_mem(&test_dir_path);  // Ignore any errors
+	// File
+	set_times_now(test_file_path, false);  // Ignore any errors
+	free_devops_mem(&test_file_path);  // Ignore any errors
+	// Pipe
+	remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+	// Symbolic Link
+	set_times_now(test_sym_link, false);  // Ignore any errors
+	free_devops_mem(&test_sym_link);  // Ignore any errors
+}
+
+
+void verify_time_update(const char *pathname, const char *time_adj,
+						time_t new_time, long new_time_nsec, time_t curr_time, long curr_time_nsec)
+{
+	// Compare times
+	if (new_time != curr_time)
+	{
+		ck_abort_msg("The %s time for %s was not updated: new sec %ld != curr sec %ld",
+					 time_adj, pathname, new_time, curr_time);
+	}
+	else if (new_time_nsec != curr_time_nsec)
+	{
+		ck_abort_msg("The %s nanoseconds for %s weren't updated: new nsec %ld != curr nsec %ld",
+					 time_adj, pathname, new_time_nsec, curr_time_nsec);
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = 0;           // Expected results
+	time_t new_sec = 0x600DC0DE;  // Seconds test input
+	long new_nsec = 0xD06F00D;    // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_dir_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	bool follow = true;         // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0xBAD71E;  // Seconds test input
+	long new_nsec = 0x347F00D;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	bool follow = true;         // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0xB00000;  // Seconds test input
+	long new_nsec = 0xC0010FF;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int exp_result = 0;       // Expected results
+	time_t new_sec = 0xD34D;  // Seconds test input
+	long new_nsec = 0xBEEF;   // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int exp_result = 0;       // Expected results
+	time_t new_sec = 0xFEED;  // Seconds test input
+	long new_nsec = 0xFACE;   // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_sym_link;
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = EINVAL;      // Expected results
+	time_t new_sec = 0x7E57;      // Seconds test input
+	long new_nsec = 0xC0DE;       // Nanoseconds test input
+	char *input_abs_path = NULL;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                          // Follow symlinks
+	int exp_result = EINVAL;                     // Expected results
+	time_t new_sec = 0x7E57;                     // Seconds test input
+	long new_nsec = 0xC0DE;                      // Nanoseconds test input
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_b01_sec_min_value)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MIN + 1;           // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b02_sec_almost_epoch)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = -1;                    // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b03_sec_epoch_time)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0;                     // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b04_sec_barely_past_epoch)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 1;                     // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b05_sec_static_now)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x66197EA4;            // Seconds test input: 4/12/2024, 1:34:12 PM
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b06_sec_max_value)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MAX;               // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b07_nsec_low_very_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = LONG_MIN;               // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b08_nsec_low_barely_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MIN - 1l;    // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b09_nsec_low_barely_good)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MIN;         // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b10_nsec_high_barely_good)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MAX;         // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b11_nsec_high_barely_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MAX + 1l;    // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b12_nsec_high_very_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = LONG_MAX;               // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_s01_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                                 // Follow symlinks
+	int exp_result = ENOENT;                            // Expected results
+	time_t new_sec = 0x7E57;                            // Seconds test input
+	long new_nsec = 0xC0DE;                             // Nanoseconds test input
+	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_s02_symbolic_link_nofollow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;        // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0x4B1D;    // Seconds test input
+	long new_nsec = 0xB16C0DE;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_sym_link;
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+ 
+
+START_TEST(test_s03_block_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                        // Follow symlinks
+	int exp_result = EPERM;                    // Expected results
+	time_t new_sec = 0x7E57;                   // Seconds test input
+	long new_nsec = 0xC0DE;                    // Nanoseconds test input
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_s04_character_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                       // Follow symlinks
+	int exp_result = EPERM;                   // Expected results
+	time_t new_sec = 0x7E57;                  // Seconds test input
+	long new_nsec = 0xC0DE;                   // Nanoseconds test input
+	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/*
+ *	NOTE: If the seconds are set to INT_MIN, the nanoseconds appear to always be set to 0.
+ */
+START_TEST(test_s05_sec_min_value_edge_case)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MIN;               // Seconds test input
+	long new_nsec = 0;                      // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+Suite *set_mtime_suite(void)
+{
+	// LOCAL VARIABLES
+	Suite *suite = suite_create("SFMW_Set_Mtime");  // Test suite
+	TCase *tc_normal = tcase_create("Normal");      // Normal test cases
+	TCase *tc_error = tcase_create("Error");        // Error test cases
+	TCase *tc_boundary = tcase_create("Boundary");  // Boundary test cases
+	TCase *tc_special = tcase_create("Special");    // Special test cases
+
+	// SETUP TEST CASES
+	tcase_add_checked_fixture(tc_normal, setup, teardown);
+	tcase_add_checked_fixture(tc_error, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_test(tc_normal, test_n01_directory);
+	tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_test(tc_normal, test_n03_regular_file);
+	tcase_add_test(tc_normal, test_n04_socket);
+	tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
+	tcase_add_test(tc_error, test_e01_null_filename);
+	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_boundary, test_b01_sec_min_value);
+	tcase_add_test(tc_boundary, test_b02_sec_almost_epoch);
+	tcase_add_test(tc_boundary, test_b03_sec_epoch_time);
+	tcase_add_test(tc_boundary, test_b04_sec_barely_past_epoch);
+	tcase_add_test(tc_boundary, test_b05_sec_static_now);
+	tcase_add_test(tc_boundary, test_b06_sec_max_value);
+	tcase_add_test(tc_boundary, test_b07_nsec_low_very_bad);
+	tcase_add_test(tc_boundary, test_b08_nsec_low_barely_bad);
+	tcase_add_test(tc_boundary, test_b09_nsec_low_barely_good);
+	tcase_add_test(tc_boundary, test_b10_nsec_high_barely_good);
+	tcase_add_test(tc_boundary, test_b11_nsec_high_barely_bad);
+	tcase_add_test(tc_boundary, test_b12_nsec_high_very_bad);
+	tcase_add_test(tc_special, test_s01_missing_filename);
+	tcase_add_test(tc_special, test_s02_symbolic_link_nofollow);
+	tcase_add_test(tc_special, test_s03_block_device);
+	tcase_add_test(tc_special, test_s04_character_device);
+	tcase_add_test(tc_special, test_s05_sec_min_value_edge_case);
+	suite_add_tcase(suite, tc_normal);
+	suite_add_tcase(suite, tc_error);
+	suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_mtime.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;         // Number of test failures
+	Suite *suite = NULL;           // Test suite
+	SRunner *suite_runner = NULL;  // Test suite runner
+
+	// SETUP
+	suite = set_mtime_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_mtime.c
+++ b/code/test/check_sfmw_set_mtime.c
@@ -124,7 +124,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -231,19 +231,19 @@ void teardown(void)
 {
 	// Directory
 	set_times_now(test_dir_path, false);  // Ignore any errors
-	free_devops_mem(&test_dir_path);  // Ignore any errors
+	free_devops_mem((void **)&test_dir_path);  // Ignore any errors
 	// File
 	set_times_now(test_file_path, false);  // Ignore any errors
-	free_devops_mem(&test_file_path);  // Ignore any errors
+	free_devops_mem((void **)&test_file_path);  // Ignore any errors
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 	// Symbolic Link
 	set_times_now(test_sym_link, false);  // Ignore any errors
-	free_devops_mem(&test_sym_link);  // Ignore any errors
+	free_devops_mem((void **)&test_sym_link);  // Ignore any errors
 }
 
 
@@ -721,7 +721,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmw_set_mtime_now.c
+++ b/code/test/check_sfmw_set_mtime_now.c
@@ -83,7 +83,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -178,10 +178,10 @@ void teardown(void)
 {
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 }
 
 
@@ -219,7 +219,7 @@ START_TEST(test_n01_directory)
 	run_test_case(input_abs_path, NULL, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -250,7 +250,7 @@ START_TEST(test_n03_regular_file)
 	run_test_case(input_abs_path, NULL, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -283,8 +283,8 @@ START_TEST(test_n05_symbolic_link_follow)
 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -348,8 +348,8 @@ START_TEST(test_s02_symbolic_link_nofollow)
 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
  
@@ -430,7 +430,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmw_set_mtime_now.c
+++ b/code/test/check_sfmw_set_mtime_now.c
@@ -1,0 +1,437 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_mtime_now() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_mtime_now.bin
+code/dist/check_sfmw_set_mtime_now.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_mtime_now.bin
+
+ *
+ */
+
+#include <check.h>                     // START_TEST(), END_TEST
+#include <limits.h>                    // PATH_MAX
+#include <stdio.h>                     // printf()
+#include <stdlib.h>
+#include <unistd.h>                    // get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"               // resolve_to_repo(), SKID_REPO_NAME
+#include "skid_file_metadata_read.h"   // get_access_time()
+#include "skid_file_metadata_write.h"  // set_mtime_now()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
+#define MICRO_SEC_SLEEP (useconds_t)10000  // Give the file timestamp 0.01 second to update
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	1. Gets the original time, 2. Calls the tested function, 3. Gets the new time.
+ *	Verifies: actual return == exp_ret, original time < new time (special cases
+ *	original time <= new time for directories because of "filesystem relatime flag").
+ *	If follow_sym is true and pathname is a symbolic link, checks the before and after timestamps
+ *	of target_name instead.  Otherwise, target_name is ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Compare the old vs new times to verify the timestamp was updated.
+ */
+void verify_time_update(const char *pathname, const char *time_adj,
+	                    time_t old_time, long old_time_nsec, time_t new_time, long new_time_nsec);
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;            // Errno values
+	time_t old_time = 0;                // Original time
+	long old_time_nsec = 0;             // Original time nanoseconds
+	time_t new_time = 0;                // New time
+	long new_time_nsec = 0;             // New time nanoseconds
+	const char *time_check = pathname;  // Filename to gather timestamps for
+
+	// CHECK IT
+	// Should we use target_name instead?
+	if (pathname && *pathname && true == follow_sym && true == is_sym_link(pathname, &errnum))
+	{
+		ck_assert_msg(0 == errnum, "is_sym_link(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+		time_check = target_name;
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+
+	// RUN IT
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 1. Get original time
+		errnum = get_mod_timestamp(time_check, &old_time, &old_time_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// 2. Call function
+	micro_sleep(MICRO_SEC_SLEEP);  // Wait before changing the timestamp
+	errnum = set_mtime_now(pathname, follow_sym);
+	ck_assert_msg(exp_ret == errnum, "set_mtime_now(%s) returned [%d] '%s' instead of [%d] '%s",
+		          pathname, errnum, strerror(errnum), exp_ret, strerror(exp_ret));
+	errnum = CANARY_INT;  // Reset temp variable
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 3. Get current time
+		errnum = get_mod_timestamp(time_check, &new_time, &new_time_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+
+		// VALIDATE RESULTS
+		verify_time_update(time_check, "modification", old_time, old_time_nsec,
+			               new_time, new_time_nsec);
+	}
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                      // Errno values
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };  // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };  // Default test input: socket
+
+	// SET IT UP
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Pipe
+	remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+}
+
+
+void verify_time_update(const char *pathname, const char *time_adj,
+	                    time_t old_time, long old_time_nsec, time_t new_time, long new_time_nsec)
+{
+	// Compare times
+	if (old_time > new_time)
+	{
+		ck_abort_msg("The %s time for %s was not updated: old sec %ld > new sec %ld",
+		             time_adj, pathname, old_time, new_time);
+	}
+	else if (old_time == new_time && old_time_nsec >= new_time_nsec)
+	{
+		ck_abort_msg("The %s nanoseconds for %s weren't updated: old nsec %ld >= new nsec %ld",
+		             time_adj, pathname, old_time_nsec, new_time_nsec);
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/");
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = EINVAL;      // Expected results
+	char *input_abs_path = NULL;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                          // Follow symlinks
+	int exp_result = EINVAL;                     // Expected results
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_s01_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                                 // Follow symlinks
+	int exp_result = ENOENT;                            // Expected results
+	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_s02_symbolic_link_nofollow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;  // Follow symlinks
+	int exp_result = 0;   // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
+}
+END_TEST
+ 
+
+START_TEST(test_s03_block_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                        // Follow symlinks
+	int exp_result = EPERM;                    // Expected results
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_s04_character_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                       // Follow symlinks
+	int exp_result = EPERM;                   // Expected results
+	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+Suite *set_mtime_now_suite(void)
+{
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
+
+	suite = suite_create("SFMW_Set_Mtime_Now");
+
+	/* Core test case */
+	tc_core = tcase_create("Core");
+	tcase_add_checked_fixture(tc_core, setup, teardown);
+	tcase_add_test(tc_core, test_n01_directory);
+	tcase_add_test(tc_core, test_n02_named_pipe);
+	tcase_add_test(tc_core, test_n03_regular_file);
+	tcase_add_test(tc_core, test_n04_socket);
+	tcase_add_test(tc_core, test_n05_symbolic_link_follow);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	tcase_add_test(tc_core, test_s02_symbolic_link_nofollow);
+	tcase_add_test(tc_core, test_s03_block_device);
+	tcase_add_test(tc_core, test_s04_character_device);
+	suite_add_tcase(suite, tc_core);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_mtime_now.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = set_mtime_now_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_ownership.c
+++ b/code/test/check_sfmw_set_ownership.c
@@ -1,0 +1,827 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_ownership() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_ownership.bin
+code/dist/check_sfmw_set_ownership.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_ownership.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+ *
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_set_ownership.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_set_ownership.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_set_ownership.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_ownership.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ *
+ */
+
+#include <check.h>						// START_TEST(), END_TEST
+#include <limits.h>						// PATH_MAX
+#include <stdio.h>						// printf()
+#include <stdlib.h>
+#include <unistd.h>						// get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"				// resolve_to_repo(), SKID_REPO_NAME
+#ifndef SKID_DEBUG
+#define SKID_DEBUG
+#endif  /* SKID_DEBUG */
+#include "skid_debug.h"     			// FPRINTF_ERR()
+#include "skid_file_metadata_read.h"	// get_access_time()
+#include "skid_file_metadata_write.h"	// set_ownership()
+
+
+/**************************************************************************************************/
+/******* DEFINE THESE CSSO_DEF_?ID MACROS TO OVERRIDE DEFAULT IDS USED IN THESE TEST CASES ********/
+/**************************************************************************************************/
+// GENERAL UNIT TEST NOTE: These unit tests will default to "id -u" for the UID and attempt to
+//	programmatically determine a compatible GID (see: "grep `whoami` /etc/group")
+// UID PRO TIP: Take care if you choose a UID other than "id -u" because you'll need to enable
+//	the CAP_CHOWN capability (see: capabilities(7)) or elevate privileges.
+// #define CSSO_DEF_UID 1234          // Check skid_file_metadata_write default owner ID
+// GID PRO TIP: If you choose a GID, choose an ID for a group in grep `whoami` /etc/group
+// #define CSSO_DEF_GID CSSO_DEF_UID  // Check skid_file_metadata_write default group ID
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+// This struct defines details about test files to aid in test execution and teardown() recovery.
+typedef struct _testPathDetails
+{
+	char *pathname;    // Heap-allocated buffer containing the pathname resolved to the repo dir
+	uid_t orig_owner;  // The original owner's UID
+	gid_t orig_group;  // The original group's GID
+} testPathDetails, *testPathDetails_ptr;
+
+testPathDetails_ptr test_dir_details;  // Heap-allocated struct containing test directory details
+testPathDetails_ptr test_file_details;  // Heap-allocated struct containing test filename details
+testPathDetails_ptr test_pipe_details;  // Heap-allocated struct containing test pipe details
+testPathDetails_ptr test_socket_details;  // Heap-allocated struct containing test socket details
+testPathDetails_ptr test_symlink_details;  // Heap-allocated struct with test symbolic link details
+
+/*
+ *	Set the ownership, UID and GID, of the test_*_details globals as specified.  If take_over is
+ *	true, this function will ignore the struct's UIDs/GIDs and use the UID/GID of the owning
+ *	process, by using get_shell_my_uid() and get_shell_my_gid() respectively, instead.
+ */
+void reset_global_ownership(bool take_over);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	
+ */
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym,
+				   uid_t new_uid, gid_t new_gid);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Allocate memory for a testPathDetails struct and populate it.
+ */
+testPathDetails_ptr setup_struct(const char *pathname);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Free all allocate memory in the testPathDetails struct in a gently tolerant way.
+ */
+void teardown_struct(testPathDetails_ptr* old_struct);
+
+
+void reset_global_ownership(bool take_over)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	uid_t tmp_uid = 0;		  // Temporary UID variable
+	gid_t tmp_gid = 0;		  // Temporary GID variable
+	bool follow_sym = false;  // No need because we'll also be resetting the file it points to
+	// Array of the global pointers to iterate over
+	testPathDetails_ptr test_structs[] = {test_dir_details, test_file_details, test_pipe_details,
+										  test_socket_details, test_symlink_details};
+
+	// SETUP
+	if (true == take_over)
+	{
+		// Get UID
+		tmp_uid = get_shell_my_uid(&errnum);
+		ck_assert_msg(0 == errnum, "get_shell_my_uid() failed with [%d] %s",
+					  errnum, strerror(errnum));
+		// Get GID
+		tmp_gid = get_shell_my_gid(&errnum);
+		ck_assert_msg(0 == errnum, "get_shell_my_gid() failed with [%d] %s",
+					  errnum, strerror(errnum));
+	}
+
+	// RESET OWNERSHIP
+	for (int i = 0; i < (sizeof(test_structs) / sizeof(test_structs[0])); i++)
+	{
+		if (test_structs[i])
+		{
+			if (false == take_over)
+			{
+				tmp_uid = test_structs[i]->orig_owner;
+				tmp_gid = test_structs[i]->orig_group;
+			}
+			// Reset owner
+			errnum = set_owner_id(test_structs[i]->pathname, tmp_uid, follow_sym);
+			if (EPERM == errnum)
+			{
+				FPRINTF_ERR("%s You may need to reset the owner of '%s' to %u\n",
+					        DEBUG_WARNG_STR, test_structs[i]->pathname, tmp_uid);
+			}
+			else
+			{
+				ck_assert_msg(0 == errnum, "set_owner_id(%s, %u) failed with [%d] %s",
+					          test_structs[i]->pathname, tmp_uid, errnum, strerror(errnum));
+			}
+			// Reset group
+			errnum = set_group_id(test_structs[i]->pathname, tmp_gid, follow_sym);
+			if (EPERM == errnum)
+			{
+				FPRINTF_ERR("%s You may need to reset the group of '%s' to %u\n",
+					        DEBUG_WARNG_STR, test_structs[i]->pathname, tmp_gid);
+			}
+			else
+			{
+				ck_assert_msg(0 == errnum, "set_group_id(%s, %u) failed with [%d] %s",
+					          test_structs[i]->pathname, tmp_gid, errnum, strerror(errnum));
+			}
+		}
+	}
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem((void **)&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym,
+				   uid_t new_uid, gid_t new_gid)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;          // Errno values
+	// uid_t old_uid = 0;                // Original UID
+	// gid_t old_gid = 0;                // Original GID
+	// uid_t curr_uid = 0;               // Current UID
+	// gid_t curr_gid = 0;               // Current GID
+	// const char *id_check = pathname;  // Filename to check *IDs for
+
+	// CHECK IT
+	// Should we use target_name instead?
+	if (pathname && *pathname && true == follow_sym)
+	{
+		if (true == is_sym_link(pathname, &errnum))
+		{
+			// id_check = target_name;
+		}
+		else
+		{
+			ck_assert_msg(0 == errnum, "is_sym_link(%s) failed with [%d] %s",
+						  pathname, errnum, strerror(errnum));
+		}
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+
+	// RUN IT
+
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                          // Errno values
+	char directory[] = { "./code/test/test_input/" };                 // Default test input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };      // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };      // Default test input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };  // Default test input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };      // Default test input: symlink
+
+	// SET IT UP
+	// Allocate structs
+	test_dir_details = setup_struct(directory);
+	test_pipe_details = setup_struct(named_pipe);
+	test_socket_details = setup_struct(raw_socket);
+	test_file_details = setup_struct(reg_file);
+	test_symlink_details = setup_struct(sym_link);
+	// Create files
+	if (test_pipe_details && test_pipe_details->pathname)
+	{
+		remove_a_file(test_pipe_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s",
+					  test_pipe_details->pathname, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Raw Socket
+	if (test_socket_details && test_socket_details->pathname)
+	{
+		remove_a_file(test_socket_details->pathname, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_details->pathname);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s",
+					  test_socket_details->pathname, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+
+	// RESET OWNERSHIP
+	reset_global_ownership(true);
+
+	// DONE
+	return;
+}
+
+
+testPathDetails_ptr setup_struct(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	char *temp_pathname = NULL;              // Holds the resolve_test_input() return value
+	testPathDetails_ptr temp_struct = NULL;  // Function return value
+
+	// SET IT UP
+	// pathname
+	temp_pathname = resolve_test_input(pathname);
+	// testPathDetails struct
+	temp_struct = alloc_devops_mem(1, sizeof(testPathDetails), &errnum);
+	ck_assert_msg(0 == errnum, "alloc_devops_mem(testPathDetails) failed with [%d] %s",
+				  errnum, strerror(errnum));
+	ck_assert_msg(NULL != temp_struct,
+				  "alloc_devops_mem(testPathDetails) memory allocation failed");
+
+	// STORE IT
+	// pathname
+	if (!errnum)
+	{
+		temp_struct->pathname = temp_pathname;
+	}
+	// orig_owner
+	if (!errnum)
+	{
+		temp_struct->orig_owner = get_owner(temp_pathname, &errnum);
+		ck_assert_msg(0 == errnum, "get_owner(%s) failed with [%d] %s",
+					  temp_pathname, errnum, strerror(errnum));
+	}
+	// orig_group
+	if (!errnum)
+	{
+		temp_struct->orig_group = get_group(temp_pathname, &errnum);
+		ck_assert_msg(0 == errnum, "get_group(%s) failed with [%d] %s",
+					  temp_pathname, errnum, strerror(errnum));
+	}
+
+	// DONE
+	if (errnum && temp_struct)
+	{
+		teardown_struct(&temp_struct);  // Something failed so undo it
+	}
+	return temp_struct;
+}
+
+
+void teardown(void)
+{
+	// Directory
+	teardown_struct(&test_dir_details);  // Ignore any errors
+	// File
+	teardown_struct(&test_file_details);  // Ignore any errors
+	// Pipe
+	teardown_struct(&test_pipe_details);  // Ignore any errors
+	// Socket
+	teardown_struct(&test_socket_details);  // Ignore any errors
+	// Symbolic Link
+	teardown_struct(&test_symlink_details);  // Ignore any errors
+}
+
+
+void teardown_struct(testPathDetails_ptr* old_struct)
+{
+	// LOCAL VARIABLES
+	int results = 0;                        // Check the results
+	testPathDetails_ptr struct_ptr = NULL;  // The actual struct pointer to free
+
+	// INPUT VALIDATION
+	if (old_struct)
+	{
+		struct_ptr = *old_struct;
+	}
+
+	// TEAR IT DOWN
+	if (struct_ptr)
+	{
+		// pathname
+		if (struct_ptr->pathname)
+		{
+			results = free_devops_mem((void **)&(struct_ptr->pathname));
+			ck_assert_msg(0 == results, "free_devops_mem(struct_ptr->pathname) failed with [%d] %s",
+						  results, strerror(results));
+		}
+		// The old struct
+		results = free_devops_mem((void **)old_struct);
+		ck_assert_msg(0 == results, "free_devops_mem(struct_ptr) failed with [%d] %s",
+					  results, strerror(results));
+	}
+}
+
+
+// /**************************************************************************************************/
+// /*************************************** NORMAL TEST CASES ****************************************/
+// /**************************************************************************************************/
+
+
+// START_TEST(test_n01_directory)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;           // Follow symlinks
+// 	int exp_result = 0;           // Expected results
+// 	time_t new_sec = 0x600DC0DE;  // Seconds test input
+// 	long new_nsec = 0xD06F00D;    // Nanoseconds test input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_dir_path;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_n02_named_pipe)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;         // Follow symlinks
+// 	int exp_result = 0;         // Expected results
+// 	time_t new_sec = 0xBAD71E;  // Seconds test input
+// 	long new_nsec = 0x347F00D;  // Nanoseconds test input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_pipe_path;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_n03_regular_file)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;         // Follow symlinks
+// 	int exp_result = 0;         // Expected results
+// 	time_t new_sec = 0xB00000;  // Seconds test input
+// 	long new_nsec = 0xC0010FF;  // Nanoseconds test input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_file_path;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_n04_socket)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;       // Follow symlinks
+// 	int exp_result = 0;       // Expected results
+// 	time_t new_sec = 0xD34D;  // Seconds test input
+// 	long new_nsec = 0xBEEF;   // Nanoseconds test input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_socket_path;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_n05_symbolic_link_follow)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;       // Follow symlinks
+// 	int exp_result = 0;       // Expected results
+// 	time_t new_sec = 0xFEED;  // Seconds test input
+// 	long new_nsec = 0xFACE;   // Nanoseconds test input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_sym_link;
+// 	// Absolute path for actual_rel_path as resolved against the repo name
+// 	char *actual_abs_path = test_file_path;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// /**************************************************************************************************/
+// /**************************************** ERROR TEST CASES ****************************************/
+// /**************************************************************************************************/
+// START_TEST(test_e01_null_filename)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;           // Follow symlinks
+// 	int exp_result = EINVAL;      // Expected results
+// 	time_t new_sec = 0x7E57;      // Seconds test input
+// 	long new_nsec = 0xC0DE;       // Nanoseconds test input
+// 	char *input_abs_path = NULL;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_e02_empty_filename)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                          // Follow symlinks
+// 	int exp_result = EINVAL;                     // Expected results
+// 	time_t new_sec = 0x7E57;                     // Seconds test input
+// 	long new_nsec = 0xC0DE;                      // Nanoseconds test input
+// 	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// /**************************************************************************************************/
+// /************************************** BOUNDARY TEST CASES ***************************************/
+// /**************************************************************************************************/
+// START_TEST(test_b01_sec_min_value)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = INT_MIN + 1;           // Seconds test input
+// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b02_sec_almost_epoch)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = -1;                    // Seconds test input
+// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b03_sec_epoch_time)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = 0;                     // Seconds test input
+// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b04_sec_barely_past_epoch)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = 1;                     // Seconds test input
+// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b05_sec_static_now)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = 0x66197EA4;            // Secs test input: 4/12/2024, 1:34:12 PM (1712946852)
+// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b06_sec_max_value)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = INT_MAX;               // Seconds test input
+// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b07_nsec_low_very_bad)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = EINVAL;                // Expected results
+// 	time_t new_sec = 0x7E57;                // Seconds test input
+// 	long new_nsec = LONG_MIN;               // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b08_nsec_low_barely_bad)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = EINVAL;                // Expected results
+// 	time_t new_sec = 0x7E57;                // Seconds test input
+// 	long new_nsec = UTIME_NSEC_MIN - 1l;    // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b09_nsec_low_barely_good)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = 0x7E57;                // Seconds test input
+// 	long new_nsec = UTIME_NSEC_MIN;         // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b10_nsec_high_barely_good)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = 0x7E57;                // Seconds test input
+// 	long new_nsec = UTIME_NSEC_MAX;         // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b11_nsec_high_barely_bad)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = EINVAL;                // Expected results
+// 	time_t new_sec = 0x7E57;                // Seconds test input
+// 	long new_nsec = UTIME_NSEC_MAX + 1l;    // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_b12_nsec_high_very_bad)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = EINVAL;                // Expected results
+// 	time_t new_sec = 0x7E57;                // Seconds test input
+// 	long new_nsec = LONG_MAX;               // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// /**************************************************************************************************/
+// /*************************************** SPECIAL TEST CASES ***************************************/
+// /**************************************************************************************************/
+// START_TEST(test_s01_missing_filename)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                                 // Follow symlinks
+// 	int exp_result = ENOENT;                            // Expected results
+// 	time_t new_sec = 0x7E57;                            // Seconds test input
+// 	long new_nsec = 0xC0DE;                             // Nanoseconds test input
+// 	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_s02_symbolic_link_nofollow)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = false;        // Follow symlinks
+// 	int exp_result = 0;         // Expected results
+// 	time_t new_sec = 0x4B1D;    // Seconds test input
+// 	long new_nsec = 0xB16C0DE;  // Nanoseconds test input
+// 	// Absolute path for test input as resolved against the repo name
+// 	char *input_abs_path = test_sym_link;
+// 	// Absolute path for actual_rel_path as resolved against the repo name
+// 	char *actual_abs_path = test_file_path;
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+ 
+
+// START_TEST(test_s03_block_device)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                        // Follow symlinks
+// 	int exp_result = EPERM;                    // Expected results
+// 	time_t new_sec = 0x7E57;                   // Seconds test input
+// 	long new_nsec = 0xC0DE;                    // Nanoseconds test input
+// 	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// START_TEST(test_s04_character_device)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                       // Follow symlinks
+// 	int exp_result = EPERM;                   // Expected results
+// 	time_t new_sec = 0x7E57;                  // Seconds test input
+// 	long new_nsec = 0xC0DE;                   // Nanoseconds test input
+// 	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// /*
+//  *	NOTE: If the seconds are set to INT_MIN, the nanoseconds appear to always be set to 0.
+//  */
+// START_TEST(test_s05_sec_min_value_edge_case)
+// {
+// 	// LOCAL VARIABLES
+// 	bool follow = true;                     // Follow symlinks
+// 	int exp_result = 0;                     // Expected results
+// 	time_t new_sec = INT_MIN;               // Seconds test input
+// 	long new_nsec = 0;                      // Nanoseconds test input
+// 	char *input_abs_path = test_file_path;  // Test case input
+
+// 	// RUN TEST
+// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+// }
+// END_TEST
+
+
+// Suite *set_ownership_suite(void)
+// {
+// 	// LOCAL VARIABLES
+// 	Suite *suite = suite_create("SFMW_Set_Ttimes");  // Test suite
+// 	TCase *tc_normal = tcase_create("Normal");       // Normal test cases
+// 	TCase *tc_error = tcase_create("Error");         // Error test cases
+// 	TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases
+// 	TCase *tc_special = tcase_create("Special");     // Special test cases
+
+// 	// SETUP TEST CASES
+// 	tcase_add_checked_fixture(tc_normal, setup, teardown);
+// 	tcase_add_checked_fixture(tc_error, setup, teardown);
+// 	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+// 	tcase_add_checked_fixture(tc_special, setup, teardown);
+// 	tcase_add_test(tc_normal, test_n01_directory);
+// 	tcase_add_test(tc_normal, test_n02_named_pipe);
+// 	tcase_add_test(tc_normal, test_n03_regular_file);
+// 	tcase_add_test(tc_normal, test_n04_socket);
+// 	tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
+// 	tcase_add_test(tc_error, test_e01_null_filename);
+// 	tcase_add_test(tc_error, test_e02_empty_filename);
+// 	tcase_add_test(tc_boundary, test_b01_sec_min_value);
+// 	tcase_add_test(tc_boundary, test_b02_sec_almost_epoch);
+// 	tcase_add_test(tc_boundary, test_b03_sec_epoch_time);
+// 	tcase_add_test(tc_boundary, test_b04_sec_barely_past_epoch);
+// 	tcase_add_test(tc_boundary, test_b05_sec_static_now);
+// 	tcase_add_test(tc_boundary, test_b06_sec_max_value);
+// 	tcase_add_test(tc_boundary, test_b07_nsec_low_very_bad);
+// 	tcase_add_test(tc_boundary, test_b08_nsec_low_barely_bad);
+// 	tcase_add_test(tc_boundary, test_b09_nsec_low_barely_good);
+// 	tcase_add_test(tc_boundary, test_b10_nsec_high_barely_good);
+// 	tcase_add_test(tc_boundary, test_b11_nsec_high_barely_bad);
+// 	tcase_add_test(tc_boundary, test_b12_nsec_high_very_bad);
+// 	tcase_add_test(tc_special, test_s01_missing_filename);
+// 	tcase_add_test(tc_special, test_s02_symbolic_link_nofollow);
+// 	tcase_add_test(tc_special, test_s03_block_device);
+// 	tcase_add_test(tc_special, test_s04_character_device);
+// 	tcase_add_test(tc_special, test_s05_sec_min_value_edge_case);
+// 	suite_add_tcase(suite, tc_normal);
+// 	suite_add_tcase(suite, tc_error);
+// 	suite_add_tcase(suite, tc_boundary);
+// 	suite_add_tcase(suite, tc_special);
+
+// 	return suite;
+// }
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_ownership.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	// Suite *suite = NULL;
+	// SRunner *suite_runner = NULL;
+
+	// // SETUP
+	// suite = set_ownership_suite();
+	// suite_runner = srunner_create(suite);
+	// srunner_set_log(suite_runner, log_abs_path);
+
+	// // RUN IT
+	// srunner_run_all(suite_runner, CK_NORMAL);
+	// number_failed = srunner_ntests_failed(suite_runner);
+
+	// // CLEANUP
+	// srunner_free(suite_runner);
+	free_devops_mem((void **)&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_ownership.c
+++ b/code/test/check_sfmw_set_ownership.c
@@ -356,7 +356,6 @@ void reset_global_ownership(bool take_over)
 				tmp_uid = test_structs[i]->orig_owner;
 				tmp_gid = test_structs[i]->orig_group;
 			}
-			FPRINTF_ERR("reset_global_ownership() IS SETTING %s OWNERSHIP TO UID %u AND GID %u\n", test_structs[i]->pathname, tmp_uid, tmp_gid);  // DEBUGGING
 			// Reset owner
 			errnum = set_owner_id(test_structs[i]->pathname, tmp_uid, follow_sym);
 			if (EPERM == errnum)
@@ -465,8 +464,6 @@ void run_test_case(const char *pathname, const char *target_name, bool follow_sy
 	{
 		compare_ownership(id_check, exp_uid, exp_gid, follow_sym);
 	}
-	FPRINTF_ERR("set_ownership(%s, %u, %u) returned [%d] '%s'",
-		        pathname, new_uid, new_gid, actual_ret, strerror(actual_ret));  // DEBUGGING
 
 	// DONE
 	return;

--- a/code/test/check_sfmw_set_ownership.c
+++ b/code/test/check_sfmw_set_ownership.c
@@ -38,7 +38,7 @@ export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_ownership.bin; unset 
 //	programmatically determine a compatible GID (see: "grep `whoami` /etc/group")
 // UID PRO TIP: Take care if you choose a UID other than "id -u" because you'll need to enable
 //	the CAP_CHOWN capability (see: capabilities(7)) or elevate privileges.
-#define CSSO_DEF_UID 1234          // Check skid_file_metadata_write default owner ID
+// #define CSSO_DEF_UID 1234          // Check skid_file_metadata_write default owner ID
 // GID PRO TIP: If you choose a GID, choose an ID for a group in grep `whoami` /etc/group
 // #define CSSO_DEF_GID CSSO_DEF_UID  // Check skid_file_metadata_write default group ID
 

--- a/code/test/check_sfmw_set_ownership.c
+++ b/code/test/check_sfmw_set_ownership.c
@@ -232,6 +232,10 @@ int determine_exp_return(const char *pathname, uid_t exp_uid, gid_t exp_gid)
 	{
 		exp_return = EINVAL;
 	}
+	else if (false == is_path_there(pathname))
+	{
+		exp_return = ENOENT;
+	}
 	else if (0 != my_uid)
 	{
 		path_owner = get_owner(pathname, &errnum);
@@ -418,7 +422,7 @@ void run_test_case(const char *pathname, const char *target_name, bool follow_sy
 
 	// SETUP
 	// Should we use target_name instead?
-	if (pathname && *pathname)
+	if (pathname && *pathname && true == is_path_there(pathname))
 	{
 		if (true == follow_sym)
 		{
@@ -745,6 +749,8 @@ END_TEST
 /**************************************************************************************************/
 /**************************************** ERROR TEST CASES ****************************************/
 /**************************************************************************************************/
+
+
 START_TEST(test_e01_null_filename)
 {
 	// LOCAL VARIABLES
@@ -766,6 +772,20 @@ START_TEST(test_e02_empty_filename)
 	uid_t new_uid = CSSO_SKIP_UID;               // Test case input
 	gid_t new_gid = get_new_gid();               // Test case input
 	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
+
+
+START_TEST(test_e03_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;                  // Test case input
+	gid_t new_gid = get_new_gid();                  // Test case input
+	char input_abs_path[] = { "/file/not/found" };  // Test case input
 
 	// RUN TEST
 	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
@@ -1061,6 +1081,7 @@ Suite *set_ownership_suite(void)
 	tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
 	tcase_add_test(tc_error, test_e01_null_filename);
 	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_error, test_e03_missing_filename);
 	// tcase_add_test(tc_boundary, test_b01_sec_min_value);
 	// tcase_add_test(tc_boundary, test_b02_sec_almost_epoch);
 	// tcase_add_test(tc_boundary, test_b03_sec_epoch_time);

--- a/code/test/check_sfmw_set_ownership.c
+++ b/code/test/check_sfmw_set_ownership.c
@@ -105,7 +105,8 @@ void reset_global_ownership(bool take_over);
 char *resolve_test_input(const char *pathname);
 
 /*
- *	
+ *	Gently validate the test input, determine the expected result, run the test case, and validate
+ *	the results.
  */
 void run_test_case(const char *pathname, const char *target_name, bool follow_sym,
 				   uid_t new_uid, gid_t new_gid);
@@ -416,8 +417,6 @@ void run_test_case(const char *pathname, const char *target_name, bool follow_sy
 	int exp_return = 0;               // Expected return value for this test input
 	uid_t exp_uid = new_uid;          // Expected UID
 	gid_t exp_gid = new_gid;          // Expected GID
-	// uid_t curr_uid = 0;               // Current UID
-	// gid_t curr_gid = 0;               // Current GID
 	const char *id_check = pathname;  // Filename to check *IDs for
 
 	// SETUP
@@ -793,271 +792,223 @@ START_TEST(test_e03_missing_filename)
 END_TEST
 
 
-// /**************************************************************************************************/
-// /************************************** BOUNDARY TEST CASES ***************************************/
-// /**************************************************************************************************/
-// START_TEST(test_b01_sec_min_value)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = INT_MIN + 1;           // Seconds test input
-// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+/**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
 
 
-// START_TEST(test_b02_sec_almost_epoch)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = -1;                    // Seconds test input
-// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+// Minimum GID for a system user (e.g., root, bin, sys)
+START_TEST(test_b01_min_good_system_user_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 0;              // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
-
-
-// START_TEST(test_b03_sec_epoch_time)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = 0;                     // Seconds test input
-// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// START_TEST(test_b04_sec_barely_past_epoch)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = 1;                     // Seconds test input
-// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+// Maximum GID for a system user (e.g., root, bin, sys)
+START_TEST(test_b02_max_good_system_user_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 99;             // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
-
-
-// START_TEST(test_b05_sec_static_now)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = 0x66197EA4;            // Secs test input: 4/12/2024, 1:34:12 PM (1712946852)
-// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// START_TEST(test_b06_sec_max_value)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = INT_MAX;               // Seconds test input
-// 	long new_nsec = 0x7E57;                 // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+// Minimum GID for an application user (e.g., crontab, syslog, pulse)
+START_TEST(test_b03_min_good_application_user_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 100;            // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
-
-
-// START_TEST(test_b07_nsec_low_very_bad)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = EINVAL;                // Expected results
-// 	time_t new_sec = 0x7E57;                // Seconds test input
-// 	long new_nsec = LONG_MIN;               // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// START_TEST(test_b08_nsec_low_barely_bad)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = EINVAL;                // Expected results
-// 	time_t new_sec = 0x7E57;                // Seconds test input
-// 	long new_nsec = UTIME_NSEC_MIN - 1l;    // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+// Maximum GID for an application user (e.g., crontab, syslog, pulse)
+START_TEST(test_b04_max_good_system_user_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 999;            // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
-
-
-// START_TEST(test_b09_nsec_low_barely_good)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = 0x7E57;                // Seconds test input
-// 	long new_nsec = UTIME_NSEC_MIN;         // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// START_TEST(test_b10_nsec_high_barely_good)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = 0x7E57;                // Seconds test input
-// 	long new_nsec = UTIME_NSEC_MAX;         // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+// Minimum GID for a regular user (see: useradd mumu)
+START_TEST(test_b05_min_good_regular_user_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 1000;           // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
-
-
-// START_TEST(test_b11_nsec_high_barely_bad)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = EINVAL;                // Expected results
-// 	time_t new_sec = 0x7E57;                // Seconds test input
-// 	long new_nsec = UTIME_NSEC_MAX + 1l;    // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// START_TEST(test_b12_nsec_high_very_bad)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = EINVAL;                // Expected results
-// 	time_t new_sec = 0x7E57;                // Seconds test input
-// 	long new_nsec = LONG_MAX;               // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+// Maximum GID for Debian: https://www.baeldung.com/linux/user-ids-reserved-values
+START_TEST(test_b06_max_good_debian_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 59999;          // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
+
+
+// Maximum GID for Solaris: https://docs.oracle.com/cd/E19455-01/805-7228/userconcept-35/index.html
+START_TEST(test_b07_max_good_solaris_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 60000;          // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
+
+
+// Maximum GID for Linux (see: grep ^GID_MAX /etc/login.defs)
+START_TEST(test_b08_max_good_linux_gid)
+{
+	// LOCAL VARIABLES
+	bool follow = true;             // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = 60000;          // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
 // /**************************************************************************************************/
 // /*************************************** SPECIAL TEST CASES ***************************************/
 // /**************************************************************************************************/
-// START_TEST(test_s01_missing_filename)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                                 // Follow symlinks
-// 	int exp_result = ENOENT;                            // Expected results
-// 	time_t new_sec = 0x7E57;                            // Seconds test input
-// 	long new_nsec = 0xC0DE;                             // Nanoseconds test input
-// 	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
 
 
-// START_TEST(test_s02_symbolic_link_nofollow)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = false;        // Follow symlinks
-// 	int exp_result = 0;         // Expected results
-// 	time_t new_sec = 0x4B1D;    // Seconds test input
-// 	long new_nsec = 0xB16C0DE;  // Nanoseconds test input
-// 	// Absolute path for test input as resolved against the repo name
-// 	char *input_abs_path = test_sym_link;
-// 	// Absolute path for actual_rel_path as resolved against the repo name
-// 	char *actual_abs_path = test_file_path;
+START_TEST(test_s01_symbolic_link_no_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;            // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;  // Test case input
+	gid_t new_gid = get_new_gid();  // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_symlink_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
- 
-
-// START_TEST(test_s03_block_device)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                        // Follow symlinks
-// 	int exp_result = EPERM;                    // Expected results
-// 	time_t new_sec = 0x7E57;                   // Seconds test input
-// 	long new_nsec = 0xC0DE;                    // Nanoseconds test input
-// 	char input_abs_path[] = { "/dev/loop0" };  // Test case input
-
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// START_TEST(test_s04_character_device)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                       // Follow symlinks
-// 	int exp_result = EPERM;                   // Expected results
-// 	time_t new_sec = 0x7E57;                  // Seconds test input
-// 	long new_nsec = 0xC0DE;                   // Nanoseconds test input
-// 	char input_abs_path[] = { "/dev/null" };  // Test case input
+START_TEST(test_s02_nobody_uid)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;                                         // Errno value
+	bool follow = true;                                     // Test case input
+	uid_t new_uid = get_shell_user_uid("nobody", &errnum);  // Test case input
+	gid_t new_gid = CSSO_SKIP_GID;                          // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// VALIDATE
+	ck_assert_msg(0 == errnum, "get_shell_user_uid() failed with [%d] %s",
+		          errnum, strerror(errnum));
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
-// /*
-//  *	NOTE: If the seconds are set to INT_MIN, the nanoseconds appear to always be set to 0.
-//  */
-// START_TEST(test_s05_sec_min_value_edge_case)
-// {
-// 	// LOCAL VARIABLES
-// 	bool follow = true;                     // Follow symlinks
-// 	int exp_result = 0;                     // Expected results
-// 	time_t new_sec = INT_MIN;               // Seconds test input
-// 	long new_nsec = 0;                      // Nanoseconds test input
-// 	char *input_abs_path = test_file_path;  // Test case input
+START_TEST(test_s03_nogroup_gid)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;                                          // Errno value
+	bool follow = true;                                      // Test case input
+	uid_t new_uid = CSSO_SKIP_UID;                           // Test case input
+	gid_t new_gid = get_shell_user_gid("nobody", &errnum);  // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
 
-// 	// RUN TEST
-// 	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
-// }
-// END_TEST
+	// VALIDATE
+	ck_assert_msg(0 == errnum, "get_shell_user_gid() failed with [%d] %s",
+		          errnum, strerror(errnum));
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
+
+
+START_TEST(test_s04_nobody_nogroup)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;      // Errno value
+	bool follow = true;  // Test case input
+	uid_t new_uid = 0;   // Test case input
+	gid_t new_gid = 0;   // Test case input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_details->pathname;
+
+	// SETUP
+	// UID
+	new_uid = get_shell_user_uid("nobody", &errnum);
+	ck_assert_msg(0 == errnum, "get_shell_user_uid() failed with [%d] %s",
+		          errnum, strerror(errnum));
+	// GID
+	new_gid = get_shell_user_gid("nobody", &errnum);
+	ck_assert_msg(0 == errnum, "get_shell_user_gid() failed with [%d] %s",
+		          errnum, strerror(errnum));
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, new_uid, new_gid);
+}
+END_TEST
 
 
 Suite *set_ownership_suite(void)
@@ -1066,14 +1017,14 @@ Suite *set_ownership_suite(void)
 	Suite *suite = suite_create("SFMW_Set_Ownership");  // Test suite
 	TCase *tc_normal = tcase_create("Normal");       // Normal test cases
 	TCase *tc_error = tcase_create("Error");         // Error test cases
-	// TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases
-	// TCase *tc_special = tcase_create("Special");     // Special test cases
+	TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases
+	TCase *tc_special = tcase_create("Special");     // Special test cases
 
 	// SETUP TEST CASES
 	tcase_add_checked_fixture(tc_normal, setup, teardown);
 	tcase_add_checked_fixture(tc_error, setup, teardown);
-	// tcase_add_checked_fixture(tc_boundary, setup, teardown);
-	// tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
 	tcase_add_test(tc_normal, test_n01_directory);
 	tcase_add_test(tc_normal, test_n02_named_pipe);
 	tcase_add_test(tc_normal, test_n03_regular_file);
@@ -1082,27 +1033,22 @@ Suite *set_ownership_suite(void)
 	tcase_add_test(tc_error, test_e01_null_filename);
 	tcase_add_test(tc_error, test_e02_empty_filename);
 	tcase_add_test(tc_error, test_e03_missing_filename);
-	// tcase_add_test(tc_boundary, test_b01_sec_min_value);
-	// tcase_add_test(tc_boundary, test_b02_sec_almost_epoch);
-	// tcase_add_test(tc_boundary, test_b03_sec_epoch_time);
-	// tcase_add_test(tc_boundary, test_b04_sec_barely_past_epoch);
-	// tcase_add_test(tc_boundary, test_b05_sec_static_now);
-	// tcase_add_test(tc_boundary, test_b06_sec_max_value);
-	// tcase_add_test(tc_boundary, test_b07_nsec_low_very_bad);
-	// tcase_add_test(tc_boundary, test_b08_nsec_low_barely_bad);
-	// tcase_add_test(tc_boundary, test_b09_nsec_low_barely_good);
-	// tcase_add_test(tc_boundary, test_b10_nsec_high_barely_good);
-	// tcase_add_test(tc_boundary, test_b11_nsec_high_barely_bad);
-	// tcase_add_test(tc_boundary, test_b12_nsec_high_very_bad);
-	// tcase_add_test(tc_special, test_s01_missing_filename);
-	// tcase_add_test(tc_special, test_s02_symbolic_link_nofollow);
-	// tcase_add_test(tc_special, test_s03_block_device);
-	// tcase_add_test(tc_special, test_s04_character_device);
-	// tcase_add_test(tc_special, test_s05_sec_min_value_edge_case);
+	tcase_add_test(tc_boundary, test_b01_min_good_system_user_gid);
+	tcase_add_test(tc_boundary, test_b02_max_good_system_user_gid);
+	tcase_add_test(tc_boundary, test_b03_min_good_application_user_gid);
+	tcase_add_test(tc_boundary, test_b04_max_good_system_user_gid);
+	tcase_add_test(tc_boundary, test_b05_min_good_regular_user_gid);
+	tcase_add_test(tc_boundary, test_b06_max_good_debian_gid);
+	tcase_add_test(tc_boundary, test_b07_max_good_solaris_gid);
+	tcase_add_test(tc_boundary, test_b08_max_good_linux_gid);
+	tcase_add_test(tc_special, test_s01_symbolic_link_no_follow);
+	tcase_add_test(tc_special, test_s02_nobody_uid);
+	tcase_add_test(tc_special, test_s03_nogroup_gid);
+	tcase_add_test(tc_special, test_s04_nobody_nogroup);
 	suite_add_tcase(suite, tc_normal);
 	suite_add_tcase(suite, tc_error);
-	// suite_add_tcase(suite, tc_boundary);
-	// suite_add_tcase(suite, tc_special);
+	suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
 
 	return suite;
 }

--- a/code/test/check_sfmw_set_times.c
+++ b/code/test/check_sfmw_set_times.c
@@ -125,7 +125,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -249,19 +249,19 @@ void teardown(void)
 {
 	// Directory
 	set_times_now(test_dir_path, false);  // Ignore any errors
-	free_devops_mem(&test_dir_path);  // Ignore any errors
+	free_devops_mem((void **)&test_dir_path);  // Ignore any errors
 	// File
 	// set_times_now(test_file_path, false);  // Ignore any errors
-	free_devops_mem(&test_file_path);  // Ignore any errors
+	free_devops_mem((void **)&test_file_path);  // Ignore any errors
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 	// Symbolic Link
 	set_times_now(test_sym_link, false);  // Ignore any errors
-	free_devops_mem(&test_sym_link);  // Ignore any errors
+	free_devops_mem((void **)&test_sym_link);  // Ignore any errors
 }
 
 
@@ -739,7 +739,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmw_set_times.c
+++ b/code/test/check_sfmw_set_times.c
@@ -251,7 +251,7 @@ void teardown(void)
 	set_times_now(test_dir_path, false);  // Ignore any errors
 	free_devops_mem((void **)&test_dir_path);  // Ignore any errors
 	// File
-	// set_times_now(test_file_path, false);  // Ignore any errors
+	set_times_now(test_file_path, false);  // Ignore any errors
 	free_devops_mem((void **)&test_file_path);  // Ignore any errors
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort

--- a/code/test/check_sfmw_set_times.c
+++ b/code/test/check_sfmw_set_times.c
@@ -1,0 +1,746 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_times() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_times.bin
+code/dist/check_sfmw_set_times.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_times.bin
+
+ *
+ *	The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *	Execute this command to run just one NEBS category:
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfmw_set_times.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfmw_set_times.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfmw_set_times.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfmw_set_times.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ *
+ */
+
+#include <check.h>                     // START_TEST(), END_TEST
+#include <limits.h>                    // PATH_MAX
+#include <stdio.h>                     // printf()
+#include <stdlib.h>
+#include <unistd.h>                    // get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"               // resolve_to_repo(), SKID_REPO_NAME
+#include "skid_file_metadata_read.h"   // get_access_time()
+#include "skid_file_metadata_write.h"  // set_times()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
+#define MICRO_SEC_SLEEP (useconds_t)10000  // Give the file timestamp 0.01 second to update
+#define UTIME_NSEC_MIN 0l          // Minimum allowed value for tv_nsec (see: utimensat(2))
+#define UTIME_NSEC_MAX 999999999l  // Maximum allowed value for tv_nsec (see: utimensat(2))
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+
+char *test_dir_path;  // Heap array containing the absolute directory name resolved to the repo
+char *test_file_path;  // Heap array containing the absolute filename resolved to the repo
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+char *test_sym_link;  // Heap array with the absolute symbolic link filename resolved to the repo
+
+/*
+ *	Set the atime and mtime timestamps of the test_*_path globals to "now".
+ */
+void reset_global_timestamps(void);
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	For both access and modification times...
+ *	1. Gets the original time, 2. Calls the tested function, 3. Gets the new time.
+ *	Verifies: actual return == exp_ret, desired time == current time
+ *	If follow_sym is true and pathname is a symbolic link, checks the before and after timestamps
+ *	of target_name instead.  Otherwise, target_name is ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret,
+	               time_t new_sec, long new_nsec);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Compare the desired time vs current times to verify the timestamp was updated.
+ */
+void verify_time_update(const char *pathname, const char *time_adj,
+						time_t new_time, long new_time_nsec, time_t curr_time, long curr_time_nsec);
+
+
+void reset_global_timestamps(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;  // Errno values
+	// Array of the global pointers to iterate over
+	char *test_paths[] = {test_dir_path, test_file_path, test_pipe_path,
+	                      test_socket_path, test_sym_link};
+
+	// RESET TIMES
+	for (int i = 0; i < (sizeof(test_paths) / sizeof(test_paths[0])); i++)
+	{
+		errnum = set_times_now(test_paths[i], false);
+		ck_assert_msg(0 == errnum, "set_times_now(%s) failed with [%d] %s", test_paths[i],
+			          errnum, strerror(errnum));
+	}
+
+	// DONE
+	return;
+}
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret,
+	               time_t new_sec, long new_nsec)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;            // Errno values
+	time_t old_atime = 0;               // Original atime
+	long old_atime_nsec = 0;            // Original atime nanoseconds
+	time_t curr_atime = 0;              // New atime
+	long curr_atime_nsec = 0;           // New atime nanoseconds
+	time_t old_mtime = 0;               // Original mtime
+	long old_mtime_nsec = 0;            // Original mtime nanoseconds
+	time_t curr_mtime = 0;              // New mtime
+	long curr_mtime_nsec = 0;           // New mtime nanoseconds
+	const char *time_check = pathname;  // Filename to gather timestamps for
+
+	// CHECK IT
+	// Should we use target_name instead?
+	if (pathname && *pathname && true == follow_sym && true == is_sym_link(pathname, &errnum))
+	{
+		ck_assert_msg(0 == errnum, "is_sym_link(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+		time_check = target_name;
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+
+	// RUN IT
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 1. Get original time
+		// Access Time
+		errnum = get_access_timestamp(time_check, &old_atime, &old_atime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_access_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		// Modification Time
+		errnum = get_mod_timestamp(time_check, &old_mtime, &old_mtime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// 2. Call function
+	micro_sleep(MICRO_SEC_SLEEP);  // Wait before changing the timestamp
+	errnum = set_times(pathname, follow_sym, new_sec, new_nsec);
+	ck_assert_msg(exp_ret == errnum, "set_times(%s) returned [%d] '%s' instead of [%d] '%s",
+				  pathname, errnum, strerror(errnum), exp_ret, strerror(exp_ret));
+	errnum = CANARY_INT;  // Reset temp variable
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 3. Get current time
+		// Access Time
+		errnum = get_access_timestamp(time_check, &curr_atime, &curr_atime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_access_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		// Modification Time
+		errnum = get_mod_timestamp(time_check, &curr_mtime, &curr_mtime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+
+		// VALIDATE RESULTS
+		verify_time_update(time_check, "access", new_sec, new_nsec, curr_atime, curr_atime_nsec);
+		verify_time_update(time_check, "modification", new_sec, new_nsec,
+						   curr_mtime, curr_mtime_nsec);
+	}
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                          // Errno values
+	char directory[] = { "./code/test/test_input/" };                 // Default test input: dir
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };      // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };      // Default test input: socket
+	char reg_file[] = { "./code/test/test_input/regular_file.txt" };  // Default test input: file
+	char sym_link[] = { "./code/test/test_input/sym_link.txt" };      // Default test input: symlink
+
+	// SET IT UP
+	// Directory
+	test_dir_path = resolve_test_input(directory);
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Regular File
+	test_file_path = resolve_test_input(reg_file);
+	// Symbolic Link
+	test_sym_link = resolve_test_input(sym_link);
+
+	// RESET TIMESTAMPS
+	reset_global_timestamps();
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Directory
+	set_times_now(test_dir_path, false);  // Ignore any errors
+	free_devops_mem(&test_dir_path);  // Ignore any errors
+	// File
+	// set_times_now(test_file_path, false);  // Ignore any errors
+	free_devops_mem(&test_file_path);  // Ignore any errors
+	// Pipe
+	remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+	// Symbolic Link
+	set_times_now(test_sym_link, false);  // Ignore any errors
+	free_devops_mem(&test_sym_link);  // Ignore any errors
+}
+
+
+void verify_time_update(const char *pathname, const char *time_adj,
+						time_t new_time, long new_time_nsec, time_t curr_time, long curr_time_nsec)
+{
+	// Compare times
+	if (new_time != curr_time)
+	{
+		ck_abort_msg("The %s time for %s was not updated: new sec %ld != curr sec %ld",
+					 time_adj, pathname, new_time, curr_time);
+	}
+	else if (new_time_nsec != curr_time_nsec)
+	{
+		ck_abort_msg("The %s nanoseconds for %s weren't updated: new nsec %ld != curr nsec %ld",
+					 time_adj, pathname, new_time_nsec, curr_time_nsec);
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = 0;           // Expected results
+	time_t new_sec = 0x600DC0DE;  // Seconds test input
+	long new_nsec = 0xD06F00D;    // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_dir_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	bool follow = true;         // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0xBAD71E;  // Seconds test input
+	long new_nsec = 0x347F00D;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	bool follow = true;         // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0xB00000;  // Seconds test input
+	long new_nsec = 0xC0010FF;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int exp_result = 0;       // Expected results
+	time_t new_sec = 0xD34D;  // Seconds test input
+	long new_nsec = 0xBEEF;   // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = true;       // Follow symlinks
+	int exp_result = 0;       // Expected results
+	time_t new_sec = 0xFEED;  // Seconds test input
+	long new_nsec = 0xFACE;   // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_sym_link;
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = EINVAL;      // Expected results
+	time_t new_sec = 0x7E57;      // Seconds test input
+	long new_nsec = 0xC0DE;       // Nanoseconds test input
+	char *input_abs_path = NULL;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                          // Follow symlinks
+	int exp_result = EINVAL;                     // Expected results
+	time_t new_sec = 0x7E57;                     // Seconds test input
+	long new_nsec = 0xC0DE;                      // Nanoseconds test input
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/************************************** BOUNDARY TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_b01_sec_min_value)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MIN + 1;           // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b02_sec_almost_epoch)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = -1;                    // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b03_sec_epoch_time)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0;                     // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b04_sec_barely_past_epoch)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 1;                     // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b05_sec_static_now)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x66197EA4;            // Secs test input: 4/12/2024, 1:34:12 PM (1712946852)
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b06_sec_max_value)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MAX;               // Seconds test input
+	long new_nsec = 0x7E57;                 // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b07_nsec_low_very_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = LONG_MIN;               // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b08_nsec_low_barely_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MIN - 1l;    // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b09_nsec_low_barely_good)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MIN;         // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b10_nsec_high_barely_good)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MAX;         // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b11_nsec_high_barely_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = UTIME_NSEC_MAX + 1l;    // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_b12_nsec_high_very_bad)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = EINVAL;                // Expected results
+	time_t new_sec = 0x7E57;                // Seconds test input
+	long new_nsec = LONG_MAX;               // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_s01_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                                 // Follow symlinks
+	int exp_result = ENOENT;                            // Expected results
+	time_t new_sec = 0x7E57;                            // Seconds test input
+	long new_nsec = 0xC0DE;                             // Nanoseconds test input
+	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_s02_symbolic_link_nofollow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;        // Follow symlinks
+	int exp_result = 0;         // Expected results
+	time_t new_sec = 0x4B1D;    // Seconds test input
+	long new_nsec = 0xB16C0DE;  // Nanoseconds test input
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_sym_link;
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = test_file_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+ 
+
+START_TEST(test_s03_block_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                        // Follow symlinks
+	int exp_result = EPERM;                    // Expected results
+	time_t new_sec = 0x7E57;                   // Seconds test input
+	long new_nsec = 0xC0DE;                    // Nanoseconds test input
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+START_TEST(test_s04_character_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                       // Follow symlinks
+	int exp_result = EPERM;                   // Expected results
+	time_t new_sec = 0x7E57;                  // Seconds test input
+	long new_nsec = 0xC0DE;                   // Nanoseconds test input
+	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+/*
+ *	NOTE: If the seconds are set to INT_MIN, the nanoseconds appear to always be set to 0.
+ */
+START_TEST(test_s05_sec_min_value_edge_case)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                     // Follow symlinks
+	int exp_result = 0;                     // Expected results
+	time_t new_sec = INT_MIN;               // Seconds test input
+	long new_nsec = 0;                      // Nanoseconds test input
+	char *input_abs_path = test_file_path;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result, new_sec, new_nsec);
+}
+END_TEST
+
+
+Suite *set_times_suite(void)
+{
+	// LOCAL VARIABLES
+	Suite *suite = suite_create("SFMW_Set_Ttimes");  // Test suite
+	TCase *tc_normal = tcase_create("Normal");       // Normal test cases
+	TCase *tc_error = tcase_create("Error");         // Error test cases
+	TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases
+	TCase *tc_special = tcase_create("Special");     // Special test cases
+
+	// SETUP TEST CASES
+	tcase_add_checked_fixture(tc_normal, setup, teardown);
+	tcase_add_checked_fixture(tc_error, setup, teardown);
+	tcase_add_checked_fixture(tc_boundary, setup, teardown);
+	tcase_add_checked_fixture(tc_special, setup, teardown);
+	tcase_add_test(tc_normal, test_n01_directory);
+	tcase_add_test(tc_normal, test_n02_named_pipe);
+	tcase_add_test(tc_normal, test_n03_regular_file);
+	tcase_add_test(tc_normal, test_n04_socket);
+	tcase_add_test(tc_normal, test_n05_symbolic_link_follow);
+	tcase_add_test(tc_error, test_e01_null_filename);
+	tcase_add_test(tc_error, test_e02_empty_filename);
+	tcase_add_test(tc_boundary, test_b01_sec_min_value);
+	tcase_add_test(tc_boundary, test_b02_sec_almost_epoch);
+	tcase_add_test(tc_boundary, test_b03_sec_epoch_time);
+	tcase_add_test(tc_boundary, test_b04_sec_barely_past_epoch);
+	tcase_add_test(tc_boundary, test_b05_sec_static_now);
+	tcase_add_test(tc_boundary, test_b06_sec_max_value);
+	tcase_add_test(tc_boundary, test_b07_nsec_low_very_bad);
+	tcase_add_test(tc_boundary, test_b08_nsec_low_barely_bad);
+	tcase_add_test(tc_boundary, test_b09_nsec_low_barely_good);
+	tcase_add_test(tc_boundary, test_b10_nsec_high_barely_good);
+	tcase_add_test(tc_boundary, test_b11_nsec_high_barely_bad);
+	tcase_add_test(tc_boundary, test_b12_nsec_high_very_bad);
+	tcase_add_test(tc_special, test_s01_missing_filename);
+	tcase_add_test(tc_special, test_s02_symbolic_link_nofollow);
+	tcase_add_test(tc_special, test_s03_block_device);
+	tcase_add_test(tc_special, test_s04_character_device);
+	tcase_add_test(tc_special, test_s05_sec_min_value_edge_case);
+	suite_add_tcase(suite, tc_normal);
+	suite_add_tcase(suite, tc_error);
+	suite_add_tcase(suite, tc_boundary);
+	suite_add_tcase(suite, tc_special);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_times.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = set_times_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfmw_set_times.c
+++ b/code/test/check_sfmw_set_times.c
@@ -672,7 +672,7 @@ END_TEST
 Suite *set_times_suite(void)
 {
 	// LOCAL VARIABLES
-	Suite *suite = suite_create("SFMW_Set_Ttimes");  // Test suite
+	Suite *suite = suite_create("SFMW_Set_Times");  // Test suite
 	TCase *tc_normal = tcase_create("Normal");       // Normal test cases
 	TCase *tc_error = tcase_create("Error");         // Error test cases
 	TCase *tc_boundary = tcase_create("Boundary");   // Boundary test cases

--- a/code/test/check_sfmw_set_times_now.c
+++ b/code/test/check_sfmw_set_times_now.c
@@ -83,7 +83,7 @@ char *resolve_test_input(const char *pathname)
 	// DONE
 	if (0 != errnum && resolved_name)
 	{
-		free_devops_mem(&resolved_name);  // Best effort
+		free_devops_mem((void **)&resolved_name);  // Best effort
 	}
 	return resolved_name;
 }
@@ -195,10 +195,10 @@ void teardown(void)
 {
 	// Pipe
 	remove_a_file(test_pipe_path, true);  // Best effort
-	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	free_devops_mem((void **)&test_pipe_path);  // Ignore any errors
 	// Socket
 	remove_a_file(test_socket_path, true);  // Best effort
-	free_devops_mem(&test_socket_path);  // Ignore any errors
+	free_devops_mem((void **)&test_socket_path);  // Ignore any errors
 }
 
 
@@ -236,7 +236,7 @@ START_TEST(test_n01_directory)
 	run_test_case(input_abs_path, NULL, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -267,7 +267,7 @@ START_TEST(test_n03_regular_file)
 	run_test_case(input_abs_path, NULL, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
+	free_devops_mem((void **)&input_abs_path);
 }
 END_TEST
 
@@ -300,8 +300,8 @@ START_TEST(test_n05_symbolic_link_follow)
 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
 
@@ -365,8 +365,8 @@ START_TEST(test_s02_symbolic_link_nofollow)
 	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
 
 	// CLEANUP
-	free_devops_mem(&input_abs_path);
-	free_devops_mem(&actual_abs_path);
+	free_devops_mem((void **)&input_abs_path);
+	free_devops_mem((void **)&actual_abs_path);
 }
 END_TEST
  
@@ -447,7 +447,7 @@ int main(void)
 
 	// CLEANUP
 	srunner_free(suite_runner);
-	free_devops_mem(&log_abs_path);
+	free_devops_mem((void **)&log_abs_path);
 
 	// DONE
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/code/test/check_sfmw_set_times_now.c
+++ b/code/test/check_sfmw_set_times_now.c
@@ -1,0 +1,454 @@
+/*
+ *  Check unit test suit for skid_file_metadata_write.h's set_times_now() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfmw_set_times_now.bin
+code/dist/check_sfmw_set_times_now.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfmw_set_times_now.bin
+
+ *
+ */
+
+#include <check.h>                     // START_TEST(), END_TEST
+#include <limits.h>                    // PATH_MAX
+#include <stdio.h>                     // printf()
+#include <stdlib.h>
+#include <unistd.h>                    // get_current_dir_name(), usleep()
+// Local includes
+#include "devops_code.h"               // resolve_to_repo(), SKID_REPO_NAME
+#include "skid_file_metadata_read.h"   // get_access_time()
+#include "skid_file_metadata_write.h"  // set_times_now()
+
+
+// Use this to help highlight an errnum that wasn't updated
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+// Use this with usleep(MICRO_SEC_SLEEP) to let the file timestamp update
+#define MICRO_SEC_SLEEP (useconds_t)10000  // Give the file timestamp 0.01 second to update
+
+
+/**************************************************************************************************/
+/***************************************** TEST FIXTURES ******************************************/
+/**************************************************************************************************/
+
+char *test_pipe_path;  // Heap array containing the absolute pipe filename resolved to the repo
+char *test_socket_path;  // Heap array containing the absolute socket filename resolved to the repo
+
+/*
+ *	Resolve paththame to SKID_REPO_NAME in a standardized way.  Use free_devops_mem() to free
+ *	the return value.
+ */
+char *resolve_test_input(const char *pathname);
+
+/*
+ *	1. Gets the original time, 2. Calls the tested function, 3. Gets the new time.
+ *	Verifies: actual return == exp_ret, original time < new time (special cases
+ *	original time <= new time for directories because of "filesystem relatime flag").
+ *	If follow_sym is true and pathname is a symbolic link, checks the before and after timestamps
+ *	of target_name instead.  Otherwise, target_name is ignored.
+ */
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret);
+
+/*
+ *	Resolve the named pipe and raw socket default filenames to the repo and store the heap
+ *	memory pointer in the globals.
+ */
+void setup(void);
+
+/*
+ *	Delete the named pipe and raw socket files.  Then, free the heap memory arrays.
+ */
+void teardown(void);
+
+/*
+ *	Compare the old vs new times to verify the timestamp was updated.
+ */
+void verify_time_update(const char *pathname, const char *time_adj,
+	                    time_t old_time, long old_time_nsec, time_t new_time, long new_time_nsec);
+
+
+char *resolve_test_input(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                 // Errno values
+	const char *repo_name = SKID_REPO_NAME;  // Name of the repo
+	char *resolved_name = NULL;              // pathname resolved to repo_name
+
+	// RESOLVE IT
+	resolved_name = resolve_to_repo(repo_name, pathname, false, &errnum);
+	ck_assert_msg(0 == errnum, "resolve_to_repo(%s, %s) failed with [%d] %s", repo_name,
+				  pathname, errnum, strerror(errnum));
+	ck_assert_msg(NULL != resolved_name, "resolve_to_repo(%s, %s) failed to resolve the path",
+				  repo_name, pathname);
+
+	// DONE
+	if (0 != errnum && resolved_name)
+	{
+		free_devops_mem(&resolved_name);  // Best effort
+	}
+	return resolved_name;
+}
+
+
+void run_test_case(const char *pathname, const char *target_name, bool follow_sym, int exp_ret)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;            // Errno values
+	time_t old_atime = 0;               // Original atime
+	long old_atime_nsec = 0;            // Original atime nanoseconds
+	time_t new_atime = 0;               // New atime
+	long new_atime_nsec = 0;            // New atime nanoseconds
+	time_t old_mtime = 0;               // Original mtime
+	long old_mtime_nsec = 0;            // Original mtime nanoseconds
+	time_t new_mtime = 0;               // New mtime
+	long new_mtime_nsec = 0;            // New mtime nanoseconds
+	const char *time_check = pathname;  // Filename to gather timestamps for
+
+	// CHECK IT
+	// Should we use target_name instead?
+	if (pathname && *pathname && true == follow_sym && true == is_sym_link(pathname, &errnum))
+	{
+		ck_assert_msg(0 == errnum, "is_sym_link(%s) failed with [%d] %s",
+					  pathname, errnum, strerror(errnum));
+		time_check = target_name;
+	}
+	errnum = CANARY_INT;  // Reset temp variable
+
+	// RUN IT
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 1. Get original time
+		// Access Time
+		errnum = get_access_timestamp(time_check, &old_atime, &old_atime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_access_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		// Modification Time
+		errnum = get_mod_timestamp(time_check, &old_mtime, &old_mtime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "old get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// 2. Call function
+	micro_sleep(MICRO_SEC_SLEEP);  // Wait before changing the timestamp
+	errnum = set_times_now(pathname, follow_sym);
+	ck_assert_msg(exp_ret == errnum, "set_times_now(%s) returned [%d] '%s' instead of [%d] '%s",
+		          pathname, errnum, strerror(errnum), exp_ret, strerror(exp_ret));
+	errnum = CANARY_INT;  // Reset temp variable
+	// No need to compare times if the expected result is "error"
+	if (0 == exp_ret)
+	{
+		// 3. Get current time
+		// Access Time
+		errnum = get_access_timestamp(time_check, &new_atime, &new_atime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_access_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		// Modification Time
+		errnum = get_mod_timestamp(time_check, &new_mtime, &new_mtime_nsec, follow_sym);
+		ck_assert_msg(0 == errnum, "new get_mod_timestamp(%s) failed with [%d] %s",
+					  time_check, errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+
+		// VALIDATE RESULTS
+		verify_time_update(time_check, "access", old_atime, old_atime_nsec,
+			               new_atime, new_atime_nsec);
+		verify_time_update(time_check, "modification", old_mtime, old_mtime_nsec,
+			               new_mtime, new_mtime_nsec);
+	}
+}
+
+
+void setup(void)
+{
+	// LOCAL VARIABLES
+	int errnum = CANARY_INT;                                      // Errno values
+	char named_pipe[] = { "./code/test/test_input/named_pipe" };  // Default test input: pipe
+	char raw_socket[] = { "./code/test/test_input/raw_socket" };  // Default test input: socket
+
+	// SET IT UP
+	// Named Pipe
+	test_pipe_path = resolve_test_input(named_pipe);
+	if (test_pipe_path)
+	{
+		remove_a_file(test_pipe_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_pipe(test_pipe_path);
+		ck_assert_msg(0 == errnum, "make_a_pipe(%s) failed with [%d] %s", test_pipe_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+	// Raw Socket
+	test_socket_path = resolve_test_input(raw_socket);
+	if (test_socket_path)
+	{
+		remove_a_file(test_socket_path, true);  // Remove leftovers and ignore errors
+		errnum = make_a_socket(test_socket_path);
+		ck_assert_msg(0 == errnum, "make_a_socket(%s) failed with [%d] %s", test_socket_path,
+					  errnum, strerror(errnum));
+		errnum = CANARY_INT;  // Reset temp variable
+	}
+
+	// DONE
+	return;
+}
+
+
+void teardown(void)
+{
+	// Pipe
+	remove_a_file(test_pipe_path, true);  // Best effort
+	free_devops_mem(&test_pipe_path);  // Ignore any errors
+	// Socket
+	remove_a_file(test_socket_path, true);  // Best effort
+	free_devops_mem(&test_socket_path);  // Ignore any errors
+}
+
+
+void verify_time_update(const char *pathname, const char *time_adj,
+	                    time_t old_time, long old_time_nsec, time_t new_time, long new_time_nsec)
+{
+	// Compare times
+	if (old_time > new_time)
+	{
+		ck_abort_msg("The %s time for %s was not updated: old sec %ld > new sec %ld",
+		             time_adj, pathname, old_time, new_time);
+	}
+	else if (old_time == new_time && old_time_nsec >= new_time_nsec)
+	{
+		ck_abort_msg("The %s nanoseconds for %s weren't updated: old nsec %ld >= new nsec %ld",
+		             time_adj, pathname, old_time_nsec, new_time_nsec);
+	}
+}
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_directory)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/");
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n02_named_pipe)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_pipe_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_n03_regular_file)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+}
+END_TEST
+
+
+START_TEST(test_n04_socket)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = test_socket_path;
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_n05_symbolic_link_follow)
+{
+	// LOCAL VARIABLES
+	bool follow = true;  // Follow symlinks
+	int exp_result = 0;  // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+START_TEST(test_e01_null_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;           // Follow symlinks
+	int exp_result = EINVAL;      // Expected results
+	char *input_abs_path = NULL;  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_e02_empty_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                          // Follow symlinks
+	int exp_result = EINVAL;                     // Expected results
+	char input_abs_path[] = { "\0 NOT HERE!" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+START_TEST(test_s01_missing_filename)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                                 // Follow symlinks
+	int exp_result = ENOENT;                            // Expected results
+	char input_abs_path[] = { "/does/not/exist.txt" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_s02_symbolic_link_nofollow)
+{
+	// LOCAL VARIABLES
+	bool follow = false;  // Follow symlinks
+	int exp_result = 0;   // Expected results
+	// Absolute path for test input as resolved against the repo name
+	char *input_abs_path = resolve_test_input("./code/test/test_input/sym_link.txt");
+	// Absolute path for actual_rel_path as resolved against the repo name
+	char *actual_abs_path = resolve_test_input("./code/test/test_input/regular_file.txt");
+
+	// RUN TEST
+	run_test_case(input_abs_path, actual_abs_path, follow, exp_result);
+
+	// CLEANUP
+	free_devops_mem(&input_abs_path);
+	free_devops_mem(&actual_abs_path);
+}
+END_TEST
+ 
+
+START_TEST(test_s03_block_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                        // Follow symlinks
+	int exp_result = EACCES;                   // Expected results
+	char input_abs_path[] = { "/dev/loop0" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+START_TEST(test_s04_character_device)
+{
+	// LOCAL VARIABLES
+	bool follow = true;                       // Follow symlinks
+	int exp_result = 0;                       // Expected results
+	char input_abs_path[] = { "/dev/null" };  // Test case input
+
+	// RUN TEST
+	run_test_case(input_abs_path, NULL, follow, exp_result);
+}
+END_TEST
+
+
+Suite *set_times_now_suite(void)
+{
+	Suite *suite = NULL;
+	TCase *tc_core = NULL;
+
+	suite = suite_create("SFMW_Set_Times_Now");
+
+	/* Core test case */
+	tc_core = tcase_create("Core");
+	tcase_add_checked_fixture(tc_core, setup, teardown);
+	tcase_add_test(tc_core, test_n01_directory);
+	tcase_add_test(tc_core, test_n02_named_pipe);
+	tcase_add_test(tc_core, test_n03_regular_file);
+	tcase_add_test(tc_core, test_n04_socket);
+	tcase_add_test(tc_core, test_n05_symbolic_link_follow);
+	tcase_add_test(tc_core, test_e01_null_filename);
+	tcase_add_test(tc_core, test_e02_empty_filename);
+	tcase_add_test(tc_core, test_s01_missing_filename);
+	tcase_add_test(tc_core, test_s02_symbolic_link_nofollow);
+	tcase_add_test(tc_core, test_s03_block_device);
+	tcase_add_test(tc_core, test_s04_character_device);
+	suite_add_tcase(suite, tc_core);
+
+	return suite;
+}
+
+
+int main(void)
+{
+	// LOCAL VARIABLES
+	int errnum = 0;  // Errno from the function call
+	// Relative path for this test case's input
+	char log_rel_path[] = { "./code/test/test_output/check_sfmw_set_times_now.log" };
+	// Absolute path for log_rel_path as resolved against the repo name
+	char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+	int number_failed = 0;
+	Suite *suite = NULL;
+	SRunner *suite_runner = NULL;
+
+	// SETUP
+	suite = set_times_now_suite();
+	suite_runner = srunner_create(suite);
+	srunner_set_log(suite_runner, log_abs_path);
+
+	// RUN IT
+	srunner_run_all(suite_runner, CK_NORMAL);
+	number_failed = srunner_ntests_failed(suite_runner);
+
+	// CLEANUP
+	srunner_free(suite_runner);
+	free_devops_mem(&log_abs_path);
+
+	// DONE
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/test_devops_code_get_compatible_gid.c
+++ b/code/test/test_devops_code_get_compatible_gid.c
@@ -1,0 +1,93 @@
+/*
+ *	Manually test skid_file_metadata_write.h's get_shell_compatible_gid() functions.
+ *	The commands below will set set the ownership to your current UID and GID.
+ *	Adjust the values as necessary.
+ *
+ *	Copy/paste the following...
+
+./code/dist/test_devops_code_get_compatible_gid.bin
+sudo ./code/dist/test_devops_code_get_compatible_gid.bin
+sudo -u nobody ./code/dist/test_devops_code_get_compatible_gid.bin
+sudo -u whoopsie ./code/dist/test_devops_code_get_compatible_gid.bin
+
+ *
+ */
+
+// Standard includes
+#include <errno.h>                     // EINVAL
+#include <stdio.h>                     // fprintf(), printf()
+#include <stdlib.h>					   // exit()
+#include <sys/sysmacros.h>			   // major(), minor()
+// Local includes
+#include "devops_code.h"			   // get_shell_compatible_gid(), get_shell_my_uid()
+#ifndef SKID_DEBUG
+#define SKID_DEBUG                     // The DEBUG output is doing double duty as test output
+#endif  /* SKID_DEBUG */
+#include "skid_debug.h"                // PRINT_ERRNO(), PRINT_ERROR()
+
+
+int main(int argc, char *argv[])
+{
+	// LOCAL VARIABLES
+	int exit_code = 0;      // Store errno and/or results here
+	uid_t my_uid = 0;       // The UID of the executing process
+	gid_t *gid_arr = NULL;  // Array of compatible GIDs
+	gid_t *tmp_ptr = NULL;  // Temp iterating variable for the GID array
+	gid_t tmp_gid = 0;      // Watch for duplicates to avoid buffer overruns
+
+	// INPUT VALIDATION
+	if (argc != 1)
+	{
+	   fprintf(stderr, "Usage: %s\n", argv[0]);
+	   exit_code = EINVAL;
+	}
+
+	// GET IT
+	// Get my UID
+	if (!exit_code)
+	{
+		my_uid = get_shell_my_uid(&exit_code);
+		printf("My UID is %u\n", my_uid);
+	}
+	// Get compatible GIDs
+	if (!exit_code)
+	{
+		gid_arr = get_shell_compatible_gid(&exit_code);
+		if (exit_code)
+		{
+			PRINT_ERROR(The call to get_shell_compatible_gid() failed);
+			PRINT_ERRNO(exit_code);
+		}
+		// printf("%s Ownership:\tUID=%u   GID=%u\n", pathname, curr_uid, curr_gid);
+	}
+	// Print compatible GIDs
+	if (!exit_code)
+	{
+		tmp_ptr = gid_arr;
+		printf("Compatible GIDs:");
+		while(tmp_gid != my_uid)
+		{
+			if (tmp_gid != *tmp_ptr)
+			{
+				printf("\t%u", *tmp_ptr);
+				tmp_gid = *tmp_ptr;
+				tmp_ptr++;
+			}
+			else
+			{
+				break;  // Found a duplicate so it must be done
+			}
+		}
+		printf("\n");
+		tmp_ptr = NULL;
+	}
+
+	// CLEANUP
+	if (gid_arr)
+	{
+		exit_code = free_devops_mem((void**)&gid_arr);
+	}
+
+	// DONE
+	exit(exit_code);
+}

--- a/code/test/test_sfmr_file_metadata.c
+++ b/code/test/test_sfmr_file_metadata.c
@@ -35,7 +35,7 @@
  *  Returns:
  *		The time, on success.  0 on error, and errnum is set.
  */
-typedef time_t (*GetTime)(const char *pathname, int *errnum);
+typedef time_t (*GetTime)(const char *pathname, int *errnum, bool);
 
 
 /*
@@ -59,11 +59,13 @@ int print_file_type(const char *pathname);
  *      get_time_func: Function pointer to a get_*_time() function.
  *		func_type: The answer to "...pathname's _____ is..." (e.g., access, change, modification)
  *      pathname: The path to fetch a time for.
+ *		follow_sym: If true, follows symlinks to evaluate the target.
  *
  *  Returns:
  *      On success, 0.  Errno or -1 on failure.
  */
-int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname);
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname,
+	                     bool follow_sym);
 
 
 /*
@@ -241,17 +243,17 @@ int main(int argc, char *argv[])
 	// Access Time (atime)
 	if (!exit_code)
 	{
-		exit_code = print_formatted_time(get_access_time, "access", pathname);
+		exit_code = print_formatted_time(get_access_time, "access", pathname, false);
 	}
 	// Change Time (ctime)
 	if (!exit_code)
 	{
-		exit_code = print_formatted_time(get_change_time, "status change", pathname);
+		exit_code = print_formatted_time(get_change_time, "status change", pathname, false);
 	}
 	// Modification Time (mtime)
 	if (!exit_code)
 	{
-		exit_code = print_formatted_time(get_mod_time, "modification", pathname);
+		exit_code = print_formatted_time(get_mod_time, "modification", pathname, false);
 	}
 
 	// DONE
@@ -323,7 +325,7 @@ int print_file_type(const char *pathname)
 }
 
 
-int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname)
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname, bool follow_sym)
 {
 	// LOCAL VARIABLES
 	int result = 0;              // Store errno and/or results here
@@ -340,7 +342,7 @@ int print_formatted_time(GetTime get_time_func, const char *func_type, const cha
 	// Get the time
 	if (!result)
 	{
-		answer = (*get_time_func)(pathname, &result);
+		answer = (*get_time_func)(pathname, &result, follow_sym);
 	}
 	// Format the time
 	if (!result)

--- a/code/test/test_sfmr_file_metadata.c
+++ b/code/test/test_sfmr_file_metadata.c
@@ -74,25 +74,27 @@ int print_formatted_time(GetTime get_time_func, const char *func_type, const cha
  *
  *  Args:
  *      pathname: The path to fetch ownership for.
+ *		follow_sym: Follow symbolic links.
  *
  *  Returns:
  *      On success, 0.  Errno on failure.
  */
-int print_ownership(const char *pathname);
+int print_ownership(const char *pathname, bool follow_sym);
 
 
 int main(int argc, char *argv[])
 {
 	// LOCAL VARIABLES
-	int exit_code = 0;               // Store errno and/or results here
-	dev_t tmp_dev = 0;               // Temp variable for library return values
-	ino_t tmp_ino = 0;               // Temp variable for library return values
-	mode_t tmp_mode = 0;             // Temp variable for library return values
-	nlink_t tmp_link = 0;            // Temp variable for library return values
-	blksize_t tmp_blksize = 0;       // Temp variable for library return values
-	off_t tmp_off = 0;               // Temp variable for library return values
-	blkcnt_t tmp_blkcnt = 0;         // Temp variable for library return values
-	char *pathname = NULL;           // Get this from argv[1]
+	int exit_code = 0;          // Store errno and/or results here
+	dev_t tmp_dev = 0;          // Temp variable for library return values
+	ino_t tmp_ino = 0;          // Temp variable for library return values
+	mode_t tmp_mode = 0;        // Temp variable for library return values
+	nlink_t tmp_link = 0;       // Temp variable for library return values
+	blksize_t tmp_blksize = 0;  // Temp variable for library return values
+	off_t tmp_off = 0;          // Temp variable for library return values
+	blkcnt_t tmp_blkcnt = 0;    // Temp variable for library return values
+	char *pathname = NULL;      // Get this from argv[1]
+	bool follow_sym = false;    // Do not follow symbolic links
 
 	// INPUT VALIDATION
 	if (argc != 2)
@@ -196,7 +198,7 @@ int main(int argc, char *argv[])
 	// Owner and Group IDs
 	if (!exit_code)
 	{
-		exit_code = print_ownership(pathname);
+		exit_code = print_ownership(pathname, follow_sym);
 	}
 	// Preferred Block Size
 	if (!exit_code)
@@ -360,7 +362,7 @@ int print_formatted_time(GetTime get_time_func, const char *func_type, const cha
 }
 
 
-int print_ownership(const char *pathname)
+int print_ownership(const char *pathname, bool follow_sym)
 {
 	// LOCAL VARIABLES
 	int result = 0;     // Store errno and/or results here
@@ -369,7 +371,7 @@ int print_ownership(const char *pathname)
 
 	// PRINT IT
 	// Get the owner ID
-	tmp_uid = get_owner(pathname, &result);
+	tmp_uid = get_owner(pathname, &result, follow_sym);
 	if (result)
 	{
 		PRINT_ERROR(The call to get_owner() failed);
@@ -382,7 +384,7 @@ int print_ownership(const char *pathname)
 	// Get the group ID
 	if (!result)
 	{
-		tmp_gid = get_group(pathname, &result);
+		tmp_gid = get_group(pathname, &result, follow_sym);
 		if (result)
 		{
 			PRINT_ERROR(The call to get_group() failed);

--- a/code/test/test_sfmr_get_file_times.c
+++ b/code/test/test_sfmr_get_file_times.c
@@ -31,11 +31,12 @@
  *  Args:
  *      pathname: Absolute or relative pathname to fetch the time for.
  *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
  *
  *  Returns:
  *		The time, on success.  0 on error, and errnum is set.
  */
-typedef time_t (*GetTime)(const char *pathname, int *errnum);
+typedef time_t (*GetTime)(const char *pathname, int *errnum, bool follow_sym);
 
 
 /*
@@ -46,11 +47,13 @@ typedef time_t (*GetTime)(const char *pathname, int *errnum);
  *      get_time_func: Function pointer to a get_*_time() function.
  *		func_type: The answer to "...pathname's _____ is..." (e.g., access, change, modification)
  *      pathname: The path to fetch a time for.
+ *		follow_sym: If true, follows symlinks to evaluate the target.
  *      
  *  Returns:
  *      On success, 0.  Errno or -1 on failure.
  */
-int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname);
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname,
+	                     bool follow_sym);
 
 
 int main(int argc, char *argv[])
@@ -74,17 +77,17 @@ int main(int argc, char *argv[])
 	// Access Time (atime)
 	if (!exit_code)
 	{
-		exit_code = print_formatted_time(get_access_time, "access", pathname);
+		exit_code = print_formatted_time(get_access_time, "access", pathname, false);
 	}
 	// Change Time (ctime)
 	if (!exit_code)
 	{
-		exit_code = print_formatted_time(get_change_time, "change", pathname);
+		exit_code = print_formatted_time(get_change_time, "change", pathname, false);
 	}
 	// Modification Time (mtime)
 	if (!exit_code)
 	{
-		exit_code = print_formatted_time(get_mod_time, "modification", pathname);
+		exit_code = print_formatted_time(get_mod_time, "modification", pathname, false);
 	}
 
 	// DONE
@@ -92,7 +95,8 @@ int main(int argc, char *argv[])
 }
 
 
-int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname)
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname,
+	                     bool follow_sym)
 {
 	// LOCAL VARIABLES
 	int result = 0;              // Store errno and/or results here
@@ -109,7 +113,7 @@ int print_formatted_time(GetTime get_time_func, const char *func_type, const cha
 	// Get the time
 	if (!result)
 	{
-		answer = (*get_time_func)(pathname, &result);
+		answer = (*get_time_func)(pathname, &result, follow_sym);
 	}
 	// Format the time
 	if (!result)

--- a/code/test/test_sfmw_set_atime_now.c
+++ b/code/test/test_sfmw_set_atime_now.c
@@ -1,0 +1,165 @@
+/*
+ *	Manually test skid_file_metadata_write.h's set_atime_now() functions.
+ *
+ *	Copy/paste the following...
+
+./code/dist/test_sfmw_set_atime_now.bin ./code/test/test_input/                  # Directory
+./code/dist/test_sfmw_set_atime_now.bin ./code/test/test_input/regular_file.txt  # Regular file
+
+ *
+ */
+
+// Standard includes
+#include <errno.h>                     // EINVAL
+#include <stdio.h>                     // fprintf(), printf()
+#include <stdlib.h>					   // exit()
+#include <sys/sysmacros.h>			   // major(), minor()
+// Local includes
+#define SKID_DEBUG                     // The DEBUG output is doing double duty as test output
+#include "skid_debug.h"                // PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_metadata_read.h"   // get_*_time()
+#include "skid_file_metadata_write.h"  // set_atime_now()
+
+
+/*
+ *	skid_file_metadata_read's get_*_time() functions generally follow this behavior:
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to fetch the time for.
+ *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *
+ *  Returns:
+ *		The time, on success.  0 on error, and errnum is set.
+ */
+typedef time_t (*GetTime)(const char *pathname, int *errnum);
+
+
+/*
+ *  Description:
+ *		Print the human readable atime, ctime, and mtime for pathname.
+ *      
+ *  Args:
+ *      pathname: The path to fetch times for.
+ *      
+ *  Returns:
+ *      On success, 0.  Errno or -1 on failure.
+ */
+int print_all_times(const char *pathname);
+
+
+/*
+ *  Description:
+ *		Call get_time_func(), translate the result into a human-readable string, and print results.
+ *      
+ *  Args:
+ *      get_time_func: Function pointer to a get_*_time() function.
+ *		func_type: The answer to "...pathname's _____ is..." (e.g., access, change, modification)
+ *      pathname: The path to fetch a time for.
+ *      
+ *  Returns:
+ *      On success, 0.  Errno or -1 on failure.
+ */
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname);
+
+
+int main(int argc, char *argv[])
+{
+	// LOCAL VARIABLES
+	int exit_code = 0;               // Store errno and/or results here
+	char *pathname = NULL;           // Get this from argv[1]
+
+	// INPUT VALIDATION
+	if (argc != 2)
+	{
+	   fprintf(stderr, "Usage: %s <pathname>\n", argv[0]);
+	   exit_code = EINVAL;
+	}
+	else
+	{
+		pathname = argv[1];
+	}
+
+	// GET IT
+	// Before
+	if (!exit_code)
+	{
+		puts("BEFORE");
+		exit_code = print_all_times(pathname);
+	}
+	// Set time
+	if (!exit_code)
+	{
+		exit_code = set_atime_now(pathname, false);
+	}
+	// After
+	if (!exit_code)
+	{
+		puts("AFTER");
+		exit_code = print_all_times(pathname);
+	}
+
+	// DONE
+	exit(exit_code);
+}
+
+
+int print_all_times(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int result = 0;  // Store errno and/or results here
+
+	// GET IT
+	// Access Time (atime)
+	if (!result)
+	{
+		result = print_formatted_time(get_access_time, "access", pathname);
+	}
+	// Change Time (ctime)
+	if (!result)
+	{
+		result = print_formatted_time(get_change_time, "change", pathname);
+	}
+	// Modification Time (mtime)
+	if (!result)
+	{
+		result = print_formatted_time(get_mod_time, "modification", pathname);
+	}
+
+	// DONE
+	return result;
+}
+
+
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname)
+{
+	// LOCAL VARIABLES
+	int result = 0;              // Store errno and/or results here
+	time_t answer = 0;           // Return value from get_time_func()
+	char time_str[512] = { 0 };  // Temp storage buffer for human-readable time string
+
+	// INPUT VALIDATION
+	if (!get_time_func || !func_type || !(*func_type) || !pathname || !(*pathname))
+	{
+		result = EINVAL;  // Bad input
+	}
+
+	// PRINT IT
+	// Get the time
+	if (!result)
+	{
+		answer = (*get_time_func)(pathname, &result);
+	}
+	// Format the time
+	if (!result)
+	{
+		result = format_time(time_str, sizeof(time_str) - 1, answer);
+	}
+	// Print the time
+	if (!result)
+	{
+		printf("%s's %s time is: %s\n", pathname, func_type, time_str);
+	}
+
+	// DONE
+	return result;
+}

--- a/code/test/test_sfmw_set_ownership.c
+++ b/code/test/test_sfmw_set_ownership.c
@@ -1,0 +1,128 @@
+/*
+ *	Manually test skid_file_metadata_write.h's set_ownership() functions.
+ *	The commands below will set set the ownership to your current UID and GID.
+ *	Adjust the values as necessary.
+ *
+ *	Copy/paste the following...
+
+./code/dist/test_sfmw_set_ownership.bin ./code/test/test_input/ `id -u` `id -g`                  # Directory
+./code/dist/test_sfmw_set_ownership.bin ./code/test/test_input/regular_file.txt `id -u` `id -g`  # Regular file
+
+ *
+ */
+
+// Standard includes
+#include <errno.h>                     // EINVAL
+#include <stdio.h>                     // fprintf(), printf()
+#include <stdlib.h>					   // exit()
+#include <sys/sysmacros.h>			   // major(), minor()
+// Local includes
+#define SKID_DEBUG                     // The DEBUG output is doing double duty as test output
+#include "skid_debug.h"                // PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_metadata_read.h"   // get_*_time()
+#include "skid_file_metadata_write.h"  // set_ownership()
+
+
+/*
+ *  Description:
+ *		Print the UID and GID for pathname.
+ *      
+ *  Args:
+ *      pathname: The path to fetch the IDs for.
+ *      
+ *  Returns:
+ *      On success, 0.  Errno or -1 on failure.
+ */
+int print_all_ids(const char *pathname);
+
+
+int main(int argc, char *argv[])
+{
+	// LOCAL VARIABLES
+	int exit_code = 0;              // Store errno and/or results here
+	char *pathname = NULL;          // Get this from argv[1]
+	uid_t new_uid = 0;              // Converted UID argument value
+	gid_t new_gid = 0;              // Converted GID argument value
+	bool follow_sym_links = false;  // Follow symbolic links
+
+	// INPUT VALIDATION
+	if (argc != 4)
+	{
+	   fprintf(stderr, "Usage: %s <pathname> <new_UID> <new_GID>\n"
+	   	       "NOTE: Use -1 as an ID value to skip it.\n", argv[0]);
+	   exit_code = EINVAL;
+	}
+	else
+	{
+		pathname = argv[1];
+		new_uid = atoi(argv[2]);
+		new_gid = atoi(argv[3]);
+	}
+
+	// GET IT
+	// Before
+	if (!exit_code)
+	{
+		puts("BEFORE");
+		exit_code = print_all_ids(pathname);
+	}
+	// Set time
+	if (!exit_code)
+	{
+		exit_code = set_ownership(pathname, new_uid, new_gid, follow_sym_links);
+		if (exit_code)
+		{
+			PRINT_ERROR(The call to set_ownership() failed);
+			PRINT_ERRNO(exit_code);
+		}
+	}
+	// After
+	if (!exit_code)
+	{
+		puts("AFTER");
+		exit_code = print_all_ids(pathname);
+	}
+
+	// DONE
+	exit(exit_code);
+}
+
+
+int print_all_ids(const char *pathname)
+{
+	// LOCAL VARIABLES
+	int result = 0;  	 // Store errno and/or results here
+	uid_t curr_uid = 0;  // Current UID
+	gid_t curr_gid = 0;  // Current GID
+
+	// GET IT
+	// UID
+	if (!result)
+	{
+		curr_uid = get_owner(pathname, &result);
+		if (result)
+		{
+			PRINT_ERROR(The call to get_owner() failed);
+			PRINT_ERRNO(result);
+		}
+	}
+	// GID
+	if (!result)
+	{
+		curr_gid = get_group(pathname, &result);
+		if (result)
+		{
+			PRINT_ERROR(The call to get_group() failed);
+			PRINT_ERRNO(result);
+		}
+	}
+
+	// PRINT IT
+	if (!result)
+	{
+		printf("%s Ownership:\tUID=%u   GID=%u\n", pathname, curr_uid, curr_gid);
+	}
+
+	// DONE
+	return result;
+}

--- a/code/test/test_sfmw_set_ownership.c
+++ b/code/test/test_sfmw_set_ownership.c
@@ -29,11 +29,12 @@
  *      
  *  Args:
  *      pathname: The path to fetch the IDs for.
+ *		follow_sym_links: Follow symbolic links.
  *      
  *  Returns:
  *      On success, 0.  Errno or -1 on failure.
  */
-int print_all_ids(const char *pathname);
+int print_all_ids(const char *pathname, bool follow_sym_links);
 
 
 int main(int argc, char *argv[])
@@ -64,7 +65,7 @@ int main(int argc, char *argv[])
 	if (!exit_code)
 	{
 		puts("BEFORE");
-		exit_code = print_all_ids(pathname);
+		exit_code = print_all_ids(pathname, follow_sym_links);
 	}
 	// Set time
 	if (!exit_code)
@@ -80,7 +81,7 @@ int main(int argc, char *argv[])
 	if (!exit_code)
 	{
 		puts("AFTER");
-		exit_code = print_all_ids(pathname);
+		exit_code = print_all_ids(pathname, follow_sym_links);
 	}
 
 	// DONE
@@ -88,7 +89,7 @@ int main(int argc, char *argv[])
 }
 
 
-int print_all_ids(const char *pathname)
+int print_all_ids(const char *pathname, bool follow_sym_links)
 {
 	// LOCAL VARIABLES
 	int result = 0;  	 // Store errno and/or results here
@@ -99,7 +100,7 @@ int print_all_ids(const char *pathname)
 	// UID
 	if (!result)
 	{
-		curr_uid = get_owner(pathname, &result);
+		curr_uid = get_owner(pathname, &result, follow_sym_links);
 		if (result)
 		{
 			PRINT_ERROR(The call to get_owner() failed);
@@ -109,7 +110,7 @@ int print_all_ids(const char *pathname)
 	// GID
 	if (!result)
 	{
-		curr_gid = get_group(pathname, &result);
+		curr_gid = get_group(pathname, &result, follow_sym_links);
 		if (result)
 		{
 			PRINT_ERROR(The call to get_group() failed);

--- a/code/test/test_sfmw_set_times.c
+++ b/code/test/test_sfmw_set_times.c
@@ -1,0 +1,182 @@
+/*
+ *	Manually test skid_file_metadata_write.h's set_times() functions.
+ *	The second argument is what the atime and mtime timestamps will be changed to.  Specifically,
+ *	it is represented as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+ *	(See: time(2))
+ *
+ *	Copy/paste the following...
+
+./code/dist/test_sfmw_set_times.bin ./code/test/test_input/ 1712946852                  # Directory
+./code/dist/test_sfmw_set_times.bin ./code/test/test_input/regular_file.txt 1712946852  # Regular file
+
+ *
+ *	NOTE: Adding 1712946852 seconds to epoch time should result in 4/12/2024, 1:34:12 PM
+ */
+
+// Standard includes
+#include <errno.h>                     // EINVAL
+#include <stdio.h>                     // fprintf(), printf()
+#include <stdlib.h>					   // exit()
+#include <sys/sysmacros.h>			   // major(), minor()
+// Local includes
+#define SKID_DEBUG                     // The DEBUG output is doing double duty as test output
+#include "skid_debug.h"                // PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_metadata_read.h"   // get_*_time()
+#include "skid_file_metadata_write.h"  // set_times()
+
+
+/*
+ *	skid_file_metadata_read's get_*_time() functions generally follow this behavior:
+ *
+ *  Args:
+ *      pathname: Absolute or relative pathname to fetch the time for.
+ *      errnum: [Out] Stores the first errno value encountered here.  Set to 0 on success.
+ *		follow_sym: If false, uses lstat() for symlinks.
+ *
+ *  Returns:
+ *		The time, on success.  0 on error, and errnum is set.
+ */
+typedef time_t (*GetTime)(const char *pathname, int *errnum, bool follow_sym);
+
+
+/*
+ *  Description:
+ *		Print the human readable atime, ctime, and mtime for pathname.
+ *      
+ *  Args:
+ *      pathname: The path to fetch times for.
+ *		follow_sym: If true, follows symlinks to evaluate the target.
+ *      
+ *  Returns:
+ *      On success, 0.  Errno or -1 on failure.
+ */
+int print_all_times(const char *pathname, bool follow_sym);
+
+
+/*
+ *  Description:
+ *		Call get_time_func(), translate the result into a human-readable string, and print results.
+ *      
+ *  Args:
+ *      get_time_func: Function pointer to a get_*_time() function.
+ *		func_type: The answer to "...pathname's _____ is..." (e.g., access, change, modification)
+ *      pathname: The path to fetch a time for.
+ *		follow_sym: If true, follows symlinks to evaluate the target.
+ *      
+ *  Returns:
+ *      On success, 0.  Errno or -1 on failure.
+ */
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname,
+	                     bool follow_sym);
+
+
+int main(int argc, char *argv[])
+{
+	// LOCAL VARIABLES
+	int exit_code = 0;              // Store errno and/or results here
+	char *pathname = NULL;          // Get this from argv[1]
+	time_t num_secs = 0;            // Converted "number of seconds" argument value
+	bool follow_sym_links = false;  // Follow symbolic links
+
+	// INPUT VALIDATION
+	if (argc != 3)
+	{
+	   fprintf(stderr, "Usage: %s <pathname> <num_of_seconds>\n", argv[0]);
+	   exit_code = EINVAL;
+	}
+	else
+	{
+		pathname = argv[1];
+		num_secs = atoi(argv[2]);
+	}
+
+	// GET IT
+	// Before
+	if (!exit_code)
+	{
+		puts("BEFORE");
+		exit_code = print_all_times(pathname, follow_sym_links);
+	}
+	// Set time
+	if (!exit_code)
+	{
+		exit_code = set_times(pathname, follow_sym_links, num_secs, 0);
+		if (exit_code)
+		{
+			PRINT_ERROR(The call to set_times() failed);
+			PRINT_ERRNO(exit_code);
+		}
+	}
+	// After
+	if (!exit_code)
+	{
+		puts("AFTER");
+		exit_code = print_all_times(pathname, follow_sym_links);
+	}
+
+	// DONE
+	exit(exit_code);
+}
+
+
+int print_all_times(const char *pathname, bool follow_sym)
+{
+	// LOCAL VARIABLES
+	int result = 0;  // Store errno and/or results here
+
+	// GET IT
+	// Access Time (atime)
+	if (!result)
+	{
+		result = print_formatted_time(get_access_time, "access", pathname, follow_sym);
+	}
+	// Change Time (ctime)
+	if (!result)
+	{
+		result = print_formatted_time(get_change_time, "change", pathname, follow_sym);
+	}
+	// Modification Time (mtime)
+	if (!result)
+	{
+		result = print_formatted_time(get_mod_time, "modification", pathname, follow_sym);
+	}
+
+	// DONE
+	return result;
+}
+
+
+int print_formatted_time(GetTime get_time_func, const char *func_type, const char *pathname,
+	                     bool follow_sym)
+{
+	// LOCAL VARIABLES
+	int result = 0;              // Store errno and/or results here
+	time_t answer = 0;           // Return value from get_time_func()
+	char time_str[512] = { 0 };  // Temp storage buffer for human-readable time string
+
+	// INPUT VALIDATION
+	if (!get_time_func || !func_type || !(*func_type) || !pathname || !(*pathname))
+	{
+		result = EINVAL;  // Bad input
+	}
+
+	// PRINT IT
+	// Get the time
+	if (!result)
+	{
+		answer = (*get_time_func)(pathname, &result, follow_sym);
+	}
+	// Format the time
+	if (!result)
+	{
+		result = format_time(time_str, sizeof(time_str) - 1, answer);
+	}
+	// Print the time
+	if (!result)
+	{
+		printf("%s's %s time is: %s\n", pathname, func_type, time_str);
+	}
+
+	// DONE
+	return result;
+}


### PR DESCRIPTION
1. Created a `skid_file_metadata_write` library that defined functionality to modify the following:
    - File mode (permissions)
    - File owner
    - File group
    - Access time
    - Modification time
2. Updated the build system
    - Dialed up the quality reporting for the compiler (e.g., enabled errors on all warnings)
4. Wrote 175 unit tests
5. Wrote manual test binaries
6. Refactored the devops code
    - Refactored the key data type of the alloc/free memory functions to `void**`
    - Added `get_shell_compatible_gid()`
    - Added `get_shell_my_gid()`
    - Added `get_shell_my_uid()`
    - Added `get_shell_my_username()`
    - Added `get_shell_user_gid()`
    - Added `get_shell_user_uid()`
    - Added `is_path_there()`
    - Added `micro_sleep()`
    - Added `read_a_file()`
    - Added `run_command_append()`
    - Added `set_shell_perms()`
8. Modified legacy production code:
    - Added standardized "header" macros to `SKID_DEBUG.h`
    - Added symbolic link support for: `get_access_time()`, `get_change_time()`, `get_group()`, `get_mod_time()`, `get_owner()`
    - Added `get_access_time_nsecs()`, `get_access_timestamp()`, `get_change_timestamp()`, `get_mod_time_nsecs()`, `get_mod_timestamp()`
10. Updated the `README.md`
    - Added shell script to auto-calculate how many Check-based unit tests have been implemented
    - Added some key links to Check library documentation