### PR TITLE
13-3: dup, ioctl, and fcntl

### DIFF
--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -298,6 +298,6 @@ $(DIST_DIR)%$(OBJ_FILE_EXT): $(SRC_DIR)%$(SRC_FILE_EXT)
 
 # BESPOKE: redirect_bin_output.bin
 $(DIST_DIR)redirect_bin_output$(BIN_FILE_EXT): $(TEST_DIR)redirect_bin_output$(SRC_FILE_EXT) $(DIST_DIR)skid_file_descriptors$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_time$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
-	@echo "$@ needs $^"  # DEBUGGING
+	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Compiling bespoke binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -252,7 +252,7 @@ $(DIST_DIR)$(MAN_TEST_SDO_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SDO_PRE
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 
 # MANUAL TEST: Linking skid_file_control library manual test binaries
-$(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_control$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_descriptors$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
+$(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_control$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_descriptors$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_signals$(OBJ_FILE_EXT) $(DIST_DIR)skid_signal_handlers$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
 	@echo "    Linking manual test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -135,7 +135,7 @@ MAN_TEST_BIN_LIST = $(foreach MAN_TEST_BIN_FILE, $(MAN_TEST_BIN_FILES), $(DIST_D
 ### SPECIAL BUILT-IN TARGET NAMES ###
 
 # Do not treat these target names as file names
-.PHONY: _all _check_link _clean _clean_dist _compile _compilation _test _test_link _validate _validate_check _validate_gcc
+.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _test _test_link _validate _validate_check _validate_gcc
 
 # Don't auto-remove my object code
 .PRECIOUS: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE)) \
@@ -151,6 +151,10 @@ _all:
 	$(CALL_MAKE) compile
 	$(CALL_MAKE) test
 
+# Builds that don't conform to the prefix mnemonic used here (e.g., check_*, test_*)
+_bespoke_builds:
+	$(CALL_MAKE) $(DIST_DIR)redirect_bin_output$(BIN_FILE_EXT)
+
 # Link all of the Check unit test binaries
 _check_link: $(foreach CHECK_BIN_FILE, $(CHECK_BIN_FILES), $(DIST_DIR)$(CHECK_BIN_FILE))
 	@#echo "$@ needs $^"  # DEBUGGING
@@ -165,6 +169,7 @@ _clean_dist:
 _compile:
 	$(CALL_MAKE) _compilation
 	$(CALL_MAKE) _test_link
+	$(CALL_MAKE) _bespoke_builds
 	$(CALL_MAKE) _check_link
 
 _compilation: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE))
@@ -290,3 +295,9 @@ $(DIST_DIR)%$(OBJ_FILE_EXT): $(SRC_DIR)%$(SRC_FILE_EXT)
 	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Verifying $@"
 	@if ! [ -f $@ ] ; then echo "Unable to locate the $@ file" >&2 && exit 2 ; fi
+
+# BESPOKE: redirect_bin_output.bin
+$(DIST_DIR)redirect_bin_output$(BIN_FILE_EXT): $(TEST_DIR)redirect_bin_output$(SRC_FILE_EXT) $(DIST_DIR)skid_file_descriptors$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_time$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
+	@echo "$@ needs $^"  # DEBUGGING
+	@echo "    Compiling bespoke binary: $@"
+	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -251,6 +251,11 @@ $(DIST_DIR)$(MAN_TEST_SDO_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SDO_PRE
 	@echo "    Linking manual test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 
+# MANUAL TEST: Linking skid_file_control library manual test binaries
+$(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_control$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_descriptors$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
+	@echo "    Linking manual test binary: $@"
+	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
+
 # MANUAL TEST: Linking skid_file_link library manual test binaries
 $(DIST_DIR)$(MAN_TEST_SFL_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFL_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_link$(OBJ_FILE_EXT)
 	@echo "    Linking manual test binary: $@"

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -70,6 +70,8 @@ DEVOPS_CODE_LINK_DEPS = $(DIST_DIR)devops_code$(OBJ_FILE_EXT) \
 CHECK_PREFIX = check_
 # Prefix for all skid_dir_operations library unit tests
 CHECK_SDO_PREFIX = $(CHECK_PREFIX)sdo_
+# Prefix for all skid_file_control library unit tests
+CHECK_SFC_PREFIX = $(CHECK_PREFIX)sfc_
 # Prefix for all skid_file_link library unit tests
 CHECK_SFL_PREFIX = $(CHECK_PREFIX)sfl_
 # Prefix for all skid_file_metadata_read library unit tests
@@ -205,6 +207,12 @@ _validate_glibc:
 
 # CHECK: Linking skid_dir_operations library unit test binaries
 $(DIST_DIR)$(CHECK_SDO_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SDO_PREFIX)%$(OBJ_FILE_EXT) $(DEVOPS_CODE_LINK_DEPS)
+	@#echo "$@ needs $^"  # DEBUGGING
+	@echo "    Linking Check unit test binary: $@"
+	@$(CC) $(CFLAGS) -o $@ $^ $(CHECK_CC_ARGS)
+
+# CHECK: Linking skid_file_control library unit test binaries
+$(DIST_DIR)$(CHECK_SFC_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SFC_PREFIX)%$(OBJ_FILE_EXT) $(DEVOPS_CODE_LINK_DEPS) $(UNIT_TEST_LINK_DEPS) $(DIST_DIR)skid_file_control$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_descriptors$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
 	@#echo "$@ needs $^"  # DEBUGGING
 	@echo "    Linking Check unit test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ $(CHECK_CC_ARGS)

--- a/code/include/skid_file_control.h
+++ b/code/include/skid_file_control.h
@@ -1,0 +1,19 @@
+#ifndef __SKID_FILE_CONTROL__
+#define __SKID_FILE_CONTROL__
+
+#include <stdbool.h>    // bool, false, true
+
+/*
+ *  Description:
+ *      Determine if the FD_CLOEXEC bit is set for a file descriptor using fcntl().
+ *
+ *  Args:
+ *      fd: File descriptor to inspect.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      True if the FD_CLOEXEC, false otherwise.  Also, false on error and errnum is set.
+ */
+bool is_close_on_exec(int fd, int *errnum);
+
+#endif  /* __SKID_FILE_CONTROL__ */

--- a/code/include/skid_file_control.h
+++ b/code/include/skid_file_control.h
@@ -14,6 +14,7 @@
  *
  *  Returns:
  *      ENOERR, on success.  On failure, an errno value.
+ *      EAGAIN or EACCES may be returned for a failed lock.
  */
 int get_read_lock(int fd);
 
@@ -21,13 +22,15 @@ int get_read_lock(int fd);
  *  Description:
  *      Use fcntl() to obtain a write lock on the given file descriptor.  The write lock will
  *      encompass the file descriptor's entire contents.  Directly utilize fcntl(F_SETLK) for
- *      finer control (see: fcntl(2)).
+ *      finer control (see: fcntl(2)).  Also know that open(O_TRUNC) may bypass the write lock so
+ *      consider adding a file seal as well (see: fcntl(2)).
  *
  *  Args:
  *      fd: File descriptor to obtain a lock for.
  *
  *  Returns:
  *      ENOERR, on success.  On failure, an errno value.
+ *      EAGAIN or EACCES may be returned for a failed lock.
  */
 int get_write_lock(int fd);
 
@@ -61,6 +64,7 @@ bool is_close_on_exec(int fd, int *errnum);
  *
  *  Returns:
  *      Pointer to the heap-allocated buffer, on success.  NULL on error (check errnum for details).
+ *      EAGAIN or EACCES may be returned for a failed lock.
  */
 char *read_locked_fd(int fd, int *errnum);
 
@@ -91,6 +95,7 @@ int release_lock(int fd);
  *
  *  Returns:
  *      On success, zero is returned.  On error, errno is returned.
+ *      EAGAIN or EACCES may be returned for a failed lock.
  */
 int write_locked_fd(int fd, const char *msg);
 

--- a/code/include/skid_file_control.h
+++ b/code/include/skid_file_control.h
@@ -5,6 +5,34 @@
 
 /*
  *  Description:
+ *      Use fcntl() to obtain a read lock on the given file descriptor.  The read lock will
+ *      encompass the file descriptor's entire contents.  Directly utilize fcntl(F_SETLK) for
+ *      finer control (see: fcntl(2)).
+ *
+ *  Args:
+ *      fd: File descriptor to obtain a lock for.
+ *
+ *  Returns:
+ *      ENOERR, on success.  On failure, an errno value.
+ */
+int get_read_lock(int fd);
+
+/*
+ *  Description:
+ *      Use fcntl() to obtain a write lock on the given file descriptor.  The write lock will
+ *      encompass the file descriptor's entire contents.  Directly utilize fcntl(F_SETLK) for
+ *      finer control (see: fcntl(2)).
+ *
+ *  Args:
+ *      fd: File descriptor to obtain a lock for.
+ *
+ *  Returns:
+ *      ENOERR, on success.  On failure, an errno value.
+ */
+int get_write_lock(int fd);
+
+/*
+ *  Description:
  *      Determine if the FD_CLOEXEC bit is set for a file descriptor using fcntl().
  *
  *  Args:
@@ -15,5 +43,55 @@
  *      True if the FD_CLOEXEC, false otherwise.  Also, false on error and errnum is set.
  */
 bool is_close_on_exec(int fd, int *errnum);
+
+/*
+ *  Description:
+ *      Obtain a read lock on the file descriptor, read its contents into a
+ *      heap-allocated buffer, and release the read lock.  It is the caller's
+ *      responsibility to free the buffer with free_skid_mem().
+ *
+ *  Notes:
+ *      - get_read_lock() is used to obtain the lock.
+ *      - skid_file_descriptor's read_fd() is called to read the fd.
+ *      - release_lock() is used to release the lock.
+ *
+ *  Args:
+ *      fd: File descriptor to read from.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      Pointer to the heap-allocated buffer, on success.  NULL on error (check errnum for details).
+ */
+char *read_locked_fd(int fd, int *errnum);
+
+/*
+ *  Description:
+ *      Release all locks on the file descriptor utilizing fcntl().
+ *
+ *  Args:
+ *      fd: File descriptor to release locks on.
+ *
+ *  Returns:
+ *      ENOERR, on success.  On failure, an errno value.
+ */
+int release_lock(int fd);
+
+/*
+ *  Description:
+ *      Obtain a write lock on the file descriptor, write the string, and release the write lock.
+ *
+ *  Notes:
+ *      - get_write_lock() is used to obtain the lock.
+ *      - skid_file_descriptor's write_fd() is called to read the fd.
+ *      - release_lock() is used to release the lock.
+ *
+ *  Args:
+ *      fd: File descriptor to write to.
+ *      msg: The nul-terminated message to write to fd.
+ *
+ *  Returns:
+ *      On success, zero is returned.  On error, errno is returned.
+ */
+int write_locked_fd(int fd, const char *msg);
 
 #endif  /* __SKID_FILE_CONTROL__ */

--- a/code/include/skid_file_descriptors.h
+++ b/code/include/skid_file_descriptors.h
@@ -19,6 +19,20 @@
 int close_fd(int *fdp, bool quiet);
 
 /*
+ *  Description:
+ *      Open a file descriptor using open().
+ *
+ *  Args:
+ *      filename: A filename, relative or absolute, to open.
+ *      flags: The flags to pass to open() (see: open(2)).
+ *      mode: The mode to pass to open() (see: open(2)).
+ *
+ *  Returns:
+ *      On success, zero is returned.  On error, errno is returned.
+ */
+int open_fd(const char *filename, int flags, mode_t mode, int *errnum);
+
+/*
  *    Description:
  *        Read the contents of the file descriptor into a heap-allocated buffer.  It is the caller's
  *        responsibility to free the buffer with free_skid_mem().

--- a/code/include/skid_file_descriptors.h
+++ b/code/include/skid_file_descriptors.h
@@ -7,17 +7,33 @@
 #include "skid_macros.h"        // SKID_BAD_FD
 
 /*
- *    Description:
- *        Close a file descriptor and sets it to SKID_BAD_FD (if it was successfully closed).
+ *  Description:
+ *      Close a file descriptor and sets it to SKID_BAD_FD (if it was successfully closed).
  *
- *    Args:
- *        fdp: [In/Out] A pointer to a file descriptor to close.
- *        quiet: If true, silences all logging/debugging.
+ *  Args:
+ *      fdp: [In/Out] A pointer to a file descriptor to close.
+ *      quiet: If true, silences all logging/debugging.
  *
- *    Returns:
- *        On success, zero is returned.  On error, errno is returned.
+ *  Returns:
+ *      On success, zero is returned.  On error, errno is returned.
  */
 int close_fd(int *fdp, bool quiet);
+
+/*
+ *  Description:
+ *      Standardize how the dup2() system call is made.  The oldfd will be copied to the newfd.
+ *      If the newfd was already opened, it is silently closed before being reused.
+ *
+ *  Args:
+ *      oldfd: The file descriptor to copy.
+ *      newfd: The new file descriptor to use.
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      On success, the new file descriptor is returned.  On error, SKID_BAD_FD is returned
+ *      (check errnum for details).
+ */
+int call_dup2(int oldfd, int newfd, int *errnum);
 
 /*
  *  Description:

--- a/code/include/skid_file_descriptors.h
+++ b/code/include/skid_file_descriptors.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>            // bool, false, true
 #include <stddef.h>             // size_t
+#include <sys/types.h>          // mode_t
 #include "skid_macros.h"        // SKID_BAD_FD
 
 /*
@@ -26,23 +27,25 @@ int close_fd(int *fdp, bool quiet);
  *      filename: A filename, relative or absolute, to open.
  *      flags: The flags to pass to open() (see: open(2)).
  *      mode: The mode to pass to open() (see: open(2)).
+ *      errnum: [Out] Storage location for errno values encountered.
  *
  *  Returns:
- *      On success, zero is returned.  On error, errno is returned.
+ *      On success, the opened file descriptor is returned.  On error, SKID_BAD_FD is returned
+ *      (check errnum for details).
  */
 int open_fd(const char *filename, int flags, mode_t mode, int *errnum);
 
 /*
- *    Description:
- *        Read the contents of the file descriptor into a heap-allocated buffer.  It is the caller's
- *        responsibility to free the buffer with free_skid_mem().
+ *  Description:
+ *      Read the contents of the file descriptor into a heap-allocated buffer.  It is the caller's
+ *      responsibility to free the buffer with free_skid_mem().
  *
- *    Args:
- *        fd: File descriptor to read from.
- *        errnum: [Out] Storage location for errno values encountered.
+ *  Args:
+ *      fd: File descriptor to read from.
+ *      errnum: [Out] Storage location for errno values encountered.
  *
- *    Returns:
- *        Pointer to the heap-allocated buffer, on success.  NULL on error (check errnum for details).
+ *  Returns:
+ *      Pointer to the heap-allocated buffer, on success.  NULL on error (check errnum for details).
  */
 char *read_fd(int fd, int *errnum);
 

--- a/code/include/skid_file_descriptors.h
+++ b/code/include/skid_file_descriptors.h
@@ -1,9 +1,9 @@
 #ifndef __SKID_FILE_DESCRIPTORS__
 #define __SKID_FILE_DESCRIPTORS__
 
-#include <stdbool.h>        // bool, false, true
-#include <stddef.h>            // size_t
-#include "skid_macros.h"    // SKID_BAD_FD
+#include <stdbool.h>            // bool, false, true
+#include <stddef.h>             // size_t
+#include "skid_macros.h"        // SKID_BAD_FD
 
 /*
  *    Description:

--- a/code/include/skid_macros.h
+++ b/code/include/skid_macros.h
@@ -6,11 +6,42 @@
 #define __SKID_MACROS__
 
 /* GENERAL MACROS */
+#ifndef ENOERR
+    #define ENOERR ((int)0)  // Success value for errno
+#endif  /* ENOERR */
 #define SKID_BAD_FD (signed int)-1  // Use this to standardize "invalid" file descriptors
 #define SKID_MAX_SZ (~(size_t)0)    // Library's value for the maximum size_t value
-#ifndef ENOERR
-#define ENOERR ((int)0)  // Success value for errno
-#endif  /* ENOERR */
+
+#ifdef __GNUC__
+    #if defined(__x86_64__) || defined(__ppc64__)
+        #define ENV64BIT
+    #else
+        #define ENV32BIT
+    #endif
+#endif  /* __GNUC__ */
+
+/* FILE MACROS */
+#if define(PATH_MAX)
+    #define SKID_PATH_MAX PATH_MAX
+#elif defined(FILENAME_MAX)
+    #if defined(ENV64BIT)
+        #if FILENAME_MAX <= 4096
+            #define SKID_PATH_MAX FILENAME_MAX
+        #else
+            #define SKID_PATH_MAX 4096
+    #else
+        #if FILENAME_MAX <= 1024
+            #define SKID_PATH_MAX FILENAME_MAX
+        #else
+            #define SKID_PATH_MAX 1024
+    #endif  /* FILENAME_MAX */
+#else
+    #if defined(ENV64BIT)
+        #define SKID_PATH_MAX 4096
+    #else
+        #define SKID_PATH_MAX 1024
+    #endif
+#endif
 
 /* FILE METADATA MACROS */
 // You may use these macros with SKID mode_t arguments.

--- a/code/include/skid_macros.h
+++ b/code/include/skid_macros.h
@@ -21,7 +21,7 @@
 #endif  /* __GNUC__ */
 
 /* FILE MACROS */
-#if define(PATH_MAX)
+#if defined(PATH_MAX)
     #define SKID_PATH_MAX PATH_MAX
 #elif defined(FILENAME_MAX)
     #if defined(ENV64BIT)
@@ -29,11 +29,13 @@
             #define SKID_PATH_MAX FILENAME_MAX
         #else
             #define SKID_PATH_MAX 4096
+        #endif
     #else
         #if FILENAME_MAX <= 1024
             #define SKID_PATH_MAX FILENAME_MAX
         #else
             #define SKID_PATH_MAX 1024
+        #endif
     #endif  /* FILENAME_MAX */
 #else
     #if defined(ENV64BIT)

--- a/code/include/skid_macros.h
+++ b/code/include/skid_macros.h
@@ -9,7 +9,6 @@
 #ifndef ENOERR
     #define ENOERR ((int)0)  // Success value for errno
 #endif  /* ENOERR */
-#define SKID_BAD_FD (signed int)-1  // Use this to standardize "invalid" file descriptors
 #define SKID_MAX_SZ (~(size_t)0)    // Library's value for the maximum size_t value
 
 #ifdef __GNUC__
@@ -44,6 +43,27 @@
         #define SKID_PATH_MAX 1024
     #endif
 #endif
+
+/* FILE DESCRIPTOR MACROS */
+#define SKID_BAD_FD (signed int)-1  // Use this to standardize "invalid" file descriptors
+// SKID_STDIN_FD - File number of stdin.
+#ifdef STDIN_FILENO
+#define SKID_STDIN_FD STDIN_FILENO
+#else
+#define SKID_STDIN_FD 0
+#endif  /* SKID_STDIN_FD */
+// SKID_STDOUT_FD - File number of stdout.
+#ifdef STDOUT_FILENO
+#define SKID_STDOUT_FD STDOUT_FILENO
+#else
+#define SKID_STDOUT_FD 1
+#endif  /* SKID_STDOUT_FD */
+// SKID_STDERR_FD - File number of stderr.
+#ifdef STDERR_FILENO
+#define SKID_STDERR_FD STDERR_FILENO
+#else
+#define SKID_STDERR_FD 2
+#endif  /* SKID_STDERR_FD */
 
 /* FILE METADATA MACROS */
 // You may use these macros with SKID mode_t arguments.

--- a/code/include/skid_macros.h
+++ b/code/include/skid_macros.h
@@ -9,6 +9,9 @@
 #ifndef ENOERR
     #define ENOERR ((int)0)  // Success value for errno
 #endif  /* ENOERR */
+#ifndef NULL
+    #define NULL ((void *)0)  // Just in case it's not already defined
+#endif  /* NULL */
 #define SKID_MAX_SZ (~(size_t)0)    // Library's value for the maximum size_t value
 
 #ifdef __GNUC__

--- a/code/include/skid_signal_handlers.h
+++ b/code/include/skid_signal_handlers.h
@@ -49,7 +49,7 @@ typedef enum { Integer = 1, Pointer = 2 } QueueData_t;
 extern volatile sig_atomic_t skid_sig_hand_interrupted;  // Non-zero values indicate SIGINT handled
 extern volatile sig_atomic_t skid_sig_hand_data_int;     // Data (int)
 extern volatile sig_atomic_t skid_sig_hand_data_ptr;     // Data (void*)
-extern volatile sig_atomic_t skid_sig_hand_ext;           // Non-zero values indicate ext reporting
+extern volatile sig_atomic_t skid_sig_hand_ext;          // Non-zero values indicate ext reporting
 extern volatile sig_atomic_t skid_sig_hand_pid;          // PID of a sending process
 extern volatile sig_atomic_t skid_sig_hand_queue;        // QueueData_t indicates queue data
 extern volatile sig_atomic_t skid_sig_hand_sigcode;      // siginfo_t.si_code value (signal code)

--- a/code/include/skid_time.h
+++ b/code/include/skid_time.h
@@ -1,0 +1,53 @@
+#ifndef __SKID_TIME__
+#define __SKID_TIME__
+
+
+#define SKID_BAD_TIME_T ((time_t)-1)
+
+#include <time.h>               // time_t
+
+
+/*
+ *  Description:
+ *      Convert the Unix Epoch into local time inside a statically allocated tm struct.
+ *      This statically allocated struct might be overwritten by subsequent calls to any of the date
+ *      and time functions.  Do *not* call free() on the return value.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      Pointer to a statically allocated struct on success.  NULL on error (check errnum for details).
+ *      ETIMEDOUT is used to communicate indiscriminate errors.
+ */
+struct tm *get_localtime(int *errnum);
+
+/*
+ *  Description:
+ *      Fetch the Unix Epoch time.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      Number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC), on success.
+ *      SKID_BAD_TIME_T on error (check errnum for details).
+ */
+time_t get_unix_time(int *errnum);
+
+/*
+ *  Description:
+ *      Translate the current local time into a YYYYMMDD-HHMMSS string format.
+ *      The caller is responsible for using free_skid_mem() to free the return value.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *
+ *  Returns:
+ *      Heap-allocated, nul-terminated, datetime-stamp formatted string, on success.
+ *      NULL on error (check errnum for details).
+ */
+char *build_timestamp(int *errnum);
+
+
+#endif  /* __SKID_TIME__ */

--- a/code/include/skid_validation.h
+++ b/code/include/skid_validation.h
@@ -1,8 +1,8 @@
 #ifndef __SKID_VALIDATION__
 #define __SKID_VALIDATION__
 
-#include <stdbool.h>        // bool, false, true
-#include "skid_macros.h"    // ENOERR, SKID_BAD_FD
+#include <stdbool.h>            // bool, false, true
+#include "skid_macros.h"        // ENOERR, SKID_BAD_FD
 
 /*
  *  Description:

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -3,7 +3,7 @@
  */
 
 #ifndef SKID_DEBUG
-#define SKID_DEBUG                      // Enable DEBUG logging
+// #define SKID_DEBUG                      // Enable DEBUG logging
 #endif  /* SKID_DEBUG */
 
 #include <errno.h>                      // errno

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -56,6 +56,9 @@ bool is_close_on_exec(int fd, int *errnum)
     int retval = -1;             // Return value from fcntl()
     bool close_on_exec = false;  // Is the FD_CLOEXEC bit set?
 
+    // INPUT VALIDATION
+    result = validate_skid_err(errnum);
+
     // IS IT?
     // Get the file descriptor flags
     if (ENOERR == result)

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -49,6 +49,30 @@ int get_fd_flags(int *errnum, int fd);
 /**************************************************************************************************/
 
 
+int get_read_lock(int fd)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+
+    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+
+    // DONE
+    return result;
+}
+
+
+int get_write_lock(int fd)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+
+    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+
+    // DONE
+    return result;
+}
+
+
 bool is_close_on_exec(int fd, int *errnum)
 {
     // LOCAL VARIABLES
@@ -80,6 +104,47 @@ bool is_close_on_exec(int fd, int *errnum)
         *errnum = result;
     }
     return close_on_exec;
+}
+
+
+char *read_locked_fd(int fd, int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;   // Errno values
+    char *fd_cont = NULL;  // Content read from fd
+
+    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return fd_cont;
+}
+
+
+int release_lock(int fd)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+
+    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+
+    // DONE
+    return result;
+}
+
+
+int write_locked_fd(int fd, const char *msg)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+
+    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+
+    // DONE
+    return result;
 }
 
 

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>                      // fcntl(), FD_CLOEXEC
 #include <stdarg.h>                     // va_end(), va_list, va_start()
 #include "skid_debug.h"                 // PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_control.h"          // get_read_lock(), get_write_lock()
 #include "skid_macros.h"                // ENOERR, NULL
 #include "skid_validation.h"            // validate_skid_fd(), validate_skid_err()
 
@@ -32,6 +33,27 @@ int call_fcntl(int *errnum, int fd, int cmd, ... /* arg */ );
 
 /*
  *  Description:
+ *      Standardize the way this library calls fcntl(), with flock structs, and responds to errors.
+ *      This function always uses the same whence (SEEK_SET), start (0), and len (0) for the
+ *      flock struct to represent the entirety of the file descriptor.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *      fd: Open file descriptor to pass to fcntl().
+ *      cmd: The fnctl() operation to execute.  Must be a command that utilizes a struct flock
+ *          (e.g., F_SETLK, F_SETLKW, F_GETLK).  See: fcntl(2).
+ *      lock_type: The lock type to set in the flock struct.  (e.g., F_RDLCK, F_WRLCK, F_UNLCK)
+ *          See: fcntl(2).
+ *
+ *  Returns:
+ *      For a successful call, the return value depends on the operation.  See: fcntl(2).
+ *      On error, -1 is returned, and errnum is set appropriately.  The errno value
+ *      EOPNOTSUPP is used to indicate an unsupported cmd or lock_type.
+ */
+int call_fcntl_flock(int *errnum, int fd, int cmd, short lock_type);
+
+/*
+ *  Description:
  *      Get the file descriptor flags using fnctl().
  *
  *  Args:
@@ -53,8 +75,14 @@ int get_read_lock(int fd)
 {
     // LOCAL VARIABLES
     int result = ENOERR;  // Errno values
+    int retval = -1;      // Return value from fcntl()
 
-    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+    // GET IT
+    retval = call_fcntl_flock(&result, fd, F_SETLK, F_RDLCK);
+    if (-1 == retval)
+    {
+        FPRINTF_ERR("%s Failed to get a read lock on file descriptor '%d'\n", DEBUG_WARNG_STR, fd);
+    }
 
     // DONE
     return result;
@@ -65,8 +93,14 @@ int get_write_lock(int fd)
 {
     // LOCAL VARIABLES
     int result = ENOERR;  // Errno values
+    int retval = -1;      // Return value from fcntl()
 
-    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+    // GET IT
+    retval = call_fcntl_flock(&result, fd, F_SETLK, F_RDLCK);
+    if (-1 == retval)
+    {
+        FPRINTF_ERR("%s Failed to get a write lock on file descriptor '%d'\n", DEBUG_WARNG_STR, fd);
+    }
 
     // DONE
     return result;
@@ -110,10 +144,24 @@ bool is_close_on_exec(int fd, int *errnum)
 char *read_locked_fd(int fd, int *errnum)
 {
     // LOCAL VARIABLES
-    int result = ENOERR;   // Errno values
-    char *fd_cont = NULL;  // Content read from fd
+    int result = ENOERR;      // Errno values
+    int tmp_result = ENOERR;  // More errno values
+    char *fd_cont = NULL;     // Content read from fd
 
-    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+    // DO IT
+    // Lock the file descriptor
+    result = get_read_lock(fd);
+    // Read the file descriptor
+    if (ENOERR == result)
+    {
+        fd_cont = read_fd(fd, &result);
+        // Release the lock (regardless of read_fd()'s success)
+        tmp_result = release_lock(fd);
+        if (ENOERR == result)
+        {
+            result = tmp_result;  // Only report the first errno value
+        }
+    }
 
     // DONE
     if (NULL != errnum)
@@ -128,8 +176,14 @@ int release_lock(int fd)
 {
     // LOCAL VARIABLES
     int result = ENOERR;  // Errno values
+    int retval = -1;      // Return value from fcntl()
 
-    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+    // GET IT
+    retval = call_fcntl_flock(&result, fd, F_SETLK, F_UNLCK);
+    if (-1 == retval)
+    {
+        FPRINTF_ERR("%s Failed to release a lock on file descriptor '%d'\n", DEBUG_WARNG_STR, fd);
+    }
 
     // DONE
     return result;
@@ -139,9 +193,23 @@ int release_lock(int fd)
 int write_locked_fd(int fd, const char *msg)
 {
     // LOCAL VARIABLES
-    int result = ENOERR;  // Errno values
+    int result = ENOERR;      // Errno values
+    int tmp_result = ENOERR;  // More errno values
 
-    result = ENOSYS;  /* TO DO: DON'T DO NOW... IMPLEMENT THIS FUNCTION */
+    // DO IT
+    // Lock the file descriptor
+    result = get_write_lock(fd);
+    // Write to the file descriptor
+    if (ENOERR == result)
+    {
+        result = write_fd(fd, msg);
+        // Release the lock (regardless of write_fd()'s success)
+        tmp_result = release_lock(fd);
+        if (ENOERR == result)
+        {
+            result = tmp_result;  // Only report the first errno value
+        }
+    }
 
     // DONE
     return result;
@@ -184,6 +252,45 @@ int call_fcntl(int *errnum, int fd, int cmd, ... /* arg */ )
 
     // CLEANUP
     va_end(arg_ptr);
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return retval;
+}
+
+
+int call_fcntl_flock(int *errnum, int fd, int cmd, short lock_type)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+    int retval = -1;      // Return value from fcntl()
+    // Flock struct
+    struct flock fl = {
+        .l_type = lock_type,
+        .l_whence = SEEK_SET,
+        .l_start = 0,
+        .l_len = 0,
+    };
+
+    // INPUT VALIDATION
+    if (F_SETLK != cmd && F_SETLKW != cmd && F_GETLK != cmd)
+    {
+        result = EOPNOTSUPP;  // Unsupported cmd
+    }
+    else if (F_RDLCK != lock_type && F_WRLCK != lock_type && F_UNLCK != lock_type)
+    {
+        result = EOPNOTSUPP;  // Unsupported lock_type
+    }
+    // NOTE: call_fcntl() validates all other input
+
+    // CALL IT
+    if (ENOERR == result)
+    {
+        retval = call_fcntl(&result, fd, cmd, &fl);
+    }
 
     // DONE
     if (NULL != errnum)

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -109,7 +109,7 @@ int get_write_lock(int fd)
     int retval = -1;      // Return value from fcntl()
 
     // GET IT
-    retval = call_fcntl_flock(&result, fd, F_SETLK, F_RDLCK);
+    retval = call_fcntl_flock(&result, fd, F_SETLK, F_WRLCK);
     if (-1 == retval)
     {
         FPRINTF_ERR("%s Failed to get a write lock on file descriptor '%d'\n", DEBUG_WARNG_STR, fd);

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -7,6 +7,7 @@
 #include <stdarg.h>                     // va_end(), va_list, va_start()
 #include "skid_debug.h"                 // PRINT_ERRNO(), PRINT_ERROR()
 #include "skid_file_control.h"          // get_read_lock(), get_write_lock()
+#include "skid_file_descriptors.h"      // read_fd(), write_fd()
 #include "skid_macros.h"                // ENOERR, NULL
 #include "skid_validation.h"            // validate_skid_fd(), validate_skid_err()
 

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -232,6 +232,11 @@ int write_locked_fd(int fd, const char *msg)
         {
             result = tmp_result;  // Only report the first errno value
         }
+        else
+        {
+            PRINT_ERROR(The call to write_fd() failed);
+            PRINT_ERRNO(result);
+        }
     }
 
     // DONE
@@ -337,6 +342,11 @@ int call_fcntl_flock(int *errnum, int fd, int cmd, short lock_type)
     if (ENOERR == result)
     {
         retval = call_fcntl(&result, FlockPtr, fd, cmd, &fl);
+        if (ENOERR != result)
+        {
+            PRINT_ERROR(The call to call_fcntl() failed);
+            PRINT_ERRNO(result);
+        }
     }
 
     // DONE

--- a/code/src/skid_file_control.c
+++ b/code/src/skid_file_control.c
@@ -1,0 +1,144 @@
+/*
+ *      This library defines functionality to read and control file descriptors.
+ */
+
+#include <errno.h>                      // errno
+#include <fcntl.h>                      // fcntl(), FD_CLOEXEC
+#include <stdarg.h>                     // va_end(), va_list, va_start()
+#include "skid_debug.h"                 // PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_macros.h"                // ENOERR, NULL
+#include "skid_validation.h"            // validate_skid_fd(), validate_skid_err()
+
+
+/**************************************************************************************************/
+/********************************* PRIVATE FUNCTION DECLARATIONS **********************************/
+/**************************************************************************************************/
+
+/*
+ *  Description:
+ *      Standardize the way this library calls fcntl() and responds to errors.
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *      fd: Open file descriptor to pass to fcntl().
+ *      cmd: The fnctl() operation to execute.  See: fcntl(2).
+ *      ... Some fcntl() cmds take a third argument.  See: fcntl(2).
+ *
+ *  Returns:
+ *      For a successful call, the return value depends on the operation.  See: fcntl(2).
+ *      On error, -1 is returned, and errnum is set appropriately.
+ */
+int call_fcntl(int *errnum, int fd, int cmd, ... /* arg */ );
+
+/*
+ *  Description:
+ *      Get the file descriptor flags using fnctl().
+ *
+ *  Args:
+ *      errnum: [Out] Storage location for errno values encountered.
+ *      fd: Open file descriptor to pass to fcntl().
+ *
+ *  Returns:
+ *      On success, the value of file descriptor flags.  On error, -1 is returned,
+ *      and errnum is set appropriately.
+ */
+int get_fd_flags(int *errnum, int fd);
+
+/**************************************************************************************************/
+/********************************** PUBLIC FUNCTION DEFINITIONS ***********************************/
+/**************************************************************************************************/
+
+
+bool is_close_on_exec(int fd, int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;         // Errno values
+    int retval = -1;             // Return value from fcntl()
+    bool close_on_exec = false;  // Is the FD_CLOEXEC bit set?
+
+    // IS IT?
+    // Get the file descriptor flags
+    if (ENOERR == result)
+    {
+        retval = get_fd_flags(&result, fd);
+    }
+    // Check the FD_CLOEXEC bit
+    if (ENOERR == result)
+    {
+        if (FD_CLOEXEC == (FD_CLOEXEC & retval))
+        {
+            close_on_exec = true;
+        }
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return close_on_exec;
+}
+
+
+/**************************************************************************************************/
+/********************************** PRIVATE FUNCTION DEFINITIONS **********************************/
+/**************************************************************************************************/
+
+
+int call_fcntl(int *errnum, int fd, int cmd, ... /* arg */ )
+{
+    // LOCAL VARIABLES
+    va_list arg_ptr;
+    int result = ENOERR;  // Errno values
+    int retval = -1;      // Return value from fcntl()
+
+    // SETUP
+    va_start(arg_ptr, cmd);
+
+    // INPUT VALIDATION
+    result = validate_skid_err(errnum);
+    if (ENOERR == result)
+    {
+        result = validate_skid_fd(fd);
+    }
+
+    // CALL IT
+    if (ENOERR == result)
+    {
+        retval = fcntl(fd, cmd, arg_ptr);
+        if (-1 == retval)
+        {
+            result = errno;
+            PRINT_ERROR(The call to fcntl() failed);
+            PRINT_ERRNO(result);
+        }
+    }
+
+    // CLEANUP
+    va_end(arg_ptr);
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return retval;
+}
+
+
+int get_fd_flags(int *errnum, int fd)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+    int retval = -1;      // Return value from fcntl()
+
+    // GET IT
+    retval = call_fcntl(&result, fd, F_GETFD);
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return retval;
+}

--- a/code/src/skid_file_descriptors.c
+++ b/code/src/skid_file_descriptors.c
@@ -146,6 +146,48 @@ int close_fd(int *fdp, bool quiet)
 }
 
 
+int call_dup2(int oldfd, int newfd, int *errnum)
+{
+    // LOCAL VARIABLES
+    int fd = SKID_BAD_FD;  // File descriptor
+    int results = ENOERR;  // Errno value
+
+    // INPUT VALIDATION
+    // oldfd
+    results = validate_skid_fd(oldfd);
+    // newfd
+    if (ENOERR == results)
+    {
+        results = validate_skid_fd(newfd);
+    }
+    // errnum
+    if (ENOERR == results)
+    {
+        results = validate_skid_err(errnum);
+    }
+
+    // CALL IT
+    if (ENOERR == results)
+    {
+        fd = dup2(oldfd, newfd);
+        if (fd < 0)
+        {
+            results = errno;
+            fd = SKID_BAD_FD;
+            PRINT_ERROR(The call to dup2() failed);
+            PRINT_ERRNO(results);
+        }
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = results;
+    }
+    return fd;
+}
+
+
 int open_fd(const char *filename, int flags, mode_t mode, int *errnum)
 {
     // LOCAL VARIABLES

--- a/code/src/skid_file_descriptors.c
+++ b/code/src/skid_file_descriptors.c
@@ -2,12 +2,13 @@
  *    This library defines functionality to manage Linux file descriptors.
  */
 
-#include <errno.h>                        // EINVAL
-#include <stddef.h>                        // size_t
-#include <string.h>                        // strlen()
-#include <unistd.h>                        // close()
-#include "skid_debug.h"                    // PRINT_ERROR()
-#include "skid_file_descriptors.h"        // close_fd()
+#include <errno.h>                      // EINVAL
+#include <fcntl.h>                      // open()
+#include <stddef.h>                     // size_t
+#include <string.h>                     // strlen()
+#include <unistd.h>                     // close()
+#include "skid_debug.h"                 // PRINT_ERROR()
+#include "skid_file_descriptors.h"      // close_fd()
 #include "skid_macros.h"                // SKID_BAD_FD
 #include "skid_memory.h"                // alloc_skid_mem(), free_skid_mem()
 #include "skid_validation.h"            // validate_skid_fd(), validate_skid_string()
@@ -148,8 +149,8 @@ int close_fd(int *fdp, bool quiet)
 int open_fd(const char *filename, int flags, mode_t mode, int *errnum)
 {
     // LOCAL VARIABLES
-    fd = SKID_BAD_FD;  // File descriptor
-    results = ENOERR;  // Errno value
+    int fd = SKID_BAD_FD;  // File descriptor
+    int results = ENOERR;  // Errno value
 
     // INPUT VALIDATION
     if (NULL == filename || NULL == errnum)
@@ -160,7 +161,7 @@ int open_fd(const char *filename, int flags, mode_t mode, int *errnum)
     // OPEN IT
     if (ENOERR == results)
     {
-        fd = open(stdout_fn, flags, mode);
+        fd = open(filename, flags, mode);
         if (-1 == fd)
         {
             results = errno;

--- a/code/src/skid_file_descriptors.c
+++ b/code/src/skid_file_descriptors.c
@@ -145,6 +145,40 @@ int close_fd(int *fdp, bool quiet)
 }
 
 
+int open_fd(const char *filename, int flags, mode_t mode, int *errnum)
+{
+    // LOCAL VARIABLES
+    fd = SKID_BAD_FD;  // File descriptor
+    results = ENOERR;  // Errno value
+
+    // INPUT VALIDATION
+    if (NULL == filename || NULL == errnum)
+    {
+        results = EINVAL;  // NULL pointer
+    }
+
+    // OPEN IT
+    if (ENOERR == results)
+    {
+        fd = open(stdout_fn, flags, mode);
+        if (-1 == fd)
+        {
+            results = errno;
+            PRINT_ERROR(The call to open() failed);
+            PRINT_ERRNO(results);
+            fd = SKID_BAD_FD;
+        }
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = results;
+    }
+    return fd;
+}
+
+
 char *read_fd(int fd, int *errnum)
 {
     // LOCAL VARIABLES

--- a/code/src/skid_file_descriptors.c
+++ b/code/src/skid_file_descriptors.c
@@ -364,7 +364,7 @@ int check_for_pre_alloc(char **output_buf, size_t *output_size)
 int read_fd_dynamic(int fd, char **output_buf, size_t *output_size)
 {
     // LOCAL VARIABLES
-    int result = validate_skid_fd(fd);           // Success of execution
+    int result = validate_skid_fd(fd);          // Success of execution
     char local_buf[SKID_FD_BUFF_SIZE] = { 0 };  // Local buffer
     ssize_t num_read = 0;                       // Number of bytes read
     size_t output_len = 0;                      // The length of *output_buf's string
@@ -527,7 +527,7 @@ int realloc_fd_dynamic(char **output_buf, size_t *output_size)
 int validate_sfd_args(char **output_buf, size_t *output_size)
 {
     // LOCAL VARIABLES
-    int result = EBADF;  // Validation result
+    int result = ENOERR;  // Validation result
 
     // VALIDATE IT
     // output_buf

--- a/code/src/skid_time.c
+++ b/code/src/skid_time.c
@@ -1,0 +1,119 @@
+
+#include <errno.h>              // errno
+#include "skid_time.h"          // SKID_BAD_TIME_T, time.h
+#include "skid_validation.h"    // validate_skid_err()
+
+
+struct tm *get_localtime(int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;      // Results of execution
+    time_t num_secs = 0;      // Number of seconds since the Unix Epoch
+    struct tm *ltime = NULL;  // Local time struct
+
+    // INPUT VALIDATION
+    result = validate_skid_err(errnum);
+
+    // GET IT
+    // Get Unix Epoch
+    if (ENOERR == result)
+    {
+        num_secs = get_unix_time(&result);
+        if (SKID_BAD_TIME_T == num_secs)
+        {
+            PRINT_ERROR(The call to get_unix_time() failed);
+            PRINT_ERRNO(result);
+        }
+    }
+    // Get Localtime
+    if (ENOERR == result)
+    {
+        ltime = localtime(&num_secs);
+        if (NULL == ltime)
+        {
+            result = errno;
+            PRINT_ERROR(The call to localtime() failed);
+            PRINT_ERRNO(result);
+        }
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return ltime;
+}
+
+
+time_t get_unix_time(int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Results of execution
+    time_t num_secs = 0;  // Number of seconds since the Unix Epoch
+
+    // INPUT VALIDATION
+    result = validate_skid_err(errnum);
+
+    // GET IT
+    if (ENOERR == result)
+    {
+        num_secs = time(NULL);
+        if (SKID_BAD_TIME_T == num_secs)
+        {
+            PRINT_ERROR(The call to time() failed);
+            result = errno;
+            if (ENOERR == result)
+            {
+                result = ETIMEDOUT;  // It failed but there's no errno?  Use ETIMEDOUT.
+            }
+            PRINT_ERRNO(result);
+        }
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return num_secs;
+}
+
+
+char *build_timestamp(int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;                        // Results of execution
+    char *timestamp = NULL;                     // Heap allocated timestamp buffer
+    size_t ts_len = strlen("YYYYMMDD-HHMMSS");  // Length of the datetime stamp
+    struct tm *dt_struct = NULL;
+
+    // INPUT VALIDATION
+    result = validate_skid_err(errnum);
+
+    // BUILD IT
+    // Allocate memory
+    if (ENOERR == result)
+    {
+        timestamp = (char *)alloc_skid_mem(ts_len + 1, sizeof(char), &result);
+    }
+    // Get the local time
+    if (ENOERR == result)
+    {
+        dt_struct = get_localtime(&result);
+    }
+    // Format the local time
+    if (ENOERR == result)
+    {
+        sprintf(timestamp, "%04d%02d%02d-%02d%02d%02d", dt_struct->tm_year+1900,
+                dt_struct->tm_mon, dt_struct->tm_mday, dt_struct->tm_hour,
+                dt_struct->tm_min, dt_struct->tm_sec);
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return timestamp;
+}

--- a/code/src/skid_time.c
+++ b/code/src/skid_time.c
@@ -1,5 +1,9 @@
 
 #include <errno.h>              // errno
+#include <stdio.h>              // sprintf()
+#include <string.h>             // strlen()
+#include "skid_debug.h"         // PRINT_ERRNO, PRINT_ERROR
+#include "skid_memory.h"        // alloc_skid_mem(), free_skid_mem()
 #include "skid_time.h"          // SKID_BAD_TIME_T, time.h
 #include "skid_validation.h"    // validate_skid_err()
 

--- a/code/src/skid_validation.c
+++ b/code/src/skid_validation.c
@@ -45,6 +45,11 @@ int validate_skid_fd(int fd)
     {
         result = ENOERR;  // Good(?).
     }
+    else
+    {
+        FPRINTF_ERR("%s file descriptor %d failed validation", DEBUG_ERROR_STR, fd);
+        PRINT_ERRNO(result);
+    }
 
     // DONE
     return result;

--- a/code/test/check_sfc_is_close_on_exec.c
+++ b/code/test/check_sfc_is_close_on_exec.c
@@ -1,0 +1,272 @@
+/*
+ *  Check unit test suit for skid_file_control.h's is_close_on_exec() function.
+ *
+ *  Copy/paste the following from the repo's top-level directory...
+
+make -C code dist/check_sfc_is_close_on_exec.bin && \
+code/dist/check_sfc_is_close_on_exec.bin && CK_FORK=no valgrind --leak-check=full --show-leak-kinds=all code/dist/check_sfc_is_close_on_exec.bin
+
+ *
+ *  The test cases have been split up by normal, error, boundary, and special (NEBS).
+ *  Execute this command to run just one NEBS category:
+ *
+
+export CK_RUN_CASE="Normal" && ./code/dist/check_sfc_is_close_on_exec.bin; unset CK_RUN_CASE  # Just run the Normal test cases
+export CK_RUN_CASE="Error" && ./code/dist/check_sfc_is_close_on_exec.bin; unset CK_RUN_CASE  # Just run the Error test cases
+export CK_RUN_CASE="Boundary" && ./code/dist/check_sfc_is_close_on_exec.bin; unset CK_RUN_CASE  # Just run the Boundary test cases
+export CK_RUN_CASE="Special" && ./code/dist/check_sfc_is_close_on_exec.bin; unset CK_RUN_CASE  # Just run the Special test cases
+
+ *
+ */
+
+#include <check.h>                      // START_TEST(), END_TEST
+#include <fcntl.h>                      // O_CLOEXEC
+#include <stdlib.h>                     // EXIT_FAILURE, EXIT_SUCCESS
+// Local includes
+#include "devops_code.h"                // resolve_to_repo(), SKID_REPO_NAME
+#ifndef SKID_DEBUG
+#define SKID_DEBUG
+#endif  /* SKID_DEBUG */
+// #include "skid_debug.h"                 // FPRINTF_ERR()
+#include "skid_file_control.h"          // is_close_on_exec()
+#include "skid_file_descriptors.h"      // close_fd(), open_fd()
+#include "skid_validation.h"            // validate_skid_fd()
+#include "unit_test_code.h"             // globals, setup(), teardown()
+
+// Use this with printf("%s", BOOL_STR_LIT(bool)); to print human readable results
+#define BOOL_STR_LIT(boolean) (boolean ? "true" : "false")
+#define CANARY_INT (int)0xBADC0DE  // Actually, a reverse canary value
+
+
+/**************************************************************************************************/
+/************************************ HELPER CODE DECLARATION *************************************/
+/**************************************************************************************************/
+
+
+/*
+ *  Create the Check test suite.
+ */
+Suite *create_test_suite(void);
+
+/*
+ *  Open filename using open_fd().  If cloexec is true, the O_CLOEXEC flag will be used.
+ */
+int open_test_fd(const char *filename, bool cloexec, int *errnum);
+
+/*
+ *  Make the function call, check the expected return value, and validate the results.
+ */
+void run_test_case_fd(int input_fd, bool exp_return, int exp_errnum);
+
+/*
+ *  Open filename using open_fd(), make the function call, check the expected return value,
+ *  validate the results, and close the open file descriptor.
+ */
+void run_test_case_fn(const char *filename, bool cloexec, bool exp_return, int exp_errnum);
+
+
+/**************************************************************************************************/
+/*************************************** NORMAL TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_n01_file_not_cloexec)
+{
+    // LOCAL VARIABLES
+    bool exp_return = false;     // Expected return value for this test case
+    int exp_errnum = ENOERR;     // Expected errnum value for this test case
+    bool use_cloexec = false;    // O_CLOEXEC usage for this test case
+    // Absolute path for test input as resolved against the repo name
+    char *input_abs_path = test_file_path;
+
+    // RUN TEST
+    run_test_case_fn(input_abs_path, use_cloexec, exp_return, exp_errnum);
+}
+END_TEST
+
+
+START_TEST(test_n02_file_cloexec)
+{
+    // TO DO: DON'T DO NOW
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/**************************************** ERROR TEST CASES ****************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_e01_bad_fd_negative)
+{
+    // TO DO: DON'T DO NOW
+}
+END_TEST
+
+
+START_TEST(test_e02_bad_fd_large)
+{
+    // TO DO: DON'T DO NOW
+}
+END_TEST
+
+
+START_TEST(test_e03_closed_fd)
+{
+    // TO DO: DON'T DO NOW
+}
+END_TEST
+
+
+START_TEST(test_e04_null_errnum)
+{
+    // TO DO: DON'T DO NOW
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/*************************************** SPECIAL TEST CASES ***************************************/
+/**************************************************************************************************/
+
+
+START_TEST(test_s01_weird_files)
+{
+    // TO DO: DON'T DO NOW
+}
+END_TEST
+
+
+/**************************************************************************************************/
+/************************************* HELPER CODE DEFINITION *************************************/
+/**************************************************************************************************/
+
+
+Suite *create_test_suite(void)
+{
+    // LOCAL VARIABLES
+    Suite *suite = suite_create("SFC_Is_Close_On_Exec");  // Test suite
+    TCase *tc_normal = tcase_create("Normal");            // Normal test cases
+    TCase *tc_error = tcase_create("Error");              // Error test cases
+    TCase *tc_special = tcase_create("Special");          // Special test cases
+
+    // SETUP TEST CASES
+    tcase_add_checked_fixture(tc_normal, setup, teardown);
+    tcase_add_checked_fixture(tc_error, setup, teardown);
+    tcase_add_checked_fixture(tc_special, setup, teardown);
+    tcase_add_test(tc_normal, test_n01_file_not_cloexec);
+    tcase_add_test(tc_normal, test_n02_file_cloexec);
+    tcase_add_test(tc_error, test_e01_bad_fd_negative);
+    tcase_add_test(tc_error, test_e02_bad_fd_large);
+    tcase_add_test(tc_error, test_e03_closed_fd);
+    tcase_add_test(tc_error, test_e04_null_errnum);
+    tcase_add_test(tc_special, test_s01_weird_files);
+    suite_add_tcase(suite, tc_normal);
+    suite_add_tcase(suite, tc_error);
+    suite_add_tcase(suite, tc_special);
+
+    // DONE
+    return suite;
+}
+
+
+int open_test_fd(const char *filename, bool cloexec, int *errnum)
+{
+    // LOCAL VARIABLES
+    int fd = SKID_BAD_FD;  // Opened file descriptor
+    int result = ENOERR;   // Results of the call to open_fd()
+    int flags = 0;         // See open_fd()
+    mode_t mode = 0;       // See open_fd()
+
+    // OPEN IT
+    if (true == cloexec)
+    {
+        flags = flags | O_CLOEXEC;
+    }
+    fd = open_fd(filename, flags, mode, &result);
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return fd;
+}
+
+
+void run_test_case_fd(int input_fd, bool exp_return, int exp_errnum)
+{
+    // LOCAL VARIABLES
+    bool actual_ret = 0;          // Return value of the tested function
+    int actual_err = CANARY_INT;  // The actual errnum value from the function call
+
+    // RUN IT
+    // Call the function
+    actual_ret = is_close_on_exec(input_fd, &actual_err);
+    // Compare actual return value to expected return value
+    ck_assert_msg(exp_return == actual_ret, "is_close_on_exec(%d, %p) returned '%s' "
+                  "instead of '%s'\n", input_fd, &actual_err, BOOL_STR_LIT(actual_ret),
+                  BOOL_STR_LIT(exp_return));
+    // Comprare the errnum value to the expected errnum value
+    // Verify the canary value was overwritten
+    ck_assert_msg(CANARY_INT != actual_err, "is_close_on_exec(%d, %p) failed to overwrite"
+                  " the errnum canary value\n", input_fd, &actual_err);
+    ck_assert_msg(exp_errnum == actual_err, "is_close_on_exec(%d, %p) provided errno [%d] '%s' "
+                  "instead of [%d] '%s'\n", input_fd, &actual_err, actual_err,
+                  strerror(actual_err), exp_errnum, strerror(exp_errnum));
+
+    // DONE
+    return;
+}
+
+
+void run_test_case_fn(const char *filename, bool cloexec, bool exp_return, int exp_errnum)
+{
+    // LOCAL VARIABLES
+    int input_fd = SKID_BAD_FD;  // File descriptor for filename
+    int result = CANARY_INT;     // Results of the call to open_test_fd()
+
+    // OPEN IT
+    input_fd = open_test_fd(filename, cloexec, &result);
+    ck_assert_msg(ENOERR == result, "open_test_fd(%s, %s, %p) failed with errno "
+                  "[%d] '%s'\n", filename, BOOL_STR_LIT(cloexec), &result, result,
+                  strerror(result));
+    ck_assert_msg(ENOERR == validate_skid_fd(input_fd), "open_test_fd(%s, %s, %p) returned "
+                  "an invalid file descriptor of %d\n", filename, BOOL_STR_LIT(cloexec), &result);
+
+    // RUN IT
+    run_test_case_fd(input_fd, exp_return, exp_errnum);
+
+    // DONE
+    close_fd(&input_fd, true);  // Quietly close the file descriptor
+}
+
+
+int main(void)
+{
+    // LOCAL VARIABLES
+    int errnum = 0;  // Errno from the function call
+    // Relative path for this test case's input
+    char log_rel_path[] = { "./code/test/test_output/check_sfc_is_close_on_exec.log" };
+    // Absolute path for log_rel_path as resolved against the repo name
+    char *log_abs_path = resolve_to_repo(SKID_REPO_NAME, log_rel_path, false, &errnum);
+    int number_failed = 0;
+    Suite *suite = NULL;
+    SRunner *suite_runner = NULL;
+
+    // SETUP
+    suite = create_test_suite();
+    suite_runner = srunner_create(suite);
+    srunner_set_log(suite_runner, log_abs_path);
+
+    // RUN IT
+    srunner_run_all(suite_runner, CK_NORMAL);
+    number_failed = srunner_ntests_failed(suite_runner);
+
+    // CLEANUP
+    srunner_free(suite_runner);
+    free_devops_mem((void **)&log_abs_path);
+
+    // DONE
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/code/test/check_sfc_is_close_on_exec.c
+++ b/code/test/check_sfc_is_close_on_exec.c
@@ -305,7 +305,8 @@ int get_test_fd(const char *filename, bool cloexec)
                   "[%d] '%s'\n", filename, BOOL_STR_LIT(cloexec), &result, result,
                   strerror(result));
     ck_assert_msg(ENOERR == validate_skid_fd(input_fd), "open_test_fd(%s, %s, %p) returned "
-                  "an invalid file descriptor of %d\n", filename, BOOL_STR_LIT(cloexec), &result);
+                  "an invalid file descriptor of %d\n", filename, BOOL_STR_LIT(cloexec), &result,
+                  input_fd);
 
     // DONE
     return input_fd;

--- a/code/test/redirect_bin_output.c
+++ b/code/test/redirect_bin_output.c
@@ -1,0 +1,138 @@
+/*
+ *  This source file utilizes SKETCHY IDEA (SKID) to implement redirect_bin_output.bin.
+ */
+
+#include "skid_file_descriptors.h"  // close_fd(), open_fd()
+#include "skid_macros.h"            // ENOERR, SKID_BAD_FD
+#include "skid_time.h"              // build_timestamp()
+
+/*
+ *  Build a unique timestamped filename which follows this format:
+ *      <TIMESTAMP>-XXXXXX-<PROPER NAME>-<TYPE>.txt
+ *
+ *  Args:
+ *      timestamp: Non-empty datetime stamp (e.g., YYYYMMDD-HHMMSS).
+ *      proper_name: Should likely be the name of the binary being executed-and-redirected.
+ *      type: Expected to be "output" (for stdout) or "errors" (for stderr).
+ *      errnum: [Out] Storage location for errno values encountered.
+ */
+char *build_filename(const char *timestamp, const char *proper_name, const char *type, int *errnum);
+
+/*
+ *  Description:
+ *      Print the usage.
+ *
+ *  Args:
+ *      prog_name: argv[0].
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int exit_code = 0;                                              // Store errno here
+    char *stdout_fn = NULL;                                         // Stdout filename
+    char *stderr_fn = NULL;                                         // Stderr filename
+    int stdout_fd = 0;                                              // Stdout file descriptor
+    int stderr_fd = 0;                                              // Stderr file descriptor
+    int flags = O_WRONLY | O_CREAT | O_CLOEXEC;                     // Flags for open()
+    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;  // Mode for open()
+    char *timestamp = NULL;                                         // YYYYMMDD-HHMMSS
+
+    // INPUT VALIDATION
+    if (argc < 2)
+    {
+        exit_code = EINVAL;  // There was no binary to redirect output for
+        print_usage(argv[0]);
+    }
+
+    // REDIRECT IT
+    // 1. Build Filenames
+    // Stdout
+    if (ENOERR == exit_code)
+    {
+        stdout_fn = build_filename(argv[1], "output", &exit_code);
+    }
+    // Stderr
+    if (ENOERR == exit_code)
+    {
+        stderr_fn = build_filename(argv[1], "errors", &exit_code);
+    }
+    // 2. Open Filenames
+    // Stdout
+    if (ENOERR == exit_code)
+    {
+        stdout_fd = open_fd(stdout_fn, flags, mode, &exit_code);
+    }
+    // Stderr
+    if (ENOERR == exit_code)
+    {
+        stderr_fd = open_fd(stderr_fn, flags, mode, &exit_code);
+    }
+    // 3. Fork
+
+    // CLEANUP
+    // Stdout filename
+    if (NULL != stdout_fn)
+    {
+        free_skid_mem(&stdout_fn);
+    }
+    // Stderr filename
+    if (NULL != stderr_fn)
+    {
+        free_skid_mem(&stderr_fn);
+    }
+    // Stdout file descriptor
+    if (SKID_BAD_FD != stdout_fd)
+    {
+        close_fd(&stdout_fd, true);  // Silence all logging/debugging
+    }
+    // Stderr file descriptor
+    if (SKID_BAD_FD != stderr_fd)
+    {
+        close_fd(&stderr_fd, true);  // Silence all logging/debugging
+    }
+
+    // DONE
+    exit(exit_code);
+}
+
+
+char *build_filename(const char *timestamp, const char *proper_name, const char *type, int *errnum)
+{
+    // LOCAL VARIABLES
+    int results = ENOERR;   // Results of execution
+    char *built_fn = NULL;  // Built filename
+
+    // INPUT VALIDATION
+    if (NULL == timestamp || NULL == proper_name || NULL == type || NULL == errnum)
+    {
+        results = EINVAL;  // NULL pointer
+    }
+
+    // BUILD IT
+    // Get temp filename
+    if (ENOERR != results)
+    {
+        
+    }
+    // Finish filename
+    if (ENOERR != results)
+    {
+        
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = results;
+    }
+    return built_fn;
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <BINARY> [COMMAND LINE ARGUMENTS...]\n", prog_name);
+}

--- a/code/test/redirect_bin_output.c
+++ b/code/test/redirect_bin_output.c
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
                 else if (0 == retval)
                 {
                     FPRINTF_ERR("%s Still waiting on the child's status to change\n",
-                                DEBUG_INFO_STR);  // DEBUGGING
+                                DEBUG_INFO_STR);
                 }
                 else if (pid == retval)
                 {
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
                     {
                         exit_code = WEXITSTATUS(wstatus);
                         FPRINTF_ERR("%s The child exited with %d\n",
-                                    DEBUG_INFO_STR, exit_code);  // DEBUGGING
+                                    DEBUG_INFO_STR, exit_code);
                         break;  // The child exited!
                     }
                     else if (WIFSIGNALED(wstatus))

--- a/code/test/test_sfc_lock_and_write_fd.c
+++ b/code/test/test_sfc_lock_and_write_fd.c
@@ -1,0 +1,189 @@
+/*
+ *  Manually test skid_file_control's file descriptor functionality.
+ *  This binary makes use of the locking functionality to lock a file indefinitely.
+ *  While not ideal, this particular binary can help showcase read and write locks.
+ *
+ *  Copy/paste the following...
+
+./code/dist/test_sfc_lock_and_write_fd.bin <FILENAME>
+# The filename is opened and locked when the user presses <ENTER>
+# Then, user input is written to the file when the input buffer is full or the user presses <ENTER>
+# Use Ctrl-C to send a SIGINT signal to safely stop reading input, release the lock, close the
+#   file and exit
+
+ *
+ */
+
+#ifndef SKID_DEBUG
+#define SKID_DEBUG                  // Enable DEBUG logging
+#endif  /* SKID_DEBUG */
+
+#include <errno.h>                  // EINVAL
+#include <fcntl.h>                  // O_CREAT, O_WRONLY
+#include <stdio.h>                  // printf()
+#include <stdlib.h>                 // exit()
+#include <unistd.h>                 // sleep()
+#include "skid_debug.h"             // FPRINTF_ERR(), PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_control.h"      // read_locked_fd()
+#include "skid_file_descriptors.h"  // close_fd(), open_fd()
+#include "skid_macros.h"            // ENOERR, SKID_BAD_FD
+#include "skid_memory.h"            // free_skid_mem()
+#include "skid_signals.h"           // set_signal_handler()
+#include "skid_signal_handlers.h"   // handle_interruptions()
+
+/*
+ *  Single point of truth for this manual test code's usage.
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int exit_code = ENOERR;                                         // Errno values
+    int temp_retval = ENOERR;                                       // Additional errno values
+    char *filename = NULL;                                          // Filename to lock and write
+    int fd = SKID_BAD_FD;                                           // Filename's file descriptor
+    int flags = O_CREAT | O_RDWR;                                   // Flags (see: open(2))
+    size_t ui_len = 1024;                                           // Number of user_input indices
+    char *user_input = NULL;                                        // User input to write to file
+    char temp_input = 0x0;                                          // One keystroke
+    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;  // Mode (see: open(2))
+    bool locked = false;                                            // Write-lock status
+
+    // INPUT VALIDATION
+    if (argc == 2)
+    {
+        filename = argv[1];  // Filename to write to
+    }
+    else
+    {
+       print_usage(argv[0]);
+       exit_code = EINVAL;
+    }
+
+    // SETUP
+    // Setup a SIGINT signal handler to gracefully handle interruptions
+    if (ENOERR == exit_code)
+    {
+        exit_code = set_signal_handler(SIGINT, handle_interruptions, 0, NULL);
+        if (ENOERR != exit_code)
+        {
+            PRINT_ERROR(The call to set_signal_handler() failed);
+            PRINT_ERRNO(exit_code);
+        }
+    }
+    // Allocate a read buffer
+    if (ENOERR == exit_code)
+    {
+        user_input = alloc_skid_mem(ui_len + 1, sizeof(char), &exit_code);
+    }
+
+    // WRITE IT
+    // Open the filename
+    if (ENOERR == exit_code)
+    {
+        fd = open_fd(filename, flags, mode, &exit_code);
+        if (SKID_BAD_FD == fd || ENOERR != exit_code)
+        {
+            FPRINTF_ERR("%s open_fd(%s, %d, %d, %p) failed with errno [%d] %s\n", DEBUG_ERROR_STR,
+                        filename, flags, mode, &exit_code, exit_code, strerror(exit_code));
+        }
+    }
+    // Lock the file
+    if (ENOERR == exit_code && 0 == skid_sig_hand_interrupted)
+    {
+        printf("The '%s' file has been opened as file descriptor number '%d'.\n", filename, fd);
+        while (1)
+        {
+            printf("Press <ENTER> to initiate a write lock.  Press <CTRL-C> to exit.\n");
+            temp_input = getchar();
+            if (0 != skid_sig_hand_interrupted)
+            {
+                break;  // SIGINT received
+            }
+            else if ('\n' == temp_input)
+            {
+                exit_code = get_write_lock(fd);
+                if (ENOERR == exit_code)
+                {
+                    locked = true;
+                    printf("The '%d' file descriptor is now write-locked.\n", fd);
+                    break;  // Got a write lock
+                }
+                else
+                {
+                    PRINT_ERROR(The call to get_write_lock() failed);
+                    PRINT_ERRNO(exit_code);
+                    exit_code = ENOERR;  // Let's keep trying
+                }
+            }
+        }
+        temp_input = 0x0;  // Clear the temp var
+    }
+    // Generate content
+    if (ENOERR == exit_code && 0 == skid_sig_hand_interrupted)
+    {
+        printf("This program will write your text to '%s', file descriptor '%d', while it is "
+               "locked for writing.\nText will be periodically written when the buffer is full "
+               "or when you press <ENTER>.\nPress <CTRL-C> to exit.\nBegin typing now...\n",
+               filename, fd);
+    }
+    while (ENOERR == exit_code && 0 == skid_sig_hand_interrupted)
+    {
+        // Take user input until the buffer is full or the user ends it
+        for (int i = 0; i < ui_len; i++)
+        {
+            temp_input = getchar();
+            user_input[i] = temp_input;
+            if (EOF == temp_input || '\n' == temp_input || 0 != skid_sig_hand_interrupted)
+            {
+                break;
+            }
+        }
+        // Write
+        exit_code = write_fd(fd, user_input);
+        if (ENOERR != exit_code)
+        {
+            FPRINTF_ERR("%s write_locked_fd(%d, %s), file descriptor for %s, failed with "
+                        "errno [%d] %s\n", DEBUG_ERROR_STR, fd, user_input, filename,
+                        exit_code, strerror(exit_code));
+        }
+        else
+        {
+            memset(user_input, 0x0, ui_len);  // Clear the buffer for reuse
+        }
+    }
+
+    // CLEANUP
+    // Release the lock
+    if (true == locked)
+    {
+        temp_retval = release_lock(fd);
+        if (ENOERR != temp_retval)
+        {
+            PRINT_ERROR(The call to release_lock() failed);
+            PRINT_ERRNO(temp_retval);
+        }
+        if (ENOERR == exit_code)
+        {
+            exit_code = temp_retval;  // Report the first, and only the first, errno value
+        }
+    }
+    // file_content
+    if (NULL != user_input)
+    {
+        free_skid_mem((void **)&user_input);  // Best effort
+    }
+    // fd
+    close_fd(&fd, true);  // Best effort
+
+    // DONE
+    exit(exit_code);
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <FILENAME>\n", prog_name);
+}

--- a/code/test/test_sfc_read_locked_fd.c
+++ b/code/test/test_sfc_read_locked_fd.c
@@ -18,15 +18,12 @@
 #include <errno.h>                   // EINVAL
 #include <stdio.h>                   // printf()
 #include <stdlib.h>                  // exit()
-// #include <string.h>                  // memset()
-// #include <sys/socket.h>              // AF_INET
 #include <unistd.h>                 // sleep()
 #include "skid_debug.h"             // FPRINTF_ERR(), PRINT_ERRNO(), PRINT_ERROR()
 #include "skid_file_control.h"      // read_locked_fd()
 #include "skid_file_descriptors.h"  // close_fd(), open_fd()
 #include "skid_macros.h"            // ENOERR, SKID_BAD_FD
 #include "skid_memory.h"            // free_skid_mem()
-// #include "skid_network.h"
 #include "skid_signals.h"           // set_signal_handler()
 #include "skid_signal_handlers.h"   // handle_interruptions()
 
@@ -63,7 +60,7 @@ int main(int argc, char *argv[])
     if (ENOERR == exit_code)
     {
         exit_code = set_signal_handler(SIGINT, handle_interruptions, 0, NULL);
-        if (ENOERR == exit_code)
+        if (ENOERR != exit_code)
         {
             PRINT_ERROR(The call to set_signal_handler() failed);
             PRINT_ERRNO(exit_code);
@@ -86,7 +83,7 @@ int main(int argc, char *argv[])
             file_content = read_locked_fd(fd, &exit_code);
             if (NULL == file_content || ENOERR != exit_code)
             {
-                FPRINTF_ERR("%s read_locked_fd(%d, %p), file descriptor for %s failed with "
+                FPRINTF_ERR("%s read_locked_fd(%d, %p), file descriptor for %s, failed with "
                             "errno [%d] %s\n", DEBUG_ERROR_STR, fd, &exit_code, filename,
                             exit_code, strerror(exit_code));
             }

--- a/code/test/test_sfc_read_locked_fd.c
+++ b/code/test/test_sfc_read_locked_fd.c
@@ -1,0 +1,147 @@
+/*
+ *  Manually test skid_file_control's file descriptor functionality.
+ *  This binary makes use of the read_locked_fd() to repeatedly read a file.
+ *
+ *  Copy/paste the following...
+
+./code/dist/test_sfc_read_locked_fd.bin <FILENAME>
+# Use Ctrl-C to send a SIGINT signal to safely exit
+
+ *
+ */
+
+#ifndef SKID_DEBUG
+#define SKID_DEBUG                  // Enable DEBUG logging
+#endif  /* SKID_DEBUG */
+#define WAIT_SLEEP 10               // Number of seconds to wait for user input
+
+#include <errno.h>                   // EINVAL
+#include <stdio.h>                   // printf()
+#include <stdlib.h>                  // exit()
+// #include <string.h>                  // memset()
+// #include <sys/socket.h>              // AF_INET
+#include <unistd.h>                 // sleep()
+#include "skid_debug.h"             // FPRINTF_ERR(), PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_control.h"      // read_locked_fd()
+#include "skid_file_descriptors.h"  // close_fd(), open_fd()
+#include "skid_macros.h"            // ENOERR, SKID_BAD_FD
+#include "skid_memory.h"            // free_skid_mem()
+// #include "skid_network.h"
+#include "skid_signals.h"           // set_signal_handler()
+#include "skid_signal_handlers.h"   // handle_interruptions()
+
+/*
+ *  Single point of truth for this manual test code's usage.
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int exit_code = ENOERR;     // Store errno and/or results here
+    int result = ENOERR;        // Additional errno values
+    char *filename = NULL;      // The filename to lock, read, and release
+    int fd = SKID_BAD_FD;       // Filename's file descriptor
+    int flags = 0;              // Flags (see: open(2))
+    mode_t mode = 0;            // Mode (see: open(2))
+    char *file_content = NULL;  // Contents of filename
+
+    // INPUT VALIDATION
+    if (argc == 2)
+    {
+        filename = argv[1];  // Filename to read
+    }
+    else
+    {
+       print_usage(argv[0]);
+       exit_code = EINVAL;
+    }
+
+    // SETUP
+    // Setup a SIGINT signal handler to gracefully handle interruptions
+    if (ENOERR == exit_code)
+    {
+        exit_code = set_signal_handler(SIGINT, handle_interruptions, 0, NULL);
+        if (ENOERR == exit_code)
+        {
+            PRINT_ERROR(The call to set_signal_handler() failed);
+            PRINT_ERRNO(exit_code);
+        }
+    }
+
+    // READ IT
+    while (ENOERR == exit_code && 0 == skid_sig_hand_interrupted)
+    {
+        // Open the filename
+        fd = open_fd(filename, flags, mode, &exit_code);
+        if (SKID_BAD_FD == fd)
+        {
+            FPRINTF_ERR("%s open_fd(%s, %d, %d, %p) failed with errno [%d] %s\n", DEBUG_ERROR_STR,
+                        filename, flags, mode, &exit_code, exit_code, strerror(exit_code));
+        }
+        // Lock and read it
+        else
+        {
+            file_content = read_locked_fd(fd, &exit_code);
+            if (NULL == file_content || ENOERR != exit_code)
+            {
+                FPRINTF_ERR("%s read_locked_fd(%d, %p), file descriptor for %s failed with "
+                            "errno [%d] %s\n", DEBUG_ERROR_STR, fd, &exit_code, filename,
+                            exit_code, strerror(exit_code));
+            }
+            else
+            {
+                printf("\nCONTENTS:\n%s\n", file_content);
+                result = free_skid_mem((void **)&file_content);
+                if (ENOERR == exit_code)
+                {
+                    exit_code = result;  // Report the first, and only the first, error
+                }
+            }
+            // Close the file descriptor
+            if (SKID_BAD_FD != fd)
+            {
+                result = close_fd(&fd, false);
+                if (ENOERR == exit_code)
+                {
+                    exit_code = result;  // Report the first, and only the first, error
+                }
+            }
+        }
+        // Sleep?
+        if (ENOERR == exit_code)
+        {
+            printf("Sleeping %d seconds to read again.  Press <CTRL-C> to exit.\n", WAIT_SLEEP);
+            for (int i = 0; i < WAIT_SLEEP; i++)
+            {
+                if (0 != skid_sig_hand_interrupted)
+                {
+                    break;  // Received a SIGINT so let's bail
+                }
+                else
+                {
+                    sleep(i);  // A tasteful sleep
+                }
+            }
+        }
+    }
+
+    // CLEANUP
+    // file_content
+    if (NULL != file_content)
+    {
+        free_skid_mem((void **)&file_content);  // Best effort
+    }
+    // fd
+    close_fd(&fd, true);  // Best effort
+
+    // DONE
+    exit(exit_code);
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <FILENAME>\n", prog_name);
+}

--- a/code/test/test_sfc_write_locked_fd.c
+++ b/code/test/test_sfc_write_locked_fd.c
@@ -1,0 +1,136 @@
+/*
+ *  Manually test skid_file_control's file descriptor functionality.
+ *  This binary makes use of the write_locked_fd() to repeatedly read a file.
+ *
+ *  Copy/paste the following...
+
+./code/dist/test_sfc_write_locked_fd.bin <FILENAME>
+# User input is written to the locked filename when the buffer if full or the user presses <ENTER>
+# Use Ctrl-C to send a SIGINT signal to safely exit
+
+ *
+ */
+
+#ifndef SKID_DEBUG
+#define SKID_DEBUG                  // Enable DEBUG logging
+#endif  /* SKID_DEBUG */
+#define WAIT_SLEEP 10               // Number of seconds to wait for user input
+
+#include <errno.h>                  // EINVAL
+#include <fcntl.h>                  // O_CREAT, O_WRONLY
+#include <stdio.h>                  // printf()
+#include <stdlib.h>                 // exit()
+#include <unistd.h>                 // sleep()
+#include "skid_debug.h"             // FPRINTF_ERR(), PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_control.h"      // read_locked_fd()
+#include "skid_file_descriptors.h"  // close_fd(), open_fd()
+#include "skid_macros.h"            // ENOERR, SKID_BAD_FD
+#include "skid_memory.h"            // free_skid_mem()
+#include "skid_signals.h"           // set_signal_handler()
+#include "skid_signal_handlers.h"   // handle_interruptions()
+
+/*
+ *  Single point of truth for this manual test code's usage.
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int exit_code = ENOERR;                                         // Errno values
+    char *filename = NULL;                                          // Filename to lock and write
+    int fd = SKID_BAD_FD;                                           // Filename's file descriptor
+    int flags = O_CREAT | O_RDWR | O_TRUNC;                         // Flags (see: open(2))
+    size_t ui_len = 1024;                                           // Number of user_input indices
+    char *user_input = NULL;                                        // User input to write to file
+    char temp_input = 0x0;                                          // One keystroke
+    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;  // Mode (see: open(2))
+
+    // INPUT VALIDATION
+    if (argc == 2)
+    {
+        filename = argv[1];  // Filename to read
+    }
+    else
+    {
+       print_usage(argv[0]);
+       exit_code = EINVAL;
+    }
+
+    // SETUP
+    // Setup a SIGINT signal handler to gracefully handle interruptions
+    if (ENOERR == exit_code)
+    {
+        exit_code = set_signal_handler(SIGINT, handle_interruptions, 0, NULL);
+        if (ENOERR != exit_code)
+        {
+            PRINT_ERROR(The call to set_signal_handler() failed);
+            PRINT_ERRNO(exit_code);
+        }
+    }
+    // Allocate a read buffer
+    if (ENOERR == exit_code)
+    {
+        user_input = alloc_skid_mem(ui_len + 1, sizeof(char), &exit_code);
+    }
+
+    // WRITE IT
+    // Open the filename
+    if (ENOERR == exit_code)
+    {
+        fd = open_fd(filename, flags, mode, &exit_code);
+        if (SKID_BAD_FD == fd || ENOERR != exit_code)
+        {
+            FPRINTF_ERR("%s open_fd(%s, %d, %d, %p) failed with errno [%d] %s\n", DEBUG_ERROR_STR,
+                        filename, flags, mode, &exit_code, exit_code, strerror(exit_code));
+        }
+        else
+        {
+            printf("This program will write your text to '%s' while it is locked for writing.\n"
+                   "Text will be periodically written when the buffer is full "
+                   "or when you press <ENTER>.\nPress <CTRL-C> to exit.\nBegin typing now...\n",
+                   filename);
+        }
+    }
+    // Generate content
+    while (ENOERR == exit_code && 0 == skid_sig_hand_interrupted)
+    {
+        // Take user input until the buffer is full or the user ends it
+        for (int i = 0; i < ui_len; i++)
+        {
+            temp_input = getchar();
+            user_input[i] = temp_input;
+            if (EOF == temp_input || '\n' == temp_input || 0 != skid_sig_hand_interrupted)
+            {
+                break;
+            }
+        }
+        // Lock and write
+        exit_code = write_locked_fd(fd, user_input);
+        if (ENOERR != exit_code)
+        {
+            FPRINTF_ERR("%s write_locked_fd(%d, %s), file descriptor for %s, failed with "
+                        "errno [%d] %s\n", DEBUG_ERROR_STR, fd, user_input, filename,
+                        exit_code, strerror(exit_code));
+        }
+    }
+
+    // CLEANUP
+    // file_content
+    if (NULL != user_input)
+    {
+        free_skid_mem((void **)&user_input);  // Best effort
+    }
+    // fd
+    close_fd(&fd, true);  // Best effort
+
+    // DONE
+    exit(exit_code);
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <FILENAME>\n", prog_name);
+}


### PR DESCRIPTION
Primary Work done:

- Added `skid_file_control` library to handle `fcntl` work
- Wrote unit tests for `is_close_on_exec()`
- Wrote a releasable binary `redirect_bin_output.bin` to showcase `dup2`
- Wrote manual test code to showcase `fcntl()` file-locking features

Secondary Work:
- Added `skid_time` library
- Cleaned up some whitespace formatting

All tests passing in the original native host and my dev VM.
Valgrind is happy.
`SKID_DEBUG` is disabled for all production code.