### PR TITLE
8-4: Release SKID as a shared object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,14 @@
 ##########################
 #
 # 1. Do everything in $(CODE_DIR)
-# 2. make
+# 2. `make`
 # 3. Watch for errors
 # 4. Check $(CODE_DIR)$(DIST_DIR) for your binaries
-# 5. Modifiy $(CODE_DIR)Makefile_linux with special rules
+# 5. `make install` to install the SKETCHY IDEA (SKID) shared object
 #
-# Global "constants" are defined in code/Makefile_constants
+# NOTES:
+# - Modifiy $(CODE_DIR)Makefile_linux with special rules
+# - Global "constants" are defined in code/Makefile_constants
 #
 
 
@@ -26,7 +28,7 @@ include $(CODE_DIR)Makefile_constants
 ### MAKEFILE ARGUMENTS ###
 SKID_MF_ARGS = --directory=$(CODE_DIR)
 
-.PHONY: all clean compile test validate
+.PHONY: all clean compile install release test validate
 
 
 ##########################
@@ -40,6 +42,12 @@ clean:
 
 compile:
 	$(CALL_MAKE) $(SKID_MF_ARGS) compile
+
+install:
+	$(CALL_MAKE) $(SKID_MF_ARGS) install
+
+release:
+	$(CALL_MAKE) $(SKID_MF_ARGS) release
 
 test:
 	$(CALL_MAKE) $(SKID_MF_ARGS) test

--- a/code/Makefile
+++ b/code/Makefile
@@ -34,6 +34,7 @@ all:
 	$(CALL_MAKE) clean
 	$(CALL_MAKE) compile
 	$(CALL_MAKE) test
+	$(CALL_MAKE) release
 
 clean:
 	@echo ""
@@ -44,6 +45,11 @@ compile:
 	@echo ""
 	@echo "COMPILING"
 	$(CALL_MAKE) _compile
+
+release:
+	@echo ""
+	@echo "RELEASING"
+	$(CALL_MAKE) _release
 
 test:
 	@echo ""

--- a/code/Makefile
+++ b/code/Makefile
@@ -46,6 +46,11 @@ compile:
 	@echo "COMPILING"
 	$(CALL_MAKE) _compile
 
+install:
+	@echo ""
+	@echo "INSTALLING"
+	$(CALL_MAKE) _install
+
 release:
 	@echo ""
 	@echo "RELEASING"

--- a/code/Makefile_constants
+++ b/code/Makefile_constants
@@ -26,6 +26,7 @@ TEST_DIR = test/
 HDR_FILE_EXT = .h
 LIB_FILE_EXT = .lib
 OBJ_FILE_EXT = .o
+SHD_FILE_EXT = .so
 SRC_FILE_EXT = .c
 
 ### MAKEFILE ARGUMENTS ###

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -205,7 +205,7 @@ _install: $(DIST_DIR)$(FULL_LIB_NAME)
 	sudo ln -f -s $(LIB_INSTALL_DIR)/$(SHORT_LIB_NAME) $(LIB_INSTALL_DIR)/$(BASE_SO_NAME)
 
 _release:
-	@#echo "Releasing $(FULL_LIB_NAME)"  # DEBUGGING
+	@echo "Releasing $(FULL_LIB_NAME)"  # DEBUGGING
 	@$(CC) -fpic -o $(DIST_DIR)$(FULL_LIB_NAME) $(SKID_SRC_FILES) -shared -Wl,-soname,$(SHORT_LIB_NAME) -I $(INCLUDE_DIR)
 
 _test:

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -155,7 +155,7 @@ FULL_LIB_NAME = $(SHORT_LIB_NAME).$(MIN_VER).$(MIC_VER)
 ### SPECIAL BUILT-IN TARGET NAMES ###
 
 # Do not treat these target names as file names
-.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _install _release _test _test_link _validate _validate_check _validate_gcc
+.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _install _release _test _test_link _validate _validate_check _validate_gcc _validate_musl
 
 # Don't auto-remove my object code
 .PRECIOUS: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE)) \
@@ -217,6 +217,7 @@ _validate:
 	$(CALL_MAKE) _validate_gcc
 	$(CALL_MAKE) _validate_glibc
 	$(CALL_MAKE) _validate_check
+	$(CALL_MAKE) _validate_musl
 
 _validate_check:
 	@echo "    Validating Check"
@@ -232,6 +233,11 @@ _validate_glibc:
 	@echo "    Validating glibc"
 	@ldd --version > $(NULL)
 	@echo "        $(CHECK) $(shell ldd --version | head -n 1)"
+
+_validate_musl:
+	@echo "    Validating "$(MCC)""
+	@$(MCC) --version > $(NULL)
+	@echo "        $(CHECK) $(shell $(MCC) --version | head -n 1)"
 
 # CHECK: Linking skid_dir_operations library unit test binaries
 $(DIST_DIR)$(CHECK_SDO_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(CHECK_SDO_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT) $(DEVOPS_CODE_LINK_DEPS)

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -138,11 +138,21 @@ UNIT_TEST_LINK_DEPS = $(foreach UNIT_TEST_OBJ_FILE, $(UNIT_TEST_OBJ_FILES), $(DI
 # A space-separated list of all the test binaries
 CHECK_BIN_LIST = $(shell ls $(DIST_DIR)$(CHECK_PREFIX)*$(BIN_FILE_EXT))
 MAN_TEST_BIN_LIST = $(foreach MAN_TEST_BIN_FILE, $(MAN_TEST_BIN_FILES), $(DIST_DIR)$(MAN_TEST_BIN_FILE))
+# Shared Object Variables
+# All skid_*.c filenames found in SRC_DIR
+SKID_SRC_FILES := $(shell ls $(SRC_DIR)skid_*$(SRC_FILE_EXT))
+BASE_LIB_NAME = libsketchyidea
+MAJ_VER = 1
+MIN_VER = 0
+MIC_VER = 0
+SHORT_LIB_NAME = $(BASE_LIB_NAME)$(SHD_FILE_EXT).$(MAJ_VER)
+FULL_LIB_NAME = $(SHORT_LIB_NAME).$(MIN_VER).$(MIC_VER)
+
 
 ### SPECIAL BUILT-IN TARGET NAMES ###
 
 # Do not treat these target names as file names
-.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _test _test_link _validate _validate_check _validate_gcc
+.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _release _test _test_link _validate _validate_check _validate_gcc
 
 # Don't auto-remove my object code
 .PRECIOUS: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE)) \
@@ -157,6 +167,7 @@ _all:
 	$(CALL_MAKE) clean
 	$(CALL_MAKE) compile
 	$(CALL_MAKE) test
+	$(CALL_MAKE) release
 
 # Builds that don't conform to the prefix mnemonic used here (e.g., check_*, test_*)
 _bespoke_builds:
@@ -181,6 +192,10 @@ _compile:
 
 _compilation: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE))
 	@#echo "$@ needs $^"  # DEBUGGING
+
+_release:
+	@#echo "Releasing $(FULL_LIB_NAME)"  # DEBUGGING
+	@$(CC) -fpic -o $(DIST_DIR)$(FULL_LIB_NAME) $(SKID_SRC_FILES) -shared -Wl,-soname,$(SHORT_LIB_NAME) -I $(INCLUDE_DIR)
 
 _test:
 	@#echo "$@ needs $^"  # DEBUGGING

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -36,6 +36,8 @@ ifneq ($(OS),Windows_NT)
 else
 $(error Wrong operating system.  This is $(OS).)
 endif
+HDR_INSTALL_DIR = /usr/include
+LIB_INSTALL_DIR = /lib
 
 # $(NULL) - Shunt output here to silence it
 NULL :=
@@ -141,6 +143,7 @@ MAN_TEST_BIN_LIST = $(foreach MAN_TEST_BIN_FILE, $(MAN_TEST_BIN_FILES), $(DIST_D
 # Shared Object Variables
 # All skid_*.c filenames found in SRC_DIR
 SKID_SRC_FILES := $(shell ls $(SRC_DIR)skid_*$(SRC_FILE_EXT))
+SKID_HDR_FILES := $(shell ls $(INCLUDE_DIR)skid_*$(HDR_FILE_EXT))
 BASE_LIB_NAME = libsketchyidea
 MAJ_VER = 1
 MIN_VER = 0
@@ -152,7 +155,7 @@ FULL_LIB_NAME = $(SHORT_LIB_NAME).$(MIN_VER).$(MIC_VER)
 ### SPECIAL BUILT-IN TARGET NAMES ###
 
 # Do not treat these target names as file names
-.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _release _test _test_link _validate _validate_check _validate_gcc
+.PHONY: _all _bespoke_builds _check_link _clean _clean_dist _compile _compilation _install _release _test _test_link _validate _validate_check _validate_gcc
 
 # Don't auto-remove my object code
 .PRECIOUS: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE)) \
@@ -192,6 +195,11 @@ _compile:
 
 _compilation: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FILE))
 	@#echo "$@ needs $^"  # DEBUGGING
+
+_install: $(DIST_DIR)$(FULL_LIB_NAME)
+	@echo "Installing $^"  # DEBUGGING
+	$(foreach SKID_HDR_FILE, $(SKID_HDR_FILES), sudo cp $(SKID_HDR_FILE) $(HDR_INSTALL_DIR);)
+	@sudo cp $(DIST_DIR)$(FULL_LIB_NAME) $(LIB_INSTALL_DIR)
 
 _release:
 	@#echo "Releasing $(FULL_LIB_NAME)"  # DEBUGGING

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -99,6 +99,8 @@ CHECK_CC_ARGS = -lcheck -lm -lsubunit -lrt -lpthread
 MAN_TEST_PREFIX = test_
 # Prefix for all devops_code library manual tests
 MAN_TEST_DEVOPS_PREFIX = $(MAN_TEST_PREFIX)devops_code_
+# Prefix for all libsketchyidea shared object manual tests
+MAN_TEST_LIB_PREFIX = $(MAN_TEST_PREFIX)libskid_
 # Prefix for all skid_assembly library manual tests
 MAN_TEST_SA_PREFIX = $(MAN_TEST_PREFIX)sa_
 # Prefix for all skid_dir_operations library manual tests
@@ -288,6 +290,11 @@ $(DIST_DIR)$(CHECK_PREFIX)%$(OBJ_FILE_EXT): $(TEST_DIR)$(CHECK_PREFIX)%$(SRC_FIL
 $(DIST_DIR)$(MAN_TEST_DEVOPS_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_DEVOPS_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT) $(DEVOPS_CODE_LINK_DEPS)
 	@echo "    Linking manual test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
+
+# MANUAL TEST: Linking libsketchyidea manual test binaries
+$(DIST_DIR)$(MAN_TEST_LIB_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_LIB_PREFIX)%$(OBJ_FILE_EXT)
+	@echo "    Linking manual test binary against $(BASE_LIB_NAME): $@"
+	@$(CC) $(CFLAGS) -o $@ $^ -lsketchyidea
 
 # MANUAL TEST: Linking skid_assembly library manual test binaries
 $(DIST_DIR)$(MAN_TEST_SA_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SA_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_assembly$(OBJ_FILE_EXT)

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -205,7 +205,7 @@ _install: $(DIST_DIR)$(FULL_LIB_NAME)
 	sudo ln -f -s $(LIB_INSTALL_DIR)/$(SHORT_LIB_NAME) $(LIB_INSTALL_DIR)/$(BASE_SO_NAME)
 
 _release:
-	@echo "Releasing $(FULL_LIB_NAME)"  # DEBUGGING
+	@echo "Releasing $(FULL_LIB_NAME)"
 	@$(CC) -fpic -o $(DIST_DIR)$(FULL_LIB_NAME) $(SKID_SRC_FILES) -shared -Wl,-soname,$(SHORT_LIB_NAME) -I $(INCLUDE_DIR)
 
 _test:

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -144,11 +144,12 @@ MAN_TEST_BIN_LIST = $(foreach MAN_TEST_BIN_FILE, $(MAN_TEST_BIN_FILES), $(DIST_D
 # All skid_*.c filenames found in SRC_DIR
 SKID_SRC_FILES := $(shell ls $(SRC_DIR)skid_*$(SRC_FILE_EXT))
 SKID_HDR_FILES := $(shell ls $(INCLUDE_DIR)skid_*$(HDR_FILE_EXT))
-BASE_LIB_NAME = libsketchyidea
 MAJ_VER = 1
 MIN_VER = 0
 MIC_VER = 0
-SHORT_LIB_NAME = $(BASE_LIB_NAME)$(SHD_FILE_EXT).$(MAJ_VER)
+BASE_LIB_NAME = libsketchyidea
+BASE_SO_NAME = $(BASE_LIB_NAME)$(SHD_FILE_EXT)
+SHORT_LIB_NAME = $(BASE_SO_NAME).$(MAJ_VER)
 FULL_LIB_NAME = $(SHORT_LIB_NAME).$(MIN_VER).$(MIC_VER)
 
 
@@ -199,7 +200,9 @@ _compilation: $(foreach RAW_OBJ_FILE, $(RAW_OBJ_FILES), $(DIST_DIR)$(RAW_OBJ_FIL
 _install: $(DIST_DIR)$(FULL_LIB_NAME)
 	@echo "Installing $^"  # DEBUGGING
 	$(foreach SKID_HDR_FILE, $(SKID_HDR_FILES), sudo cp $(SKID_HDR_FILE) $(HDR_INSTALL_DIR);)
-	@sudo cp $(DIST_DIR)$(FULL_LIB_NAME) $(LIB_INSTALL_DIR)
+	sudo cp $(DIST_DIR)$(FULL_LIB_NAME) $(LIB_INSTALL_DIR)
+	sudo ln -f -s $(LIB_INSTALL_DIR)/$(FULL_LIB_NAME) $(LIB_INSTALL_DIR)/$(SHORT_LIB_NAME)
+	sudo ln -f -s $(LIB_INSTALL_DIR)/$(SHORT_LIB_NAME) $(LIB_INSTALL_DIR)/$(BASE_SO_NAME)
 
 _release:
 	@#echo "Releasing $(FULL_LIB_NAME)"  # DEBUGGING

--- a/code/src/skid_file_link.c
+++ b/code/src/skid_file_link.c
@@ -23,7 +23,7 @@
  *  Returns:
  *      An errno value indicating the results of validation.  ENOERR on successful validation.
  */
-int validate_pathname(const char *pathname);
+int validate_sfl_pathname(const char *pathname);
 
 
 /**************************************************************************************************/
@@ -37,10 +37,10 @@ int create_hard_link(const char *source, const char *hard_link)
     int errnum = ENOERR;  // Results of the function call
 
     // INPUT VALIDATION
-    errnum = validate_pathname(source);
+    errnum = validate_sfl_pathname(source);
     if (ENOERR == errnum)
     {
-        errnum = validate_pathname(hard_link);
+        errnum = validate_sfl_pathname(hard_link);
     }
 
     // CREATE IT
@@ -65,10 +65,10 @@ int create_sym_link(const char *source, const char *sym_link)
     int errnum = ENOERR;  // Results of the function call
 
     // INPUT VALIDATION
-    errnum = validate_pathname(source);
+    errnum = validate_sfl_pathname(source);
     if (ENOERR == errnum)
     {
-        errnum = validate_pathname(sym_link);
+        errnum = validate_sfl_pathname(sym_link);
     }
 
     // CREATE IT
@@ -92,7 +92,7 @@ int create_sym_link(const char *source, const char *sym_link)
 /**************************************************************************************************/
 
 
-int validate_pathname(const char *pathname)
+int validate_sfl_pathname(const char *pathname)
 {
     return validate_skid_pathname(pathname, false);  // Refactored for backwards compatibility
 }

--- a/code/src/skid_file_metadata_write.c
+++ b/code/src/skid_file_metadata_write.c
@@ -143,7 +143,7 @@ int validate_sfmw_input(const char *pathname, int *errnum);
  *  Returns:
  *      An errno value indicating the results of validation.  ENOERR on successful validation.
  */
-int validate_pathname(const char *pathname);
+int validate_sfmw_pathname(const char *pathname);
 
 /*
  *  Description:
@@ -169,7 +169,7 @@ int add_mode(const char *pathname, mode_t more_mode)
     mode_t new_mode = 0;  // Set this with set_mode()
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // ADD IT UP
     // 1. Get current mode
@@ -201,7 +201,7 @@ int remove_mode(const char *pathname, mode_t less_mode)
     mode_t new_mode = 0;  // Set this with set_mode()
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // ADD IT UP
     // 1. Get current mode
@@ -232,7 +232,7 @@ int set_atime(const char *pathname, bool follow_sym, time_t seconds, long nsecon
     struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     // Prepare atime
@@ -263,7 +263,7 @@ int set_atime_now(const char *pathname, bool follow_sym)
     struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     // Prepare atime
@@ -294,7 +294,7 @@ int set_group_id(const char *pathname, gid_t new_group, bool follow_sym)
     uid_t uid = SFMW_IGNORE_ID;  // Ignore the owner
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     if (ENOERR == result)
@@ -313,7 +313,7 @@ int set_mode(const char *pathname, mode_t new_mode)
     int result = ENOERR;  // 0 on success, errno on failure
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     if (ENOERR == result)
@@ -338,7 +338,7 @@ int set_mtime(const char *pathname, bool follow_sym, time_t seconds, long nsecon
     struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     // Prepare atime
@@ -369,7 +369,7 @@ int set_mtime_now(const char *pathname, bool follow_sym)
     struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     // Prepare atime
@@ -400,7 +400,7 @@ int set_owner_id(const char *pathname, uid_t new_owner, bool follow_sym)
     gid_t gid = SFMW_IGNORE_ID;  // Ignore the group
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     if (ENOERR == result)
@@ -419,7 +419,7 @@ int set_ownership(const char *pathname, uid_t new_owner, gid_t new_group, bool f
     int result = ENOERR;  // 0 on success, errno on failure
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     if (ENOERR == result)
@@ -439,7 +439,7 @@ int set_times(const char *pathname, bool follow_sym, time_t seconds, long nsecon
     struct timespec times[2] = {};  // Communicate with utimensat() using atime, mtime
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // SET IT
     // Prepare atime
@@ -469,7 +469,7 @@ int set_times_now(const char *pathname, bool follow_sym)
     int result = ENOERR;            // 0 on success, errno on failure
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // Call call_utnsat()
     if (ENOERR == result)
@@ -495,7 +495,7 @@ int call_a_chown(const char *pathname, uid_t new_owner, gid_t new_group, bool fo
     bool is_sym = false;  // Is pathname a symbolic link?
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // CALL IT
     // Is pathname a symbolic link?
@@ -527,7 +527,7 @@ int call_chown(const char *pathname, uid_t new_owner, gid_t new_group)
     int result = ENOERR;  // The results of execution
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // CALL IT
     if (ENOERR == result)
@@ -551,7 +551,7 @@ int call_lchown(const char *pathname, uid_t new_owner, gid_t new_group)
     int result = ENOERR;  // The results of execution
 
     // INPUT VALIDATION
-    result = validate_pathname(pathname);
+    result = validate_sfmw_pathname(pathname);
 
     // CALL IT
     if (ENOERR == result)
@@ -577,7 +577,7 @@ int call_utnsat(const char *pathname, const struct timespec times[2], bool follo
     int flags = 0;        // flags argument for utimensat()
 
     // INPUT VALIDATION
-    retval = validate_pathname(pathname);
+    retval = validate_sfmw_pathname(pathname);
     // CALL IT
     // Is pathname absolute?
     if (ENOERR == retval)
@@ -707,7 +707,7 @@ int validate_sfmw_input(const char *pathname, int *errnum)
 
     // VALIDATE IT
     // pathname
-    retval = validate_pathname(pathname);
+    retval = validate_sfmw_pathname(pathname);
     // errnum
     if (ENOERR == retval)
     {
@@ -723,7 +723,7 @@ int validate_sfmw_input(const char *pathname, int *errnum)
 }
 
 
-int validate_pathname(const char *pathname)
+int validate_sfmw_pathname(const char *pathname)
 {
     return validate_skid_pathname(pathname, false);  // Refactored for backwards compatibility
 }

--- a/code/test/test_libskid_sa_read_cpu_tsc.c
+++ b/code/test/test_libskid_sa_read_cpu_tsc.c
@@ -1,0 +1,67 @@
+/*
+ *  Manually test skid_assembly's inline assembly functionality...
+ *  ...using the libsketchyidea shared object.
+ *  This binary makes use of the read_cpu_tsc() to read the processor's timestamp counter.
+ *
+ *  Copy/paste the following...
+
+make
+make install
+./code/dist/test_sa_read_cpu_tsc.bin
+
+ *
+ */
+
+#ifndef SKID_DEBUG
+#define SKID_DEBUG                  // Enable DEBUG logging
+#endif  /* SKID_DEBUG */
+#define WAIT_SLEEP 1                // Number of seconds to wait
+#define NUM_LOOPS 10                // Number of times to loop
+
+#include <errno.h>                  // EINVAL
+#include <inttypes.h>               // PRIu64
+#include <stdio.h>                  // printf()
+#include <stdlib.h>                 // exit()
+#include <unistd.h>                 // sleep()
+#include "skid_assembly.h"          // read_cpu_tsc()
+#include "skid_macros.h"            // ENOERR
+
+/*
+ *  Single point of truth for this manual test code's usage.
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int exit_code = ENOERR;  // Errno values
+    uint64_t timestamp = 0;  // Processor's timestamp counter value
+
+    // INPUT VALIDATION
+    if (argc != 1)
+    {
+       print_usage(argv[0]);
+       exit_code = EINVAL;
+    }
+
+    // GET IT
+    if (ENOERR == exit_code)
+    {
+        for (int i = 0; i < NUM_LOOPS; i++)
+        {
+            timestamp = read_cpu_tsc();
+            printf("The timestamp is currently: %" PRIu64 "\n", timestamp);
+            sleep(WAIT_SLEEP);
+        }
+    }
+
+    // DONE
+    exit(exit_code);
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s\n", prog_name);
+}

--- a/code/test/test_libskid_sdo_read_dir_contents.c
+++ b/code/test/test_libskid_sdo_read_dir_contents.c
@@ -1,0 +1,160 @@
+/*
+ *	Manually test skid_dir_operations' read_dir_contents()...
+ *  ...using the libsketchyidea shared object.
+ *
+ *	Copy/paste the following...
+
+make
+make install
+./code/dist/test_sdo_read_dir_contents.bin <DIR_TO_READ>
+
+ *
+ */
+
+#define SKID_DEBUG						// Enable DEBUG logging
+
+#include <errno.h>						// EINVAL
+#include <stdlib.h>						// exit()
+#include "skid_debug.h"					// FPRINTF_ERR(), PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_dir_operations.h"		// read_dir_contents()
+#include "skid_file_metadata_read.h"	// is_directory()
+#include "skid_macros.h"				// ENOERR
+
+/*
+ *	Description:
+ *		Print num_entries number of entries from dir_contents.
+ *
+ *	Args:
+ *		dir_name: The name of the directory the contents were read from.
+ *		dir_contents: An NULL-terminate array of string pointers, on success.
+ *			May be NULL (for an empty dir).
+ *		num_entries: The total number of indices, 0 or otherwise, in dir_contents.
+ *
+ *	Returns:
+ *		ENOERR on success, errno on failure.  EIO is used to indicate a mismatch between the
+ *		NULL-terminated dir_contents and num_entries.
+ */
+int print_contents(char *dir_name, char **dir_contents, size_t num_entries);
+
+/*
+ *	Description:
+ *		Print the "help" usage for this manual test code.
+ *
+ *	Args:
+ *		prog_name: Pass in argv[0] here.
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+	// LOCAL VARIABLES
+	int exit_code = 0;           // Store errno and/or results here
+	bool recurse = false;        // Recurse argument value for read_dir_contents()
+	char **dir_contents = NULL;  // Pointer to an array of character pointers
+	size_t num_entries = 0;      // Number of entries in the dir_contents array
+
+	// INPUT VALIDATION
+	if (argc != 2)
+	{
+		print_usage(argv[0]);
+		exit_code = EINVAL;
+	}
+	else if (false == is_directory(argv[1], &exit_code))
+	{
+		fprintf(stderr, "'%s' is not a directory.\n%s\n", argv[1], strerror(exit_code));
+		print_usage(argv[0]);
+		if (ENOERR == exit_code)
+		{
+			exit_code = ENOTDIR;  // Just in case
+		}
+	}
+	
+	// READ IT
+	if (ENOERR == exit_code)
+	{
+		dir_contents = read_dir_contents(argv[1], recurse, &exit_code, &num_entries);
+		if (ENOERR == exit_code)
+		{
+			exit_code = print_contents(argv[1], dir_contents, num_entries);
+		}
+		else
+		{
+			PRINT_ERROR(The call to read_dir_contents() failed);
+			PRINT_ERRNO(exit_code);
+		}
+	}
+
+	// CLEANUP
+	free_skid_dir_contents(&dir_contents);  // Best effort
+
+	// DONE
+	exit(exit_code);
+}
+
+
+int print_contents(char *dir_name, char **dir_contents, size_t num_entries)
+{
+	// LOCAL VARIABLES
+	int errnum = ENOERR;    // Errno value to return
+	char **tmp_ptr = NULL;  // Iterating variable
+	int count = 0;          // Number of entries found in dir_contents
+
+	// INPUT VALIDATION
+	if (NULL == dir_name || 0x0 == *dir_name)
+	{
+		errnum = EINVAL;  // Bad string
+	}
+	if (NULL == dir_contents && 0 != num_entries)
+	{
+		FPRINTF_ERR("Directory contents are empty but num_entries is %lu\n", num_entries);
+		errnum = EIO;  // Mismatch
+	}
+	else if (NULL != dir_contents && 0 == num_entries)
+	{
+		FPRINTF_ERR("Directory contents exist but num_entries is %lu\n", num_entries);
+		errnum = EIO;  // Mismatch
+	}
+	else
+	{
+		// Validate length
+		tmp_ptr = dir_contents;
+		while (tmp_ptr && *tmp_ptr)
+		{
+			count++;  // Increment the count
+			tmp_ptr++;  // Next position
+		}
+		if (count >= num_entries && count > 0)
+		{
+			FPRINTF_ERR("Directory content count is %d but num_entries is %lu\n",
+				        count, num_entries);
+			errnum = EIO;  // Mismatch
+		}
+	}
+
+	// PRINT CONTENTS
+	if (ENOERR == errnum)
+	{
+		printf("The contents of '%s':\n", dir_name);
+		if (NULL == dir_contents)
+		{
+			printf("\t[EMPTY]\n");
+		}
+		else
+		{
+			for (int i = 0; i < num_entries && dir_contents[i]; i++)
+			{
+				printf("\t%s\n", dir_contents[i]);
+			}
+		}
+	}
+
+	// DONE
+	return errnum;
+}
+
+
+void print_usage(const char *prog_name)
+{
+	fprintf(stderr, "Usage: %s <DIRECTORY>\n", prog_name);
+}

--- a/code/test/test_libskid_sfmr_get_file_perms.c
+++ b/code/test/test_libskid_sfmr_get_file_perms.c
@@ -1,0 +1,63 @@
+/*
+ *	Manually test skid_file_metadata_read.h's get_file_perms() function...
+ *  ...using the libsketchyidea shared object.
+ *
+ *	Copy/paste the following...
+
+make
+make install
+./code/dist/test_sfmr_get_file_perms.bin ./code/test/test_input/regular_file.txt
+./code/dist/test_sfmr_get_file_perms.bin ./code/test/test_input/
+./code/dist/test_sfmr_get_file_perms.bin ./code/test/test_input/sym_link.txt
+
+ *	NOTE: A symbolic link identifies as a regular file here because stat() follows symbolic links.
+ *		Use lstat() to positively identify symbolic links.
+ */
+
+// Standard includes
+#include <errno.h>                    // EINVAL
+#include <stdint.h>					  // uintmax_t
+#include <stdio.h>                    // fprintf()
+#include <stdlib.h>					  // exit()
+// Local includes
+#define SKID_DEBUG                    // The DEBUG output is doing double duty as test output
+#include "skid_debug.h"               // PRINT_ERRNO(), PRINT_ERROR()
+#include "skid_file_metadata_read.h"  // get_file_perms()
+
+
+int main(int argc, char *argv[])
+{
+	// LOCAL VARIABLES
+	int exit_code = 0;      // Store errno and/or results here
+	mode_t answer = 0;      // Return value from get_file_perms()
+	char *pathname = NULL;  // Get this from argv[1]
+
+	// INPUT VALIDATION
+	if (argc != 2)
+	{
+	   fprintf(stderr, "Usage: %s <pathname>\n", argv[0]);
+	   exit_code = EINVAL;
+	}
+	else
+	{
+		pathname = argv[1];
+	}
+
+	// CHECK IT
+	if (!exit_code)
+	{
+		answer = get_file_perms(pathname, &exit_code);
+		if (exit_code)
+		{
+			PRINT_ERROR(The call to get_file_perms() failed);
+			PRINT_ERRNO(exit_code);
+		}
+		else
+		{
+			printf("%s has the following permissions: %jo (octal).\n", pathname, (uintmax_t)answer);
+		}
+	}
+
+	// DONE
+	exit(exit_code);
+}

--- a/devops/files/8-4_output.txt
+++ b/devops/files/8-4_output.txt
@@ -1,0 +1,1067 @@
+Wed Jun 11 17:13:22 UTC 2025
+
+VALIDATING
+    Validating gcc
+        [✓] gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+    Validating glibc
+        [✓] ldd (Ubuntu GLIBC 2.35-0ubuntu3.10) 2.35
+    Validating Check
+        [✓] Check unit test version: (0) (15) (2)
+    Validating musl-gcc
+        [✓] x86_64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+
+CLEANING
+    Cleaning dist/ directory
+
+COMPILING
+    Compiling: src/devops_code.c
+    Compiling: src/skid_assembly.c
+    Compiling: src/skid_dir_operations.c
+    Compiling: src/skid_file_control.c
+    Compiling: src/skid_file_descriptors.c
+    Compiling: src/skid_file_link.c
+    Compiling: src/skid_file_metadata_read.c
+    Compiling: src/skid_file_metadata_write.c
+    Compiling: src/skid_file_operations.c
+    Compiling: src/skid_memory.c
+    Compiling: src/skid_network.c
+    Compiling: src/skid_signal_handlers.c
+    Compiling: src/skid_signals.c
+    Compiling: src/skid_time.c
+    Compiling: src/skid_validation.c
+    Compiling: src/unit_test_code.c
+    Compiling manual test object code: dist/test_devops_code_create_path_tree.o
+    Linking manual test binary: dist/test_devops_code_create_path_tree.bin
+    Compiling manual test object code: dist/test_devops_code_get_compatible_gid.o
+    Linking manual test binary: dist/test_devops_code_get_compatible_gid.bin
+    Compiling manual test object code: dist/test_feature_test_macros.o
+    Linking manual test binary: dist/test_feature_test_macros.bin
+    Compiling manual test object code: dist/test_libskid_sa_read_cpu_tsc.o
+    Linking manual test binary against libsketchyidea: dist/test_libskid_sa_read_cpu_tsc.bin
+    Compiling manual test object code: dist/test_libskid_sdo_read_dir_contents.o
+    Linking manual test binary against libsketchyidea: dist/test_libskid_sdo_read_dir_contents.bin
+    Compiling manual test object code: dist/test_libskid_sfmr_get_file_perms.o
+    Linking manual test binary against libsketchyidea: dist/test_libskid_sfmr_get_file_perms.bin
+    Statically compiling bespoke binary: dist/test_misc_glibc_vs_musl-static_glibc.bin
+    Statically compiling bespoke binary: dist/test_misc_glibc_vs_musl-static_musl.bin
+    Compiling manual test object code: dist/test_misc_setjmp_longjmp.o
+    Linking manual test binary: dist/test_misc_setjmp_longjmp.bin
+    Compiling manual test object code: dist/test_sa_read_cpu_tsc.o
+    Linking manual test binary: dist/test_sa_read_cpu_tsc.bin
+    Compiling manual test object code: dist/test_sdo_read_dir_contents.o
+    Linking manual test binary: dist/test_sdo_read_dir_contents.bin
+    Compiling manual test object code: dist/test_sfc_lock_and_write_fd.o
+    Linking manual test binary: dist/test_sfc_lock_and_write_fd.bin
+    Compiling manual test object code: dist/test_sfc_read_locked_fd.o
+    Linking manual test binary: dist/test_sfc_read_locked_fd.bin
+    Compiling manual test object code: dist/test_sfc_write_locked_fd.o
+    Linking manual test binary: dist/test_sfc_write_locked_fd.bin
+    Compiling manual test object code: dist/test_sfl_create_hard_link.o
+    Linking manual test binary: dist/test_sfl_create_hard_link.bin
+    Compiling manual test object code: dist/test_sfl_create_sym_link.o
+    Linking manual test binary: dist/test_sfl_create_sym_link.bin
+    Compiling manual test object code: dist/test_sfmr_file_metadata.o
+    Linking manual test binary: dist/test_sfmr_file_metadata.bin
+    Compiling manual test object code: dist/test_sfmr_get_block_size.o
+    Linking manual test binary: dist/test_sfmr_get_block_size.bin
+    Compiling manual test object code: dist/test_sfmr_get_container_device_id.o
+    Linking manual test binary: dist/test_sfmr_get_container_device_id.bin
+    Compiling manual test object code: dist/test_sfmr_get_file_device_id.o
+    Linking manual test binary: dist/test_sfmr_get_file_device_id.bin
+    Compiling manual test object code: dist/test_sfmr_get_file_perms.o
+    Linking manual test binary: dist/test_sfmr_get_file_perms.bin
+    Compiling manual test object code: dist/test_sfmr_get_file_times.o
+    Linking manual test binary: dist/test_sfmr_get_file_times.bin
+    Compiling manual test object code: dist/test_sfmr_is_block_device.o
+    Linking manual test binary: dist/test_sfmr_is_block_device.bin
+    Compiling manual test object code: dist/test_sfmr_is_character_device.o
+    Linking manual test binary: dist/test_sfmr_is_character_device.bin
+    Compiling manual test object code: dist/test_sfmr_is_named_pipe.o
+    Linking manual test binary: dist/test_sfmr_is_named_pipe.bin
+    Compiling manual test object code: dist/test_sfmr_is_regular_file.o
+    Linking manual test binary: dist/test_sfmr_is_regular_file.bin
+    Compiling manual test object code: dist/test_sfmr_is_symbolic_link.o
+    Linking manual test binary: dist/test_sfmr_is_symbolic_link.bin
+    Compiling manual test object code: dist/test_sfmw_set_atime_now.o
+    Linking manual test binary: dist/test_sfmw_set_atime_now.bin
+    Compiling manual test object code: dist/test_sfmw_set_ownership.o
+    Linking manual test binary: dist/test_sfmw_set_ownership.bin
+    Compiling manual test object code: dist/test_sfmw_set_times.o
+    Linking manual test binary: dist/test_sfmw_set_times.bin
+    Compiling manual test object code: dist/test_sn_multi_sniffer.o
+    Linking manual test binary: dist/test_sn_multi_sniffer.bin
+    Compiling manual test object code: dist/test_sn_simple_dgram_client.o
+    Linking manual test binary: dist/test_sn_simple_dgram_client.bin
+    Compiling manual test object code: dist/test_sn_simple_dgram_server.o
+    Linking manual test binary: dist/test_sn_simple_dgram_server.bin
+    Compiling manual test object code: dist/test_sn_simple_sniffer.o
+    Linking manual test binary: dist/test_sn_simple_sniffer.bin
+    Compiling manual test object code: dist/test_sn_simple_stream_client.o
+    Linking manual test binary: dist/test_sn_simple_stream_client.bin
+    Compiling manual test object code: dist/test_sn_simple_stream_server.o
+    Linking manual test binary: dist/test_sn_simple_stream_server.bin
+    Compiling manual test object code: dist/test_ss_block_unblock.o
+    Linking manual test binary: dist/test_ss_block_unblock.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_async_client.o
+    Linking manual test binary: dist/test_ssh_handle_ext_async_client.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_async_server.o
+    Linking manual test binary: dist/test_ssh_handle_ext_async_server.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_read_queue_int.o
+    Linking manual test binary: dist/test_ssh_handle_ext_read_queue_int.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_sending_process.o
+    Linking manual test binary: dist/test_ssh_handle_ext_sending_process.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_signal_code.o
+    Linking manual test binary: dist/test_ssh_handle_ext_signal_code.bin
+    Compiling manual test object code: dist/test_ssh_handle_interruptions.o
+    Linking manual test binary: dist/test_ssh_handle_interruptions.bin
+    Compiling manual test object code: dist/test_ssh_handle_signal_number.o
+    Linking manual test binary: dist/test_ssh_handle_signal_number.bin
+    Compiling bespoke binary: dist/redirect_bin_output.bin
+    Compiling Check unit test code: test/check_sdo_create_dir.c
+    Linking Check unit test binary: dist/check_sdo_create_dir.bin
+    Compiling Check unit test code: test/check_sdo_delete_dir.c
+    Linking Check unit test binary: dist/check_sdo_delete_dir.bin
+    Compiling Check unit test code: test/check_sdo_destroy_dir.c
+    Linking Check unit test binary: dist/check_sdo_destroy_dir.bin
+    Compiling Check unit test code: test/check_sdo_read_dir_contents.c
+    Linking Check unit test binary: dist/check_sdo_read_dir_contents.bin
+    Compiling Check unit test code: test/check_sfc_is_close_on_exec.c
+    Linking Check unit test binary: dist/check_sfc_is_close_on_exec.bin
+    Compiling Check unit test code: test/check_sfl_create_hard_link.c
+    Linking Check unit test binary: dist/check_sfl_create_hard_link.bin
+    Compiling Check unit test code: test/check_sfl_create_sym_link.c
+    Linking Check unit test binary: dist/check_sfl_create_sym_link.bin
+    Compiling Check unit test code: test/check_sfmr_get_access_time.c
+    Linking Check unit test binary: dist/check_sfmr_get_access_time.bin
+    Compiling Check unit test code: test/check_sfmr_get_block_count.c
+    Linking Check unit test binary: dist/check_sfmr_get_block_count.bin
+    Compiling Check unit test code: test/check_sfmr_get_block_size.c
+    Linking Check unit test binary: dist/check_sfmr_get_block_size.bin
+    Compiling Check unit test code: test/check_sfmr_get_change_time.c
+    Linking Check unit test binary: dist/check_sfmr_get_change_time.bin
+    Compiling Check unit test code: test/check_sfmr_get_container_device_id.c
+    Linking Check unit test binary: dist/check_sfmr_get_container_device_id.bin
+    Compiling Check unit test code: test/check_sfmr_get_file_device_id.c
+    Linking Check unit test binary: dist/check_sfmr_get_file_device_id.bin
+    Compiling Check unit test code: test/check_sfmr_get_file_perms.c
+    Linking Check unit test binary: dist/check_sfmr_get_file_perms.bin
+    Compiling Check unit test code: test/check_sfmr_get_file_type.c
+    Linking Check unit test binary: dist/check_sfmr_get_file_type.bin
+    Compiling Check unit test code: test/check_sfmr_get_group.c
+    Linking Check unit test binary: dist/check_sfmr_get_group.bin
+    Compiling Check unit test code: test/check_sfmr_get_hard_link_num.c
+    Linking Check unit test binary: dist/check_sfmr_get_hard_link_num.bin
+    Compiling Check unit test code: test/check_sfmr_get_mod_time.c
+    Linking Check unit test binary: dist/check_sfmr_get_mod_time.bin
+    Compiling Check unit test code: test/check_sfmr_get_owner.c
+    Linking Check unit test binary: dist/check_sfmr_get_owner.bin
+    Compiling Check unit test code: test/check_sfmr_get_serial_num.c
+    Linking Check unit test binary: dist/check_sfmr_get_serial_num.bin
+    Compiling Check unit test code: test/check_sfmr_get_size.c
+    Linking Check unit test binary: dist/check_sfmr_get_size.bin
+    Compiling Check unit test code: test/check_sfmr_is_block_device.c
+    Linking Check unit test binary: dist/check_sfmr_is_block_device.bin
+    Compiling Check unit test code: test/check_sfmr_is_character_device.c
+    Linking Check unit test binary: dist/check_sfmr_is_character_device.bin
+    Compiling Check unit test code: test/check_sfmr_is_directory.c
+    Linking Check unit test binary: dist/check_sfmr_is_directory.bin
+    Compiling Check unit test code: test/check_sfmr_is_named_pipe.c
+    Linking Check unit test binary: dist/check_sfmr_is_named_pipe.bin
+    Compiling Check unit test code: test/check_sfmr_is_regular_file.c
+    Linking Check unit test binary: dist/check_sfmr_is_regular_file.bin
+    Compiling Check unit test code: test/check_sfmr_is_socket.c
+    Linking Check unit test binary: dist/check_sfmr_is_socket.bin
+    Compiling Check unit test code: test/check_sfmr_is_sym_link.c
+    Linking Check unit test binary: dist/check_sfmr_is_sym_link.bin
+    Compiling Check unit test code: test/check_sfmw_add_mode.c
+    Linking Check unit test binary: dist/check_sfmw_add_mode.bin
+    Compiling Check unit test code: test/check_sfmw_remove_mode.c
+    Linking Check unit test binary: dist/check_sfmw_remove_mode.bin
+    Compiling Check unit test code: test/check_sfmw_set_atime.c
+    Linking Check unit test binary: dist/check_sfmw_set_atime.bin
+    Compiling Check unit test code: test/check_sfmw_set_atime_now.c
+    Linking Check unit test binary: dist/check_sfmw_set_atime_now.bin
+    Compiling Check unit test code: test/check_sfmw_set_mode.c
+    Linking Check unit test binary: dist/check_sfmw_set_mode.bin
+    Compiling Check unit test code: test/check_sfmw_set_mtime.c
+    Linking Check unit test binary: dist/check_sfmw_set_mtime.bin
+    Compiling Check unit test code: test/check_sfmw_set_mtime_now.c
+    Linking Check unit test binary: dist/check_sfmw_set_mtime_now.bin
+    Compiling Check unit test code: test/check_sfmw_set_ownership.c
+    Linking Check unit test binary: dist/check_sfmw_set_ownership.bin
+    Compiling Check unit test code: test/check_sfmw_set_times.c
+    Linking Check unit test binary: dist/check_sfmw_set_times.bin
+    Compiling Check unit test code: test/check_sfmw_set_times_now.c
+    Linking Check unit test binary: dist/check_sfmw_set_times_now.bin
+    Compiling Check unit test code: test/check_sv_validate_pathname.c
+    Linking Check unit test binary: dist/check_sv_validate_pathname.bin
+
+RUNNING TEST CASES
+./dist/check_sdo_create_dir.bin
+Running suite(s): SDO_Create_Dir
+100%: Checks: 20, Failures: 0, Errors: 0
+./dist/check_sdo_delete_dir.bin
+Running suite(s): SDO_Delete_Dir
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sdo_destroy_dir.bin
+Running suite(s): SDO_Destroy_Dir
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sdo_read_dir_contents.bin
+Running suite(s): SDO_Read_Dir_Contents
+100%: Checks: 27, Failures: 0, Errors: 0
+./dist/check_sfc_is_close_on_exec.bin
+Running suite(s): SFC_Is_Close_On_Exec
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfl_create_hard_link.bin
+Running suite(s): SFL_Create_Hard_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+./dist/check_sfl_create_sym_link.bin
+Running suite(s): SFL_Create_Sym_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+./dist/check_sfmr_get_access_time.bin
+Running suite(s): SFMR_Get_Access_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_block_count.bin
+Running suite(s): SFMR_Get_Block_Count
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_block_size.bin
+Running suite(s): SFMR_Get_Block_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_change_time.bin
+Running suite(s): SFMR_Get_Change_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_container_device_id.bin
+Running suite(s): SFMR_Get_Container_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_file_device_id.bin
+Running suite(s): SFMR_Get_File_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_file_perms.bin
+Running suite(s): SFMR_Get_File_Perms
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_file_type.bin
+Running suite(s): SFMR_Get_File_Type
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_group.bin
+Running suite(s): SFMR_Get_Group
+100%: Checks: 12, Failures: 0, Errors: 0
+./dist/check_sfmr_get_hard_link_num.bin
+Running suite(s): SFMR_Get_Hard_Link_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_mod_time.bin
+Running suite(s): SFMR_Get_Mod_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_owner.bin
+Running suite(s): SFMR_Get_Owner
+100%: Checks: 12, Failures: 0, Errors: 0
+./dist/check_sfmr_get_serial_num.bin
+Running suite(s): SFMR_Get_Serial_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_size.bin
+Running suite(s): SFMR_Get_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_block_device.bin
+Running suite(s): SFMR_Is_Block_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_character_device.bin
+Running suite(s): SFMR_Is_Character_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_directory.bin
+Running suite(s): SFMR_Is_Directory
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_named_pipe.bin
+Running suite(s): SFMR_Is_Named_Pipe
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_regular_file.bin
+Running suite(s): SFMR_Is_Regular_File
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_socket.bin
+Running suite(s): SFMR_Is_Socket
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_sym_link.bin
+Running suite(s): SFMR_Is_Sym_Link
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmw_add_mode.bin
+Running suite(s): SFMW_Add_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sfmw_remove_mode.bin
+Running suite(s): SFMW_Remove_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sfmw_set_atime.bin
+Running suite(s): SFMW_Set_Atime
+100%: Checks: 24, Failures: 0, Errors: 0
+./dist/check_sfmw_set_atime_now.bin
+Running suite(s): SFMW_Set_Atime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmw_set_mode.bin
+Running suite(s): SFMW_Set_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sfmw_set_mtime.bin
+Running suite(s): SFMW_Set_Mtime
+100%: Checks: 24, Failures: 0, Errors: 0
+./dist/check_sfmw_set_mtime_now.bin
+Running suite(s): SFMW_Set_Mtime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmw_set_ownership.bin
+Running suite(s): SFMW_Set_Ownership
+100%: Checks: 20, Failures: 0, Errors: 0
+./dist/check_sfmw_set_times.bin
+Running suite(s): SFMW_Set_Times
+100%: Checks: 24, Failures: 0, Errors: 0
+./dist/check_sfmw_set_times_now.bin
+Running suite(s): SFMW_Set_Times_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sv_validate_pathname.bin
+Running suite(s): SV_Validate_Pathname
+100%: Checks: 11, Failures: 0, Errors: 0
+
+RELEASING
+Releasing libsketchyidea.so.1.0.0
+
+==23143== Memcheck, a memory error detector
+==23143== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23143== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23143== Command: code/dist/check_sdo_create_dir.bin
+==23143== 
+Running suite(s): SDO_Create_Dir
+100%: Checks: 20, Failures: 0, Errors: 0
+==23143== 
+==23143== HEAP SUMMARY:
+==23143==     in use at exit: 0 bytes in 0 blocks
+==23143==   total heap usage: 1,142 allocs, 1,142 frees, 535,508 bytes allocated
+==23143== 
+==23143== All heap blocks were freed -- no leaks are possible
+==23143== 
+==23143== For lists of detected and suppressed errors, rerun with: -s
+==23143== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23226== Memcheck, a memory error detector
+==23226== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23226== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23226== Command: code/dist/check_sdo_delete_dir.bin
+==23226== 
+Running suite(s): SDO_Delete_Dir
+100%: Checks: 11, Failures: 0, Errors: 0
+==23226== 
+==23226== HEAP SUMMARY:
+==23226==     in use at exit: 0 bytes in 0 blocks
+==23226==   total heap usage: 379 allocs, 379 frees, 174,636 bytes allocated
+==23226== 
+==23226== All heap blocks were freed -- no leaks are possible
+==23226== 
+==23226== For lists of detected and suppressed errors, rerun with: -s
+==23226== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23231== Memcheck, a memory error detector
+==23231== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23231== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23231== Command: code/dist/check_sdo_destroy_dir.bin
+==23231== 
+Running suite(s): SDO_Destroy_Dir
+100%: Checks: 16, Failures: 0, Errors: 0
+==23231== 
+==23231== HEAP SUMMARY:
+==23231==     in use at exit: 0 bytes in 0 blocks
+==23231==   total heap usage: 1,100 allocs, 1,100 frees, 1,556,072 bytes allocated
+==23231== 
+==23231== All heap blocks were freed -- no leaks are possible
+==23231== 
+==23231== For lists of detected and suppressed errors, rerun with: -s
+==23231== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23267== Memcheck, a memory error detector
+==23267== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23267== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23267== Command: code/dist/check_sdo_read_dir_contents.bin
+==23267== 
+Running suite(s): SDO_Read_Dir_Contents
+100%: Checks: 27, Failures: 0, Errors: 0
+==23267== 
+==23267== HEAP SUMMARY:
+==23267==     in use at exit: 0 bytes in 0 blocks
+==23267==   total heap usage: 4,188 allocs, 4,188 frees, 2,665,189 bytes allocated
+==23267== 
+==23267== All heap blocks were freed -- no leaks are possible
+==23267== 
+==23267== For lists of detected and suppressed errors, rerun with: -s
+==23267== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23454== Memcheck, a memory error detector
+==23454== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23454== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23454== Command: code/dist/check_sfc_is_close_on_exec.bin
+==23454== 
+Running suite(s): SFC_Is_Close_On_Exec
+100%: Checks: 11, Failures: 0, Errors: 0
+==23454== 
+==23454== HEAP SUMMARY:
+==23454==     in use at exit: 0 bytes in 0 blocks
+==23454==   total heap usage: 1,293 allocs, 1,293 frees, 380,239 bytes allocated
+==23454== 
+==23454== All heap blocks were freed -- no leaks are possible
+==23454== 
+==23454== For lists of detected and suppressed errors, rerun with: -s
+==23454== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23477== Memcheck, a memory error detector
+==23477== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23477== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23477== Command: code/dist/check_sfl_create_hard_link.bin
+==23477== 
+Running suite(s): SFL_Create_Hard_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+==23477== 
+==23477== HEAP SUMMARY:
+==23477==     in use at exit: 0 bytes in 0 blocks
+==23477==   total heap usage: 1,537 allocs, 1,537 frees, 477,742 bytes allocated
+==23477== 
+==23477== All heap blocks were freed -- no leaks are possible
+==23477== 
+==23477== For lists of detected and suppressed errors, rerun with: -s
+==23477== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23506== Memcheck, a memory error detector
+==23506== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23506== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23506== Command: code/dist/check_sfl_create_sym_link.bin
+==23506== 
+Running suite(s): SFL_Create_Sym_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+==23506== 
+==23506== HEAP SUMMARY:
+==23506==     in use at exit: 0 bytes in 0 blocks
+==23506==   total heap usage: 1,513 allocs, 1,513 frees, 476,691 bytes allocated
+==23506== 
+==23506== All heap blocks were freed -- no leaks are possible
+==23506== 
+==23506== For lists of detected and suppressed errors, rerun with: -s
+==23506== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23535== Memcheck, a memory error detector
+==23535== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23535== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23535== Command: code/dist/check_sfmr_get_access_time.bin
+==23535== 
+Running suite(s): SFMR_Get_Access_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+==23535== 
+==23535== HEAP SUMMARY:
+==23535==     in use at exit: 0 bytes in 0 blocks
+==23535==   total heap usage: 1,256 allocs, 1,256 frees, 410,552 bytes allocated
+==23535== 
+==23535== All heap blocks were freed -- no leaks are possible
+==23535== 
+==23535== For lists of detected and suppressed errors, rerun with: -s
+==23535== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23572== Memcheck, a memory error detector
+==23572== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23572== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23572== Command: code/dist/check_sfmr_get_block_count.bin
+==23572== 
+Running suite(s): SFMR_Get_Block_Count
+100%: Checks: 11, Failures: 0, Errors: 0
+==23572== 
+==23572== HEAP SUMMARY:
+==23572==     in use at exit: 0 bytes in 0 blocks
+==23572==   total heap usage: 403 allocs, 403 frees, 195,701 bytes allocated
+==23572== 
+==23572== All heap blocks were freed -- no leaks are possible
+==23572== 
+==23572== For lists of detected and suppressed errors, rerun with: -s
+==23572== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23587== Memcheck, a memory error detector
+==23587== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23587== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23587== Command: code/dist/check_sfmr_get_block_size.bin
+==23587== 
+Running suite(s): SFMR_Get_Block_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+==23587== 
+==23587== HEAP SUMMARY:
+==23587==     in use at exit: 0 bytes in 0 blocks
+==23587==   total heap usage: 395 allocs, 395 frees, 194,992 bytes allocated
+==23587== 
+==23587== All heap blocks were freed -- no leaks are possible
+==23587== 
+==23587== For lists of detected and suppressed errors, rerun with: -s
+==23587== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23604== Memcheck, a memory error detector
+==23604== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23604== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23604== Command: code/dist/check_sfmr_get_change_time.bin
+==23604== 
+Running suite(s): SFMR_Get_Change_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+==23604== 
+==23604== HEAP SUMMARY:
+==23604==     in use at exit: 0 bytes in 0 blocks
+==23604==   total heap usage: 375 allocs, 375 frees, 194,672 bytes allocated
+==23604== 
+==23604== All heap blocks were freed -- no leaks are possible
+==23604== 
+==23604== For lists of detected and suppressed errors, rerun with: -s
+==23604== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23621== Memcheck, a memory error detector
+==23621== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23621== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23621== Command: code/dist/check_sfmr_get_container_device_id.bin
+==23621== 
+Running suite(s): SFMR_Get_Container_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+==23621== 
+==23621== HEAP SUMMARY:
+==23621==     in use at exit: 0 bytes in 0 blocks
+==23621==   total heap usage: 318 allocs, 318 frees, 162,147 bytes allocated
+==23621== 
+==23621== All heap blocks were freed -- no leaks are possible
+==23621== 
+==23621== For lists of detected and suppressed errors, rerun with: -s
+==23621== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23622== Memcheck, a memory error detector
+==23622== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23622== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23622== Command: code/dist/check_sfmr_get_file_device_id.bin
+==23622== 
+Running suite(s): SFMR_Get_File_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+==23622== 
+==23622== HEAP SUMMARY:
+==23622==     in use at exit: 0 bytes in 0 blocks
+==23622==   total heap usage: 403 allocs, 403 frees, 196,340 bytes allocated
+==23622== 
+==23622== All heap blocks were freed -- no leaks are possible
+==23622== 
+==23622== For lists of detected and suppressed errors, rerun with: -s
+==23622== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23642== Memcheck, a memory error detector
+==23642== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23642== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23642== Command: code/dist/check_sfmr_get_file_perms.bin
+==23642== 
+Running suite(s): SFMR_Get_File_Perms
+100%: Checks: 11, Failures: 0, Errors: 0
+==23642== 
+==23642== HEAP SUMMARY:
+==23642==     in use at exit: 0 bytes in 0 blocks
+==23642==   total heap usage: 403 allocs, 403 frees, 195,488 bytes allocated
+==23642== 
+==23642== All heap blocks were freed -- no leaks are possible
+==23642== 
+==23642== For lists of detected and suppressed errors, rerun with: -s
+==23642== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23659== Memcheck, a memory error detector
+==23659== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23659== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23659== Command: code/dist/check_sfmr_get_file_type.bin
+==23659== 
+Running suite(s): SFMR_Get_File_Type
+100%: Checks: 11, Failures: 0, Errors: 0
+==23659== 
+==23659== HEAP SUMMARY:
+==23659==     in use at exit: 0 bytes in 0 blocks
+==23659==   total heap usage: 301 allocs, 301 frees, 154,685 bytes allocated
+==23659== 
+==23659== All heap blocks were freed -- no leaks are possible
+==23659== 
+==23659== For lists of detected and suppressed errors, rerun with: -s
+==23659== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23660== Memcheck, a memory error detector
+==23660== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23660== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23660== Command: code/dist/check_sfmr_get_group.bin
+==23660== 
+Running suite(s): SFMR_Get_Group
+100%: Checks: 12, Failures: 0, Errors: 0
+==23660== 
+==23660== HEAP SUMMARY:
+==23660==     in use at exit: 0 bytes in 0 blocks
+==23660==   total heap usage: 442 allocs, 442 frees, 213,025 bytes allocated
+==23660== 
+==23660== All heap blocks were freed -- no leaks are possible
+==23660== 
+==23660== For lists of detected and suppressed errors, rerun with: -s
+==23660== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23678== Memcheck, a memory error detector
+==23678== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23678== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23678== Command: code/dist/check_sfmr_get_hard_link_num.bin
+==23678== 
+Running suite(s): SFMR_Get_Hard_Link_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+==23678== 
+==23678== HEAP SUMMARY:
+==23678==     in use at exit: 0 bytes in 0 blocks
+==23678==   total heap usage: 403 allocs, 403 frees, 196,127 bytes allocated
+==23678== 
+==23678== All heap blocks were freed -- no leaks are possible
+==23678== 
+==23678== For lists of detected and suppressed errors, rerun with: -s
+==23678== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23693== Memcheck, a memory error detector
+==23693== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23693== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23693== Command: code/dist/check_sfmr_get_mod_time.bin
+==23693== 
+Running suite(s): SFMR_Get_Mod_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+==23693== 
+==23693== HEAP SUMMARY:
+==23693==     in use at exit: 0 bytes in 0 blocks
+==23693==   total heap usage: 375 allocs, 375 frees, 194,117 bytes allocated
+==23693== 
+==23693== All heap blocks were freed -- no leaks are possible
+==23693== 
+==23693== For lists of detected and suppressed errors, rerun with: -s
+==23693== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23708== Memcheck, a memory error detector
+==23708== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23708== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23708== Command: code/dist/check_sfmr_get_owner.bin
+==23708== 
+Running suite(s): SFMR_Get_Owner
+100%: Checks: 12, Failures: 0, Errors: 0
+==23708== 
+==23708== HEAP SUMMARY:
+==23708==     in use at exit: 0 bytes in 0 blocks
+==23708==   total heap usage: 442 allocs, 442 frees, 213,025 bytes allocated
+==23708== 
+==23708== All heap blocks were freed -- no leaks are possible
+==23708== 
+==23708== For lists of detected and suppressed errors, rerun with: -s
+==23708== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23725== Memcheck, a memory error detector
+==23725== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23725== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23725== Command: code/dist/check_sfmr_get_serial_num.bin
+==23725== 
+Running suite(s): SFMR_Get_Serial_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+==23725== 
+==23725== HEAP SUMMARY:
+==23725==     in use at exit: 0 bytes in 0 blocks
+==23725==   total heap usage: 1,284 allocs, 1,284 frees, 411,396 bytes allocated
+==23725== 
+==23725== All heap blocks were freed -- no leaks are possible
+==23725== 
+==23725== For lists of detected and suppressed errors, rerun with: -s
+==23725== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23762== Memcheck, a memory error detector
+==23762== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23762== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23762== Command: code/dist/check_sfmr_get_size.bin
+==23762== 
+Running suite(s): SFMR_Get_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+==23762== 
+==23762== HEAP SUMMARY:
+==23762==     in use at exit: 0 bytes in 0 blocks
+==23762==   total heap usage: 403 allocs, 403 frees, 194,210 bytes allocated
+==23762== 
+==23762== All heap blocks were freed -- no leaks are possible
+==23762== 
+==23762== For lists of detected and suppressed errors, rerun with: -s
+==23762== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23777== Memcheck, a memory error detector
+==23777== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23777== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23777== Command: code/dist/check_sfmr_is_block_device.bin
+==23777== 
+Running suite(s): SFMR_Is_Block_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+==23777== 
+==23777== HEAP SUMMARY:
+==23777==     in use at exit: 0 bytes in 0 blocks
+==23777==   total heap usage: 301 allocs, 301 frees, 154,997 bytes allocated
+==23777== 
+==23777== All heap blocks were freed -- no leaks are possible
+==23777== 
+==23777== For lists of detected and suppressed errors, rerun with: -s
+==23777== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23778== Memcheck, a memory error detector
+==23778== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23778== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23778== Command: code/dist/check_sfmr_is_character_device.bin
+==23778== 
+Running suite(s): SFMR_Is_Character_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+==23778== 
+==23778== HEAP SUMMARY:
+==23778==     in use at exit: 0 bytes in 0 blocks
+==23778==   total heap usage: 301 allocs, 301 frees, 155,621 bytes allocated
+==23778== 
+==23778== All heap blocks were freed -- no leaks are possible
+==23778== 
+==23778== For lists of detected and suppressed errors, rerun with: -s
+==23778== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23779== Memcheck, a memory error detector
+==23779== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23779== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23779== Command: code/dist/check_sfmr_is_directory.bin
+==23779== 
+Running suite(s): SFMR_Is_Directory
+100%: Checks: 11, Failures: 0, Errors: 0
+==23779== 
+==23779== HEAP SUMMARY:
+==23779==     in use at exit: 0 bytes in 0 blocks
+==23779==   total heap usage: 301 allocs, 301 frees, 154,529 bytes allocated
+==23779== 
+==23779== All heap blocks were freed -- no leaks are possible
+==23779== 
+==23779== For lists of detected and suppressed errors, rerun with: -s
+==23779== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23780== Memcheck, a memory error detector
+==23780== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23780== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23780== Command: code/dist/check_sfmr_is_named_pipe.bin
+==23780== 
+Running suite(s): SFMR_Is_Named_Pipe
+100%: Checks: 11, Failures: 0, Errors: 0
+==23780== 
+==23780== HEAP SUMMARY:
+==23780==     in use at exit: 0 bytes in 0 blocks
+==23780==   total heap usage: 301 allocs, 301 frees, 154,685 bytes allocated
+==23780== 
+==23780== All heap blocks were freed -- no leaks are possible
+==23780== 
+==23780== For lists of detected and suppressed errors, rerun with: -s
+==23780== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23781== Memcheck, a memory error detector
+==23781== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23781== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23781== Command: code/dist/check_sfmr_is_regular_file.bin
+==23781== 
+Running suite(s): SFMR_Is_Regular_File
+100%: Checks: 11, Failures: 0, Errors: 0
+==23781== 
+==23781== HEAP SUMMARY:
+==23781==     in use at exit: 0 bytes in 0 blocks
+==23781==   total heap usage: 301 allocs, 301 frees, 154,997 bytes allocated
+==23781== 
+==23781== All heap blocks were freed -- no leaks are possible
+==23781== 
+==23781== For lists of detected and suppressed errors, rerun with: -s
+==23781== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23782== Memcheck, a memory error detector
+==23782== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23782== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23782== Command: code/dist/check_sfmr_is_socket.bin
+==23782== 
+Running suite(s): SFMR_Is_Socket
+100%: Checks: 11, Failures: 0, Errors: 0
+==23782== 
+==23782== HEAP SUMMARY:
+==23782==     in use at exit: 0 bytes in 0 blocks
+==23782==   total heap usage: 301 allocs, 301 frees, 154,061 bytes allocated
+==23782== 
+==23782== All heap blocks were freed -- no leaks are possible
+==23782== 
+==23782== For lists of detected and suppressed errors, rerun with: -s
+==23782== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23783== Memcheck, a memory error detector
+==23783== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23783== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23783== Command: code/dist/check_sfmr_is_sym_link.bin
+==23783== 
+Running suite(s): SFMR_Is_Sym_Link
+100%: Checks: 11, Failures: 0, Errors: 0
+==23783== 
+==23783== HEAP SUMMARY:
+==23783==     in use at exit: 0 bytes in 0 blocks
+==23783==   total heap usage: 301 allocs, 301 frees, 154,373 bytes allocated
+==23783== 
+==23783== All heap blocks were freed -- no leaks are possible
+==23783== 
+==23783== For lists of detected and suppressed errors, rerun with: -s
+==23783== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==23784== Memcheck, a memory error detector
+==23784== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==23784== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==23784== Command: code/dist/check_sfmw_add_mode.bin
+==23784== 
+Running suite(s): SFMW_Add_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+==23784== 
+==23784== HEAP SUMMARY:
+==23784==     in use at exit: 0 bytes in 0 blocks
+==23784==   total heap usage: 5,321 allocs, 5,321 frees, 1,417,570 bytes allocated
+==23784== 
+==23784== All heap blocks were freed -- no leaks are possible
+==23784== 
+==23784== For lists of detected and suppressed errors, rerun with: -s
+==23784== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24153== Memcheck, a memory error detector
+==24153== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24153== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24153== Command: code/dist/check_sfmw_remove_mode.bin
+==24153== 
+Running suite(s): SFMW_Remove_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+==24153== 
+==24153== HEAP SUMMARY:
+==24153==     in use at exit: 0 bytes in 0 blocks
+==24153==   total heap usage: 5,321 allocs, 5,321 frees, 1,429,537 bytes allocated
+==24153== 
+==24153== All heap blocks were freed -- no leaks are possible
+==24153== 
+==24153== For lists of detected and suppressed errors, rerun with: -s
+==24153== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24522== Memcheck, a memory error detector
+==24522== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24522== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24522== Command: code/dist/check_sfmw_set_atime.bin
+==24522== 
+Running suite(s): SFMW_Set_Atime
+100%: Checks: 24, Failures: 0, Errors: 0
+==24522== 
+==24522== HEAP SUMMARY:
+==24522==     in use at exit: 0 bytes in 0 blocks
+==24522==   total heap usage: 2,628 allocs, 2,628 frees, 706,269 bytes allocated
+==24522== 
+==24522== All heap blocks were freed -- no leaks are possible
+==24522== 
+==24522== For lists of detected and suppressed errors, rerun with: -s
+==24522== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24523== Memcheck, a memory error detector
+==24523== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24523== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24523== Command: code/dist/check_sfmw_set_atime_now.bin
+==24523== 
+Running suite(s): SFMW_Set_Atime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+==24523== 
+==24523== HEAP SUMMARY:
+==24523==     in use at exit: 0 bytes in 0 blocks
+==24523==   total heap usage: 738 allocs, 738 frees, 315,349 bytes allocated
+==24523== 
+==24523== All heap blocks were freed -- no leaks are possible
+==24523== 
+==24523== For lists of detected and suppressed errors, rerun with: -s
+==24523== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24524== Memcheck, a memory error detector
+==24524== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24524== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24524== Command: code/dist/check_sfmw_set_mode.bin
+==24524== 
+Running suite(s): SFMW_Set_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+==24524== 
+==24524== HEAP SUMMARY:
+==24524==     in use at exit: 0 bytes in 0 blocks
+==24524==   total heap usage: 5,225 allocs, 5,225 frees, 1,359,890 bytes allocated
+==24524== 
+==24524== All heap blocks were freed -- no leaks are possible
+==24524== 
+==24524== For lists of detected and suppressed errors, rerun with: -s
+==24524== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24872== Memcheck, a memory error detector
+==24872== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24872== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24872== Command: code/dist/check_sfmw_set_mtime.bin
+==24872== 
+Running suite(s): SFMW_Set_Mtime
+100%: Checks: 24, Failures: 0, Errors: 0
+==24872== 
+==24872== HEAP SUMMARY:
+==24872==     in use at exit: 0 bytes in 0 blocks
+==24872==   total heap usage: 2,628 allocs, 2,628 frees, 706,269 bytes allocated
+==24872== 
+==24872== All heap blocks were freed -- no leaks are possible
+==24872== 
+==24872== For lists of detected and suppressed errors, rerun with: -s
+==24872== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24873== Memcheck, a memory error detector
+==24873== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24873== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24873== Command: code/dist/check_sfmw_set_mtime_now.bin
+==24873== 
+Running suite(s): SFMW_Set_Mtime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+==24873== 
+==24873== HEAP SUMMARY:
+==24873==     in use at exit: 0 bytes in 0 blocks
+==24873==   total heap usage: 738 allocs, 738 frees, 315,349 bytes allocated
+==24873== 
+==24873== All heap blocks were freed -- no leaks are possible
+==24873== 
+==24873== For lists of detected and suppressed errors, rerun with: -s
+==24873== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==24874== Memcheck, a memory error detector
+==24874== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==24874== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==24874== Command: code/dist/check_sfmw_set_ownership.bin
+==24874== 
+Running suite(s): SFMW_Set_Ownership
+100%: Checks: 20, Failures: 0, Errors: 0
+==24874== 
+==24874== HEAP SUMMARY:
+==24874==     in use at exit: 0 bytes in 0 blocks
+==24874==   total heap usage: 7,287 allocs, 7,287 frees, 1,517,442 bytes allocated
+==24874== 
+==24874== All heap blocks were freed -- no leaks are possible
+==24874== 
+==24874== For lists of detected and suppressed errors, rerun with: -s
+==24874== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==25147== Memcheck, a memory error detector
+==25147== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==25147== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==25147== Command: code/dist/check_sfmw_set_times.bin
+==25147== 
+Running suite(s): SFMW_Set_Times
+100%: Checks: 24, Failures: 0, Errors: 0
+==25147== 
+==25147== HEAP SUMMARY:
+==25147==     in use at exit: 0 bytes in 0 blocks
+==25147==   total heap usage: 2,748 allocs, 2,748 frees, 709,959 bytes allocated
+==25147== 
+==25147== All heap blocks were freed -- no leaks are possible
+==25147== 
+==25147== For lists of detected and suppressed errors, rerun with: -s
+==25147== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==25148== Memcheck, a memory error detector
+==25148== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==25148== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==25148== Command: code/dist/check_sfmw_set_times_now.bin
+==25148== 
+Running suite(s): SFMW_Set_Times_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+==25148== 
+==25148== HEAP SUMMARY:
+==25148==     in use at exit: 0 bytes in 0 blocks
+==25148==   total heap usage: 802 allocs, 802 frees, 317,573 bytes allocated
+==25148== 
+==25148== All heap blocks were freed -- no leaks are possible
+==25148== 
+==25148== For lists of detected and suppressed errors, rerun with: -s
+==25148== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==25149== Memcheck, a memory error detector
+==25149== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==25149== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==25149== Command: code/dist/check_sv_validate_pathname.bin
+==25149== 
+Running suite(s): SV_Validate_Pathname
+100%: Checks: 11, Failures: 0, Errors: 0
+==25149== 
+==25149== HEAP SUMMARY:
+==25149==     in use at exit: 0 bytes in 0 blocks
+==25149==   total heap usage: 1,160 allocs, 1,160 frees, 375,356 bytes allocated
+==25149== 
+==25149== All heap blocks were freed -- no leaks are possible
+==25149== 
+==25149== For lists of detected and suppressed errors, rerun with: -s
+==25149== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+
+TOTAL CHECK UNIT TESTS: 530
+
+
+*** SKETCHY IDEA (SKID) has been released as a shared object and installed locally ***
+Installed header files:
+The full command is 'ls -l /usr/include/skid*.h'
+Command output:
+-rw-r--r-- 1 root root   867 Jun 11 17:10 /usr/include/skid_assembly.h
+-rw-r--r-- 1 root root  1406 Jun 11 17:10 /usr/include/skid_debug.h
+-rw-r--r-- 1 root root  3742 Jun 11 17:10 /usr/include/skid_dir_operations.h
+-rw-r--r-- 1 root root  3241 Jun 11 17:10 /usr/include/skid_file_control.h
+-rw-r--r-- 1 root root  2567 Jun 11 17:10 /usr/include/skid_file_descriptors.h
+-rw-r--r-- 1 root root  2058 Jun 11 17:10 /usr/include/skid_file_link.h
+-rw-r--r-- 1 root root 20257 Jun 11 17:10 /usr/include/skid_file_metadata_read.h
+-rw-r--r-- 1 root root 10693 Jun 11 17:10 /usr/include/skid_file_metadata_write.h
+-rw-r--r-- 1 root root  2563 Jun 11 17:10 /usr/include/skid_file_operations.h
+-rw-r--r-- 1 root root  3264 Jun 11 17:10 /usr/include/skid_macros.h
+-rw-r--r-- 1 root root  1851 Jun 11 17:10 /usr/include/skid_memory.h
+-rw-r--r-- 1 root root 18601 Jun 11 17:10 /usr/include/skid_network.h
+-rw-r--r-- 1 root root  6372 Jun 11 17:10 /usr/include/skid_signal_handlers.h
+-rw-r--r-- 1 root root  3244 Jun 11 17:10 /usr/include/skid_signals.h
+-rw-r--r-- 1 root root  1548 Jun 11 17:10 /usr/include/skid_time.h
+-rw-r--r-- 1 root root  1770 Jun 11 17:10 /usr/include/skid_validation.h
+
+
+Installed shared object (with links):
+The full command is 'ls -l /lib/*sketchyidea*'
+Command output:
+lrwxrwxrwx 1 root root    24 Jun 11 17:10 /lib/libsketchyidea.so -> /lib/libsketchyidea.so.1
+lrwxrwxrwx 1 root root    28 Jun 11 17:10 /lib/libsketchyidea.so.1 -> /lib/libsketchyidea.so.1.0.0
+-rwxr-xr-x 1 root root 85032 Jun 11 17:10 /lib/libsketchyidea.so.1.0.0
+
+
+
+*** Statically compiled manual test code was also linked against the shared object ***
+./code/dist/test_libskid_sa_read_cpu_tsc.bin was linked against the SKID shared object
+The full command is 'ldd ./code/dist/test_libskid_sa_read_cpu_tsc.bin'
+Command output:
+	linux-vdso.so.1 (0x00007fff15dd5000)
+	libsketchyidea.so.1 => /lib/libsketchyidea.so.1 (0x00007fb37ac0b000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb37a9e2000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fb37ac34000)
+
+
+./code/dist/test_sa_read_cpu_tsc.bin was compiled against the source code
+The full command is 'ldd ./code/dist/test_sa_read_cpu_tsc.bin'
+Command output:
+	linux-vdso.so.1 (0x00007ffc5f7ae000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdcd4220000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fdcd445f000)
+
+
+./code/dist/test_libskid_sdo_read_dir_contents.bin was linked against the SKID shared object
+The full command is 'ldd ./code/dist/test_libskid_sdo_read_dir_contents.bin'
+Command output:
+	linux-vdso.so.1 (0x00007ffea566c000)
+	libsketchyidea.so.1 => /lib/libsketchyidea.so.1 (0x00007f7de3ce3000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7de3aba000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f7de3d0c000)
+
+
+./code/dist/test_sdo_read_dir_contents.bin was compiled against the source code
+The full command is 'ldd ./code/dist/test_sdo_read_dir_contents.bin'
+Command output:
+	linux-vdso.so.1 (0x00007ffd8bfd2000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f80fcb67000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f80fcdaa000)
+
+
+./code/dist/test_libskid_sfmr_get_file_perms.bin was linked against the SKID shared object
+The full command is 'ldd ./code/dist/test_libskid_sfmr_get_file_perms.bin'
+Command output:
+	linux-vdso.so.1 (0x00007ffe573ba000)
+	libsketchyidea.so.1 => /lib/libsketchyidea.so.1 (0x00007f070b838000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f070b60f000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f070b861000)
+
+
+./code/dist/test_sfmr_get_file_perms.bin was compiled against the source code
+The full command is 'ldd ./code/dist/test_sfmr_get_file_perms.bin'
+Command output:
+	linux-vdso.so.1 (0x00007ffc847d0000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0b2ba9e000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f0b2bcde000)
+
+
+
+*** Executing the manual test code linked against the shared object ***
+The full command is './code/dist/test_libskid_sa_read_cpu_tsc.bin'
+Command output:
+The timestamp is currently: 978859781838
+The timestamp is currently: 981550516588
+The timestamp is currently: 984239181726
+The timestamp is currently: 986928223522
+The timestamp is currently: 989661935090
+The timestamp is currently: 992355884481
+The timestamp is currently: 995055951356
+The timestamp is currently: 997743959392
+The timestamp is currently: 1000440133582
+The timestamp is currently: 1003129925439
+
+
+The full command is './code/dist/test_libskid_sdo_read_dir_contents.bin ./'
+Command output:
+The contents of './':
+	./LICENSE
+	./README.md
+	./devops
+	./main.dot
+	./.git
+	./Makefile
+	./.gitattributes
+	./.modules
+	./code
+	./.gitignore
+
+
+The full command is './code/dist/test_libskid_sfmr_get_file_perms.bin ./README.md'
+Command output:
+./README.md has the following permissions: 664 (octal).
+
+

--- a/devops/scripts/8-4_export.sh
+++ b/devops/scripts/8-4_export.sh
@@ -74,14 +74,14 @@ EXIT_CODE=0                                                         # Exit value
 DIST_DIR=./code/dist/
 MAN_TEST_BIN=("${DIST_DIR}test_libskid_sa_read_cpu_tsc.bin" "${DIST_DIR}test_libskid_sdo_read_dir_contents.bin" "${DIST_DIR}test_libskid_sfmr_get_file_perms.bin")
 
-# # 1. Stores the date
-# date && \
-# # 2. Runs the build system (which also executes the Check-based unit tests)
-# make && echo && \
-# # 3. Executes the unit tests with Valgrind
-# ./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
-# # 4. Counts the number of unit tests (by running them again)
-# for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
+# 1. Stores the date
+date && \
+# 2. Runs the build system (which also executes the Check-based unit tests)
+make && echo && \
+# 3. Executes the unit tests with Valgrind
+./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
+# 4. Counts the number of unit tests (by running them again)
+for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
 # 5. Misc.
 # 5.A. Showcases the "installed" shared object
 printf "\n%s SKETCHY IDEA (SKID) has been released as a shared object and installed locally %s\n" "$BOOKEND" "$BOOKEND"

--- a/devops/scripts/8-4_export.sh
+++ b/devops/scripts/8-4_export.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# This script was made to help automate exporting 8-4's output into a single
+# text file to use as "proof" for my mentor.  It performs the following:
+#
+# 1. Stores the date
+# 2. Runs the build system (which also executes the Check-based unit tests)
+# 3. Executes the unit tests with Valgrind
+# 4. Counts the number of unit tests (by running them again)
+# 5. Misc. (e.g., executing bespoke manual test code highlighting features/functionality)
+#   A. Showcases the "installed" shared object
+#   B. Showcases select manual test code has been linked against the shared object
+#   C. Executes that manual test code
+
+#
+# PURPOSE:
+#   Run manual test code in a standardized way
+# ARGUMENTS:
+#   command: The command, with a variable number of argments, to echo and then execute
+# RETURN:
+#   The exit code from command execution
+#
+run_manual_test_command()
+{
+    # LOCAL VARIABLES
+    EXIT_CODE=0  # Exit code from command execution
+
+    # DO IT
+    # Echo
+    printf "The full command is '%s'\n" "$@"
+    printf "Command output:\n"
+    # Execute
+    bash -c "$@"
+    EXIT_CODE=$?
+    # Vertical whitespace
+    printf "\n\n"
+
+    # DONE
+    return $EXIT_CODE
+}
+
+#
+# PURPOSE:
+#   Verbosely run manual test code in a standardized way (calls run_manual_test_command())
+# ARGUMENTS:
+#   command: The command, with a variable number of argments, to print usage for, echo and then
+#       execute
+# RETURN:
+#   The exit code from command execution
+#
+run_manual_test_command_verbose()
+{
+    # LOCAL VARIABLES
+    FULL_CMD="$@"             # Full manual test command
+    CMD_ARRAY=($FULL_CMD)     # Full manual test command as an array
+    BASE_CMD=${CMD_ARRAY[0]}  # Base manual test binary
+    EXIT_CODE=0               # Exit code from command execution
+
+    # DO IT
+    # Invoke Usage
+    bash -c "$BASE_CMD"
+    echo
+    # Call run_manual_test_command()
+    run_manual_test_command "$FULL_CMD"
+    EXIT_CODE=$?
+
+    # DONE
+    return $EXIT_CODE
+}
+
+BOOKEND="***"                                                       # Formatting
+TEMP_RET=0                                                          # Temporary exit code var
+EXIT_CODE=0                                                         # Exit value
+DIST_DIR=./code/dist/
+MAN_TEST_BIN=("${DIST_DIR}test_libskid_sa_read_cpu_tsc.bin" "${DIST_DIR}test_libskid_sdo_read_dir_contents.bin" "${DIST_DIR}test_libskid_sfmr_get_file_perms.bin")
+
+# # 1. Stores the date
+# date && \
+# # 2. Runs the build system (which also executes the Check-based unit tests)
+# make && echo && \
+# # 3. Executes the unit tests with Valgrind
+# ./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
+# # 4. Counts the number of unit tests (by running them again)
+# for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
+# 5. Misc.
+# 5.A. Showcases the "installed" shared object
+printf "\n%s SKETCHY IDEA (SKID) has been released as a shared object and installed locally %s\n" "$BOOKEND" "$BOOKEND"
+printf "Installed header files:\n"
+run_manual_test_command "ls -l /usr/include/skid*.h"
+printf "Installed shared object (with links):\n"
+run_manual_test_command "ls -l /lib/*sketchyidea*"
+
+# 5.B. Showcases select manual test code has been linked against the shared object
+printf "\n%s Statically compiled manual test code was also linked against the shared object %s\n" "$BOOKEND" "$BOOKEND"
+for linked_bin in `ls ${DIST_DIR}test_libskid_*.bin`; do
+    static_bin=$(echo "$linked_bin" | sed 's/_libskid//')
+    printf "%s was linked against the SKID shared object\n" "$linked_bin"
+    run_manual_test_command "ldd ${linked_bin}"
+    printf "%s was compiled against the source code\n" "$static_bin"
+    run_manual_test_command "ldd ${static_bin}"
+done
+
+# 5.C. Executes that manual test code
+printf "\n%s Executing the manual test code linked against the shared object %s\n" "$BOOKEND" "$BOOKEND"
+run_manual_test_command "${MAN_TEST_BIN[0]}"
+run_manual_test_command "${MAN_TEST_BIN[1]} ./"
+run_manual_test_command "${MAN_TEST_BIN[2]} ./README.md"


### PR DESCRIPTION
Explicit Requirements:

- [ ] Add a Makefile rule that automatically "releases" SKID as a shared object
- [ ] Add an optional rule to "install" SKID's headers and shared object in Linux-appropriate ways
- [ ] Write some manual test code to utilize functionality defined in the shared object

Implicit Requirements:

- Verify the `musl` compiler was installed (should have been done in branch `2-11` (see: #53 )