### PR TITLE
SKID-15: Fix brittle DEBUG header dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ code/test/test_output/
 
 # Repo files
 code/test/test_input/sym_link.txt
+*.bak
 

--- a/code/include/skid_dir_operations.h
+++ b/code/include/skid_dir_operations.h
@@ -6,6 +6,7 @@
 #endif  /* _DEFAULT_SOURCE */
 
 #include <stdbool.h>    // bool, false, true
+#include <stddef.h>		// size_t
 #include <sys/stat.h>	// mode_t
 
 /*

--- a/code/include/skid_memory.h
+++ b/code/include/skid_memory.h
@@ -1,6 +1,8 @@
 #ifndef __SKID_MEMORY__
 #define __SKID_MEMORY__
 
+#include <stddef.h>		// size_t
+
 /*
  *	Description:
  *		Allocate a zeroized array in heap memory.

--- a/code/src/skid_dir_operations.c
+++ b/code/src/skid_dir_operations.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to create, remove, and parse Linux directories.
  */
 
-#define SKID_DEBUG						// Enable DEBUG logging
+// #define SKID_DEBUG						// Enable DEBUG logging
 
 #include "skid_debug.h"				  	// PRINT_ERRNO()
 #include "skid_dir_operations.h"		// _DEFAULT_SOURCE, delete_dir()

--- a/code/src/skid_dir_operations.c
+++ b/code/src/skid_dir_operations.c
@@ -12,6 +12,7 @@
 #include <dirent.h>						// closedir(), opendir(), readdir(), struct dirent
 #include <errno.h>						// errno
 #include <stdint.h>						// SIZE_MAX
+#include <string.h>						// strncpy()
 #include <unistd.h>						// link(), rmdir(), symlink()
 #ifndef SKID_ARRAY_SIZE
 // #define SKID_ARRAY_SIZE 1024			// Starting num of indices in read_dir_contents()'s array

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -3,7 +3,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L		  	// Expose utimensat()
-// #define SKID_DEBUG                    // Enable DEBUG logging
+// #define SKID_DEBUG                      // Enable DEBUG logging
 
 #include <fcntl.h>					  	// AT_FDCWD
 #include "skid_debug.h"				  	// PRINT_ERRNO()

--- a/code/src/skid_file_operations.c
+++ b/code/src/skid_file_operations.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>						// errno
 #include <stdio.h>						// fclose(), fopen(), fread(), fwrite()
+#include <string.h>						// strlen()
 #include <unistd.h>						// unlink()
 #include "skid_debug.h"					// PRINT_ERROR()
 #include "skid_file_metadata_read.h"	// get_size()
@@ -27,8 +28,11 @@
  *
  *	Args:
  *		stream: A pointer to a file pointer.
+ *
+ *	Returns:
+ *		0 on success, errno on failure.
  */
-void close_stream(FILE **stream);
+int close_stream(FILE **stream);
 
 /*
  *  Description:
@@ -265,10 +269,10 @@ char *read_file(const char *filename, int *errnum)
 /**************************************************************************************************/
 
 
-void close_stream(FILE **stream)
+int close_stream(FILE **stream)
 {
 	// LOCAL VARIABLES
-	int errnum = ENOERR;      // Store errno values here
+	int errnum = ENOERR;  // Store errno values here
 
 	// INPUT VALIDATION
 	if (stream && *stream)
@@ -283,7 +287,7 @@ void close_stream(FILE **stream)
 	}
 
 	// DONE
-	return;
+	return errnum;
 }
 
 
@@ -305,7 +309,9 @@ int read_stream(FILE *stream, char *contents, size_t buff_size)
 {
 	// LOCAL VARIABLES
 	int result = ENOERR;    // The results of validation
+#ifdef SKID_DEBUG
 	size_t bytes_read = 0;  // Return value from fread()
+#endif  /* SKID_DEBUG */
 
 	// INPUT VALIDATION
 	if (!stream || !contents || buff_size <= 0)
@@ -316,7 +322,11 @@ int read_stream(FILE *stream, char *contents, size_t buff_size)
 	// READ IT
 	if (ENOERR == result)
 	{
+#ifdef SKID_DEBUG
 		bytes_read = fread(contents, buff_size, 1, stream);
+#else
+		fread(contents, buff_size, 1, stream);
+#endif  /* SKID_DEBUG */
 		if (feof(stream))
 		{
 			// Great news.  Continue...

--- a/code/src/skid_file_operations.c
+++ b/code/src/skid_file_operations.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to create, delete, and empty Linux files.
  */
 
-#define SKID_DEBUG					// Enable DEBUG logging
+// #define SKID_DEBUG					// Enable DEBUG logging
 
 #include <errno.h>						// errno
 #include <stdio.h>						// fclose(), fopen(), fread(), fwrite()

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>						// errno
 #include <stdlib.h>						// calloc()
+#include <string.h>						// strlen()
 #include "skid_debug.h"				  	// PRINT_ERRNO()
 #include "skid_memory.h"				// free_skid_string()
 #ifndef ENOERR

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to allocate and free memory on behalf of SKID.
  */
 
-#define SKID_DEBUG						// Enable DEBUG logging
+// #define SKID_DEBUG						// Enable DEBUG logging
 
 #include <errno.h>						// errno
 #include <stdlib.h>						// calloc()

--- a/code/src/skid_network.c
+++ b/code/src/skid_network.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to help manager server/clients.
  */
 
-#define SKID_DEBUG						// Enable DEBUG logging
+// #define SKID_DEBUG						// Enable DEBUG logging
 
 #include "skid_file_descriptors.h"		// close_fd()
 #include "skid_debug.h"					// PRINT_ERRNO(), PRINT_ERROR()

--- a/code/src/skid_network.c
+++ b/code/src/skid_network.c
@@ -12,6 +12,7 @@
 #include "skid_validation.h"			// validate_skid_err(), validate_skid_sockfd()
 #include <arpa/inet.h>					// inet_ntop()
 #include <errno.h>						// EINVAL
+#include <string.h>						// strlen()
 #include <unistd.h>						// close()
 
 #ifdef SKID_DEBUG

--- a/code/src/skid_signal_handlers.c
+++ b/code/src/skid_signal_handlers.c
@@ -9,6 +9,7 @@
 #include "skid_signals.h"				// SignalHandler
 #include "skid_signal_handlers.h"		// Externed atomic variables
 #include <errno.h>						// EINVAL
+#include <stddef.h>						// NULL
 #include <sys/types.h>					// pid_t
 #include <sys/wait.h>					// waitpid()
 

--- a/code/src/skid_signal_handlers.c
+++ b/code/src/skid_signal_handlers.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to help automate signal handling.
  */
 
-#define SKID_DEBUG						// Enable DEBUG logging
+// #define SKID_DEBUG						// Enable DEBUG logging
 
 #include "skid_debug.h"				  	// PRINT_ERRNO(), PRINT_ERROR()
 #include "skid_macros.h"				// SignalHandler

--- a/code/src/skid_signals.c
+++ b/code/src/skid_signals.c
@@ -17,6 +17,7 @@
 #include "skid_signals.h"				// Signal MACROs, SignalHandler
 #include "skid_validation.h"			// validate_skid_err()
 #include <errno.h>						// EINVAL
+#include <string.h>						// memset()
 #include <sys/types.h>					// pid_t
 #include <sys/wait.h>					// waitpid()
 

--- a/code/src/skid_signals.c
+++ b/code/src/skid_signals.c
@@ -9,7 +9,7 @@
 #define _XOPEN_SOURCE_EXTENDED			// Expose the TRAP_* signal code macros
 #endif  /* _XOPEN_SOURCE_EXTENDED */
 
-#define SKID_DEBUG						// Enable DEBUG logging
+// #define SKID_DEBUG						// Enable DEBUG logging
 
 #include "skid_debug.h"				  	// PRINT_ERRNO(), PRINT_ERROR()
 #include "skid_macros.h"				// NOERR

--- a/code/src/skid_validation.c
+++ b/code/src/skid_validation.c
@@ -7,6 +7,7 @@
 #include "skid_debug.h"				  	// PRINT_ERRNO(), PRINT_ERROR()
 #include "skid_validation.h"			// ENOERR
 #include <errno.h>						// EINVAL
+#include <stddef.h>						// NULL
 
 
 /**************************************************************************************************/

--- a/code/src/skid_validation.c
+++ b/code/src/skid_validation.c
@@ -2,7 +2,7 @@
  *	This library defines functionality to help automate validation.
  */
 
-#define SKID_DEBUG						// Enable DEBUG logging
+// #define SKID_DEBUG						// Enable DEBUG logging
 
 #include "skid_debug.h"				  	// PRINT_ERRNO(), PRINT_ERROR()
 #include "skid_validation.h"			// ENOERR

--- a/devops/scripts/1-3_export.sh
+++ b/devops/scripts/1-3_export.sh
@@ -50,7 +50,7 @@ date && \
 # 2. Runs the build system (which also executes the Check-based unit tests)
 make && echo && \
 # 3. Executes the unit tests with Valgrind
-for check_bin in $(ls code/dist/check_*.bin); do CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin; [[ $? -ne 0 ]] && break || continue; done && echo && \
+./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
 # 4. Counts the number of unit tests (by running them again)
 for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
 # 5. Misc.
@@ -66,9 +66,9 @@ run_manual_test_command "code/dist/test_ssh_handle_ext_read_queue_int.bin 10"
 printf "%s Extended Signal Handler: Translating signal codes %s\n" "$BOOKEND" "$BOOKEND"
 printf "Send the following command to speed this proccess up:\nkill -SIGUSR1 \`pidof test_ssh_handle_ext_signal_code.bin\`\n"
 run_manual_test_command "code/dist/test_ssh_handle_ext_signal_code.bin"
-# kill -SIGUSR1 `pidof test_ssh_handle_ext_signal_code.bin`
+# kill -s 10 `pidof test_ssh_handle_ext_signal_code.bin`
 # 3. Identifying the sending process
 printf "%s Extended Signal Handler: Identifying the sending process %s\n" "$BOOKEND" "$BOOKEND"
 printf "Send the following command to speed this proccess up:\nkill -SIGUSR2 \`pidof test_ssh_handle_ext_sending_process.bin\`\n"
 run_manual_test_command "code/dist/test_ssh_handle_ext_sending_process.bin"
-# kill -SIGUSR2 `pidof test_ssh_handle_ext_sending_process.bin`
+# kill -s 12 `pidof test_ssh_handle_ext_sending_process.bin`

--- a/devops/scripts/13-2_export.sh
+++ b/devops/scripts/13-2_export.sh
@@ -51,7 +51,7 @@ date && \
 # 2. Runs the build system (which also executes the Check-based unit tests)
 make && echo && \
 # 3. Executes the unit tests with Valgrind
-for check_bin in $(ls code/dist/check_*.bin); do CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin; [[ $? -ne 0 ]] && break || continue; done && echo && \
+./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
 # 4. Counts the number of unit tests (by running them again)
 for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
 # 5. Misc.

--- a/devops/scripts/13-4_export.sh
+++ b/devops/scripts/13-4_export.sh
@@ -79,7 +79,7 @@ date && \
 # 2. Runs the build system (which also executes the Check-based unit tests)
 make && echo && \
 # 3. Executes the unit tests with Valgrind
-for check_bin in $(ls code/dist/check_*.bin); do CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin; [[ $? -ne 0 ]] && break || continue; done && echo && \
+./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
 # 4. Counts the number of unit tests (by running them again)
 for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
 # 5. Misc.

--- a/devops/scripts/13-6_export.sh
+++ b/devops/scripts/13-6_export.sh
@@ -79,7 +79,7 @@ date && \
 # 2. Runs the build system (which also executes the Check-based unit tests)
 make && echo && \
 # 3. Executes the unit tests with Valgrind
-for check_bin in $(ls code/dist/check_*.bin); do CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin; [[ $? -ne 0 ]] && break || continue; done && echo && \
+./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
 # 4. Counts the number of unit tests (by running them again)
 for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
 # 5. Misc.

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -70,4 +70,8 @@ then
 fi
 
 # DONE
+if [[ $EXIT_CODE -eq 0 ]]
+then
+    echo -e "Done disabling SKID_DEBUG macro."
+fi
 exit $EXIT_CODE

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -72,6 +72,6 @@ fi
 # DONE
 if [[ $EXIT_CODE -eq 0 ]]
 then
-    echo -e "Done disabling SKID_DEBUG macro."
+    echo -e "\nDone disabling SKID_DEBUG macro.\n"
 fi
 exit $EXIT_CODE

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -34,6 +34,13 @@ then
             break
         fi
     done
+fi
+
+# 3. Check for changes
+if [[ `git status -s | wc -l` -ne 0 ]]
+then
+    echo -e "\nThe following files were modified:"
+    git status -s
     echo -e "\nTo undo these changes..."
     echo -e "\tgit restore $SRC_CODE_DIR/*$SRC_FILE_EXT"
     echo -e "\nTo commit these changes..."

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -64,14 +64,14 @@ then
     echo -e "\nTo undo these changes..."
     echo -e "\tgit restore $SRC_CODE_DIR/*$SRC_FILE_EXT"
     echo -e "\nTo commit these changes..."
-    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit"
-    echo -e "\nThe original files have been backed up..."
-    echo -e "\tls $SRC_CODE_DIR/*$BAK_FILE_EXT"
+    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit\n"
 fi
 
 # DONE
 if [[ $EXIT_CODE -eq 0 ]]
 then
+    echo -e "\nThe original files have been backed up..."
+    echo -e "\tls $SRC_CODE_DIR/*$BAK_FILE_EXT"
     echo -e "\nDone disabling SKID_DEBUG macro.\n"
 fi
 exit $EXIT_CODE

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -11,6 +11,7 @@
 
 SRC_CODE_DIR="./code/src"  # Source code directory
 SRC_FILE_EXT=".c"          # Source code file extension
+UPDATE_COUNT=0             # Number of files updated
 EXIT_CODE=0                # Exit code var
 
 # 1. Verify the working tree is clean
@@ -32,12 +33,14 @@ then
         then
             echo -e "\nThe sed command has failed on $skid_source_file!\n"
             break
+        else
+            UPDATE_COUNT+=1
         fi
     done
 fi
 
 # 3. Check for changes
-if [[ `git status -s | wc -l` -ne 0 ]]
+if [[ `git status -s | wc -l` -ne 0 && $UPDATE_COUNT -gt 0 ]]
 then
     echo -e "\nThe following files were modified:"
     git status -s

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -19,7 +19,7 @@ EXIT_CODE=0                # Exit code var
 if [[ `git status -s | wc -l` -ne 0 ]]
 then
     echo -e "\nYour working tree does not appear to be clean.\nStage your commits and track your files before proceeding.\n"
-    EXIT_CODE=1
+    # EXIT_CODE=1
 fi
 
 # 2. Cleanup previously backed up files
@@ -41,10 +41,10 @@ fi
 # 3. Update all the production code
 if [[ $EXIT_CODE -eq 0 ]]
 then
-    for skid_source_file in $(ls $SRC_CODE_DIR/skid_*$SRC_FILE_EXT)
+    for skid_source_file in $(ls $SRC_CODE_DIR/skid_*$SRC_FILE_EXT 2> /dev/null)
     do
         # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
-        sed -i'./*$BAK_FILE_EXT' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
+        sed -i"./*$BAK_FILE_EXT" 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
         EXIT_CODE=$?
         if [[ $EXIT_CODE -ne 0 ]]
         then

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -19,7 +19,7 @@ EXIT_CODE=0                # Exit code var
 if [[ `git status -s | wc -l` -ne 0 ]]
 then
     echo -e "\nYour working tree does not appear to be clean.\nStage your commits and track your files before proceeding.\n"
-    # EXIT_CODE=1
+    EXIT_CODE=1
 fi
 
 # 2. Cleanup previously backed up files

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -10,6 +10,7 @@
 
 
 SRC_CODE_DIR="./code/src"  # Source code directory
+SRC_FILE_EXT=".c"          # Source code file extension
 EXIT_CODE=0                # Exit code var
 
 # 1. Verify the working tree is clean
@@ -22,7 +23,7 @@ fi
 # 2. Update all the production code
 if [[ $EXIT_CODE -eq 0 ]]
 then
-    for skid_source_file in $(ls $SRC_CODE_DIR/skid_*.c)
+    for skid_source_file in $(ls $SRC_CODE_DIR/skid_*$SRC_FILE_EXT)
     do
         # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
         sed -i'./*.bak' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
@@ -33,7 +34,10 @@ then
             break
         fi
     done
-    # TO DO: DON'T DO NOW... INCLUDE COPY/PASTE UNDO AND DO_IT() COMMANDS
+    echo -e "\nTo undo these changes..."
+    echo -e "\tgit restore $SRC_CODE_DIR/*$SRC_FILE_EXT"
+    echo -e "\nTo commit these changes..."
+    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit"
 fi
 
 # DONE

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -47,7 +47,7 @@ then
     echo -e "\nTo undo these changes..."
     echo -e "\tgit restore $SRC_CODE_DIR/*$SRC_FILE_EXT"
     echo -e "\nTo commit these changes..."
-    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit"
+    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit\n"
 fi
 
 # DONE

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script was made to automate the process of globally(?) disabling SKID's DEBUG mode
+# in the production code.
+#
+# EXIT CODE
+#   0 on success
+#   Non-zero value on error
+
+
+TEMP_RET=0                                                     # Temporary exit code var
+
+# TO DO: DON'T DO NOW... check for untracked files
+
+# Update all the production code
+for skid_source_file in $(ls code/src/skid_*.c)
+do
+    # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
+    sed -i'./*.bak' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
+    TEMP_RET=$?
+    if [[ $TEMP_RET -ne 0 ]]
+    then
+        echo -e "\nThe sed command has failed on $skid_source_file!\n"
+        break
+    fi
+done
+
+# DONE
+# TO DO: DON'T DO NOW... INCLUDE COPY/PASTE UNDO AND DO_IT() COMMANDS
+exit $TEMP_RET

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -5,26 +5,35 @@
 #
 # EXIT CODE
 #   0 on success
+#   1 if the working tree is not clean (see: git status -s)
 #   Non-zero value on error
 
 
-TEMP_RET=0                                                     # Temporary exit code var
+EXIT_CODE=0   # Exit code var
 
-# TO DO: DON'T DO NOW... check for untracked files
+# 1. Verify the working tree is clean
+if [[ `git status -s | wc -l` -ne 0 ]]
+then
+    echo -e "\nYour working tree does not appear to be clean.\nStage your commits and track your files before proceeding.\n"
+    EXIT_CODE=1
+fi
 
-# Update all the production code
-for skid_source_file in $(ls code/src/skid_*.c)
-do
-    # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
-    sed -i'./*.bak' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
-    TEMP_RET=$?
-    if [[ $TEMP_RET -ne 0 ]]
-    then
-        echo -e "\nThe sed command has failed on $skid_source_file!\n"
-        break
-    fi
-done
+# 2. Update all the production code
+if [[ $EXIT_CODE -eq 0 ]]
+then
+    for skid_source_file in $(ls code/src/skid_*.c)
+    do
+        # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
+        sed -i'./*.bak' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
+        EXIT_CODE=$?
+        if [[ $EXIT_CODE -ne 0 ]]
+        then
+            echo -e "\nThe sed command has failed on $skid_source_file!\n"
+            break
+        fi
+    done
+    # TO DO: DON'T DO NOW... INCLUDE COPY/PASTE UNDO AND DO_IT() COMMANDS
+fi
 
 # DONE
-# TO DO: DON'T DO NOW... INCLUDE COPY/PASTE UNDO AND DO_IT() COMMANDS
-exit $TEMP_RET
+exit $EXIT_CODE

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -9,7 +9,8 @@
 #   Non-zero value on error
 
 
-EXIT_CODE=0   # Exit code var
+SRC_CODE_DIR="./code/src"  # Source code directory
+EXIT_CODE=0                # Exit code var
 
 # 1. Verify the working tree is clean
 if [[ `git status -s | wc -l` -ne 0 ]]
@@ -21,7 +22,7 @@ fi
 # 2. Update all the production code
 if [[ $EXIT_CODE -eq 0 ]]
 then
-    for skid_source_file in $(ls code/src/skid_*.c)
+    for skid_source_file in $(ls $SRC_CODE_DIR/skid_*.c)
     do
         # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
         sed -i'./*.bak' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file

--- a/devops/scripts/disable_skid_debug.sh
+++ b/devops/scripts/disable_skid_debug.sh
@@ -11,6 +11,7 @@
 
 SRC_CODE_DIR="./code/src"  # Source code directory
 SRC_FILE_EXT=".c"          # Source code file extension
+BAK_FILE_EXT=".bak"        # Backup file extension
 UPDATE_COUNT=0             # Number of files updated
 EXIT_CODE=0                # Exit code var
 
@@ -21,13 +22,29 @@ then
     EXIT_CODE=1
 fi
 
-# 2. Update all the production code
+# 2. Cleanup previously backed up files
+if [[ $EXIT_CODE -eq 0 ]]
+then
+    for skid_backup_file in $(ls $SRC_CODE_DIR/*$BAK_FILE_EXT)
+    do
+        echo "Removing old backup file: $skid_backup_file"
+        rm --force $skid_backup_file
+        EXIT_CODE=$?
+        if [[ $EXIT_CODE -ne 0 ]]
+        then
+            echo "The rm command encountered an error deleting $skid_backup_file"
+            break
+        fi
+    done
+fi
+
+# 3. Update all the production code
 if [[ $EXIT_CODE -eq 0 ]]
 then
     for skid_source_file in $(ls $SRC_CODE_DIR/skid_*$SRC_FILE_EXT)
     do
         # Comments out the SKID_DEBUG macro, in place, after backing up the original source in-place
-        sed -i'./*.bak' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
+        sed -i'./*$BAK_FILE_EXT' 's/^#define SKID_DEBUG/\/\/ #define SKID_DEBUG/g' $skid_source_file
         EXIT_CODE=$?
         if [[ $EXIT_CODE -ne 0 ]]
         then
@@ -39,7 +56,7 @@ then
     done
 fi
 
-# 3. Check for changes
+# 4. Provide feedback on changes
 if [[ `git status -s | wc -l` -ne 0 && $UPDATE_COUNT -gt 0 ]]
 then
     echo -e "\nThe following files were modified:"
@@ -47,7 +64,9 @@ then
     echo -e "\nTo undo these changes..."
     echo -e "\tgit restore $SRC_CODE_DIR/*$SRC_FILE_EXT"
     echo -e "\nTo commit these changes..."
-    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit\n"
+    echo -e "\tgit add $SRC_CODE_DIR/*$SRC_FILE_EXT && git commit"
+    echo -e "\nThe original files have been backed up..."
+    echo -e "\tls $SRC_CODE_DIR/*$BAK_FILE_EXT"
 fi
 
 # DONE

--- a/devops/scripts/run_valgrind.sh
+++ b/devops/scripts/run_valgrind.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script was made to help standardize how Valgrind is used to validate the Check unit tests.
+# This script will "discover" ./code/dist/check_*.bin files and run each through Valgrind.
+# Ensure all Check unit test binaries are built because this script will *not* invoke the build
+# system.
+#
+# EXIT CODE
+#   0 on success
+#   1 if Valgrind found something
+
+
+TEMP_RET=0                                                     # Temporary exit code var
+
+# Executes the unit tests with Valgrind
+for check_bin in $(ls code/dist/check_*.bin)
+do
+    CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 $check_bin
+    TEMP_RET=$?
+    if [[ $TEMP_RET -ne 0 ]]
+    then
+        echo -e "\nValgrind appears to have found an issue with $check_bin!\n"
+        break  # Valgrind found something
+    fi
+done
+
+exit $TEMP_RET


### PR DESCRIPTION
Requirements

1. Write release procedures on a wiki page
2. Include procedures, instructions, and/or scripts to disable SKID_DEBUG, re-compile, and verify dependencies without
3. Fix any dependency issues that crop up

Fix Actions

1. Wrote it [here](https://github.com/hark130/sketchy-idea/wiki/Release-Procedures) (You gotta start somewhere)
2. I wrote a script to automate the execution of valgrind and disabling `SKID_DEBUG`.  They both work reasonably were.  They are both referenced on the wiki.
3. Fixed