### PR TITLE
4-5: Use mmap to establish shared memory for IPC

### DIFF
--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -111,6 +111,8 @@ MAN_TEST_SFL_PREFIX = $(MAN_TEST_PREFIX)sfl_
 MAN_TEST_SFMR_PREFIX = $(MAN_TEST_PREFIX)sfmr_
 # Prefix for all skid_file_metadata_read library manual tests
 MAN_TEST_SFMW_PREFIX = $(MAN_TEST_PREFIX)sfmw_
+# Prefix for all skid_memory library manual tests
+MAN_TEST_SM_PREFIX = $(MAN_TEST_PREFIX)sm_
 # Prefix for all skid_network library manual tests
 MAN_TEST_SN_PREFIX = $(MAN_TEST_PREFIX)sn_
 # Prefix for all skid_signals library manual tests
@@ -313,6 +315,11 @@ $(DIST_DIR)$(MAN_TEST_SFC_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFC_PRE
 
 # MANUAL TEST: Linking skid_file_link library manual test binaries
 $(DIST_DIR)$(MAN_TEST_SFL_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFL_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_link$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
+	@echo "    Linking manual test binary: $@"
+	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
+
+# MANUAL TEST: Linking skid_memory library manual test binaries
+$(DIST_DIR)$(MAN_TEST_SM_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SM_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_operations$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
 	@echo "    Linking manual test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 

--- a/code/Makefile_linux
+++ b/code/Makefile_linux
@@ -319,7 +319,7 @@ $(DIST_DIR)$(MAN_TEST_SFL_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SFL_PRE
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 
 # MANUAL TEST: Linking skid_memory library manual test binaries
-$(DIST_DIR)$(MAN_TEST_SM_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SM_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_operations$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT)
+$(DIST_DIR)$(MAN_TEST_SM_PREFIX)%$(BIN_FILE_EXT): $(DIST_DIR)$(MAN_TEST_SM_PREFIX)%$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_metadata_read$(OBJ_FILE_EXT) $(DIST_DIR)skid_file_operations$(OBJ_FILE_EXT) $(DIST_DIR)skid_memory$(OBJ_FILE_EXT) $(DIST_DIR)skid_signals$(OBJ_FILE_EXT) $(DIST_DIR)skid_signal_handlers$(OBJ_FILE_EXT) $(DIST_DIR)skid_validation$(OBJ_FILE_EXT) $(DEVOPS_CODE_LINK_DEPS)
 	@echo "    Linking manual test binary: $@"
 	@$(CC) $(CFLAGS) -o $@ $^ -I $(INCLUDE_DIR)
 

--- a/code/include/devops_code.h
+++ b/code/include/devops_code.h
@@ -38,11 +38,11 @@ void *alloc_devops_mem(size_t num_elem, size_t size_elem, int *errnum);
  *
  *  Args:
  *      pid: The PID to queue the signal for.
- *        signum: The signal number to queue.
- *        sival_int: The integer value to include with the signal.
+ *      signum: The signal number to queue.
+ *      sival_int: The integer value to include with the signal.
  *
- *    Returns:
- *        0 on success, errno on error.
+ *  Returns:
+ *      0 on success, errno on error.
  */
 int call_sigqueue(pid_t pid, int signum, int sival_int);
 

--- a/code/include/skid_memory.h
+++ b/code/include/skid_memory.h
@@ -43,7 +43,7 @@
 // This struct communicates details about mapped memory to map_skid_mem() and unmap_skid_mem().
 typedef struct _skidMemMapRegion
 {
-    char *addr;     // [In/Out] Pointer to the virtual address space mapping
+    void *addr;     // [In/Out] Pointer to the virtual address space mapping
     size_t length;  // [Out] The length of the mapping
 } skidMemMapRegion, *skidMemMapRegion_ptr;
 

--- a/code/include/skid_memory.h
+++ b/code/include/skid_memory.h
@@ -37,6 +37,7 @@
 #endif  /* SKID_AUTO_FREE_CHAR, SKID_AUTO_FREE_VOID */
 
 #include <stddef.h>                         // size_t
+#include <sys/mman.h>                       // mmap() prot and flag macros
 #include "skid_macros.h"                    // ENOERR
 
 // This struct communicates details about mapped memory to map_skid_mem() and unmap_skid_mem().

--- a/code/include/skid_memory.h
+++ b/code/include/skid_memory.h
@@ -39,6 +39,13 @@
 #include <stddef.h>                         // size_t
 #include "skid_macros.h"                    // ENOERR
 
+// This struct communicates details about mapped memory to map_skid_mem() and unmap_skid_mem().
+typedef struct _skidMemMapRegion
+{
+    char *addr;     // [In/Out] Pointer to the virtual address space mapping
+    size_t length;  // [Out] The length of the mapping
+} skidMemMapRegion, *skidMemMapRegion_ptr;
+
 /*
  *  Description:
  *      Allocate a zeroized array in heap memory.
@@ -93,5 +100,38 @@ int free_skid_mem(void **old_mem);
  *      0 on success, errno on error.
  */
 int free_skid_string(char **old_string);
+
+/*
+ *  Description:
+ *      Map zeroized virtual memory by utilizing mmap().
+ *
+ *  Args:
+ *      new_map: [In/Out] skidMemMapRegion pointer for a new mapping.  The mapping.addr value will
+ *          be passed to mmap() as a hint about where to place the mapping.  If NULL, the kernel
+ *          chooses the address.  Regardless, this value will be overwritten by this function with
+ *          the return value from mmap().
+ *      prot: The desired memory protection of the mapping (see: mmap(2)).
+ *      flags: Determines, among other things, whether updates to the mapping are visible to
+ *          other processes mapping the same region.  This value will be ORed with MAP_ANONYMOUS to
+ *          ensure the memory region its contents are intialized to zero.  (see: mmap(2) for
+ *          additional flags)
+ *
+ *  Returns:
+ *      ENOERR on success, errno value on error.
+ */
+int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags);
+
+/*
+ *  Description:
+ *      Delete the mapping for the specified address range by utilizing munmap().
+ *
+ *  Args:
+ *      old_map: [In/Out] skidMemMapRegion pointer for a mapping  to delete.  On success, these
+ *          values will be zeroized.
+ *
+ *  Returns:
+ *      ENOERR on success, errno value on error.
+ */
+int unmap_skid_mem(skidMemMapRegion_ptr old_map);
 
 #endif  /* __SKID_MEMORY__ */

--- a/code/include/skid_memory.h
+++ b/code/include/skid_memory.h
@@ -124,6 +124,27 @@ int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags);
 
 /*
  *  Description:
+ *      Map zeroized virtual memory to contain the struct and an addr pointer of size length.
+ *      The same mapping contains the addr region and the struct so utilize unmap_skid_struct()
+ *      to delete the mapping: struct, addr, and all.
+ *
+ *  Args:
+ *      new_struct: [Out] skidMemMapRegion_ptr pointer to hold a newly mapped struct.  The struct's
+ *          addr pointer will be of length bytes that has been initialized to zero.
+ *      prot: The desired memory protection of the mapping (see: mmap(2)).
+ *      flags: Determines, among other things, whether updates to the mapping are visible to
+ *          other processes mapping the same region.  This value will be ORed with MAP_ANONYMOUS to
+ *          ensure the memory region its contents are intialized to zero.  (see: mmap(2) for
+ *          additional flags)
+ *      length: The size of the addr mapping in bytes.
+ *
+ *  Returns:
+ *      ENOERR on success, errno value on error.
+ */
+int map_skid_struct(skidMemMapRegion_ptr *new_struct, int prot, int flags, size_t length);
+
+/*
+ *  Description:
  *      Delete the mapping for the specified address range by utilizing munmap().
  *
  *  Args:
@@ -134,5 +155,19 @@ int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags);
  *      ENOERR on success, errno value on error.
  */
 int unmap_skid_mem(skidMemMapRegion_ptr old_map);
+
+/*
+ *  Description:
+ *      Delete the complete mapping of a struct that was mapped with map_skid_struct().
+ *      Unmaps both the struct and the memory region pointed to by the addr member.
+ *
+ *  Args:
+ *      old_struct: [In/Out] skidMemMapRegion_ptr pointer for a struct to delete.  On success, the
+ *          old_struct pointer will be set to NULL.
+ *
+ *  Returns:
+ *      ENOERR on success, errno value on error.
+ */
+int unmap_skid_struct(skidMemMapRegion_ptr *old_struct);
 
 #endif  /* __SKID_MEMORY__ */

--- a/code/include/skid_signal_handlers.h
+++ b/code/include/skid_signal_handlers.h
@@ -48,7 +48,7 @@ typedef enum { Integer = 1, Pointer = 2 } QueueData_t;
 
 extern volatile sig_atomic_t skid_sig_hand_interrupted;  // Non-zero values indicate SIGINT handled
 extern volatile sig_atomic_t skid_sig_hand_data_int;     // Data (int)
-extern volatile sig_atomic_t skid_sig_hand_data_ptr;     // Data (void*)
+extern volatile void *skid_sig_hand_data_ptr;            // Data (void*)
 extern volatile sig_atomic_t skid_sig_hand_ext;          // Non-zero values indicate ext reporting
 extern volatile sig_atomic_t skid_sig_hand_pid;          // PID of a sending process
 extern volatile sig_atomic_t skid_sig_hand_queue;        // QueueData_t indicates queue data
@@ -100,6 +100,24 @@ void handle_signal_number(int signum);
  *        the data before the next signal is handled.  The user must unblock signum after processing.
  */
 void handle_ext_read_queue_int(int signum, siginfo_t *info, void *context);
+
+/*
+ *    Description:
+ *        This extended signal handler will read a pointer sent for signum via sigqueue().
+ *        It sets the skid_sig_hand_queue atomic variable when it is ready to report.  The value
+ *        indicates the type of data to be read.  Interpret that value as type QueueData_t.
+ *        If skid_sig_hand_queue is QueueData_t.Pointer, retrieve values from:
+ *            - skid_sig_hand_data_ptr
+ *            - skid_sig_hand_pid
+ *            - skid_sig_hand_sigcode (SI_QUEUE)
+ *            - skid_sig_hand_signum
+ *            - skid_sig_hand_uid
+ *        This signal handler will not clear its own flags, merely overwrite them.  The user
+ *        should clear the flags if execution is to continue.  Also, this extended signal handler
+ *        will block further signum signals in an attempt to give the user a chance to process
+ *        the data before the next signal is handled.  The user must unblock signum after processing.
+ */
+void handle_ext_read_queue_ptr(int signum, siginfo_t *info, void *context);
 
 /*
  *    Description:

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -182,7 +182,7 @@ int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags)
     if (ENOERR == result)
     {
         errno = ENOERR;  // Initialize errno... for safety
-        new_map->addr = mmap(new_map->addr, new_map->length, prot, new_flags);
+        new_map->addr = mmap(new_map->addr, new_map->length, prot, new_flags, -1, 0);
         if (MAP_FAILED == new_map->addr)
         {
             result = errno;  // Something failed
@@ -201,7 +201,7 @@ int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags)
 int unmap_skid_mem(skidMemMapRegion_ptr old_map)
 {
     // LOCAL VARIABLES
-    int result = validate_sm_struct(new_map);  // Store errno value
+    int result = validate_sm_struct(old_map);  // Store errno value
 
     // UNMAP IT
     if (ENOERR == result)

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -2,7 +2,7 @@
  *  This library defines functionality to allocate and free memory on behalf of SKID.
  */
 
-#define SKID_DEBUG                          // Enable DEBUG logging
+// #define SKID_DEBUG                          // Enable DEBUG logging
 
 #include <errno.h>                          // errno
 #include <stdbool.h>                        // false

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>                        // false
 #include <stdlib.h>                         // calloc()
 #include <string.h>                         // strlen()
-#include "skid_debug.h"                     // PRINT_ERRNO()
+#include "skid_debug.h"                     // PRINT_ERROR(), PRINT_ERRNO()
 #include "skid_macros.h"                    // ENOERR, SKID_INTERNAL
 #include "skid_memory.h"                    // public functions, skidMemMapRegion*
 #include "skid_validation.h"                // validate_skid_err(), validate_skid_pathname()
@@ -204,7 +204,7 @@ int unmap_skid_mem(skidMemMapRegion_ptr old_map)
     int result = validate_sm_struct(old_map);  // Store errno value
 
     // UNMAP IT
-    if (ENOERR == result)
+    if (ENOERR == result && NULL != old_map->addr)
     {
         errno = ENOERR;  // Initialize errno... for safety
         if (0 == munmap(old_map->addr, old_map->length))
@@ -263,18 +263,10 @@ SKID_INTERNAL int validate_sm_struct(skidMemMapRegion_ptr map_mem)
         result = EINVAL;
         PRINT_ERROR(Received an invalid pointer in map_mem);
     }
-    else
+    else if (NULL != map_mem->addr && 0 == map_mem->length)
     {
-        if (NULL == map_mem->addr && map_mem->length > 0)
-        {
-            result = EINVAL;
-            PRINT_ERROR(An empty pointer may not have a non-zero length);
-        }
-        else if (NULL != map_mem->addr && 0 == map_mem->length)
-        {
-            result = EINVAL;
-            PRINT_ERROR(A valid pointer may not have a zero length);
-        }
+        result = EINVAL;
+        PRINT_ERROR(A valid pointer may not have a zero length);
     }
 
     // DONE

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -186,7 +186,7 @@ int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags)
         if (MAP_FAILED == new_map->addr)
         {
             result = errno;  // Something failed
-            PRINT_ERROR(The call to mmap failed);
+            PRINT_ERROR(The call to mmap() failed);
             PRINT_ERRNO(result);
             new_map->addr = NULL;  // Zeroize the pointer
             new_map->length = 0;  // Reset the length
@@ -215,7 +215,7 @@ int unmap_skid_mem(skidMemMapRegion_ptr old_map)
         else
         {
             result = errno;  // Something failed
-            PRINT_ERROR(The call to munmap failed);
+            PRINT_ERROR(The call to munmap() failed);
             PRINT_ERRNO(result);
         }
     }

--- a/code/src/skid_memory.c
+++ b/code/src/skid_memory.c
@@ -203,9 +203,9 @@ int map_skid_mem(skidMemMapRegion_ptr new_map, int prot, int flags)
 int map_skid_struct(skidMemMapRegion_ptr *new_struct, int prot, int flags, size_t length)
 {
     // LOCAL VARIABLES
-    int result = ENOERR;                                  // Store errno value
-    size_t total_len = length + sizeof(skidMemMapRegion)  // Total size of the mapping
-    skidMemMapRegion local_map;                           // Local struct
+    int result = ENOERR;                                   // Store errno value
+    size_t total_len = length + sizeof(skidMemMapRegion);  // Total size of the mapping
+    skidMemMapRegion local_map;                            // Local struct
 
     // INPUT VALIDATION
     if (NULL == new_struct)
@@ -235,7 +235,8 @@ int map_skid_struct(skidMemMapRegion_ptr *new_struct, int prot, int flags, size_
     // Update the out parameter
     if (ENOERR == result)
     {
-        *new_struct = local_map.addr;  // The beginning of the mapping holds the struct
+        // The beginning of the mapping holds the struct
+        *new_struct = (skidMemMapRegion_ptr)local_map.addr;
         // The remainder of the mapping is for the addr portion of size length
         (*new_struct)->addr = local_map.addr + sizeof(skidMemMapRegion);
         (*new_struct)->length = length;  // The mapping is larger than this, but not addr

--- a/code/src/skid_signal_handlers.c
+++ b/code/src/skid_signal_handlers.c
@@ -22,7 +22,7 @@ MODULE_UNLOAD();  // Print the module name being unloaded using the gcc destruct
 
 volatile sig_atomic_t skid_sig_hand_interrupted = 0;
 volatile sig_atomic_t skid_sig_hand_data_int = 0;
-volatile sig_atomic_t skid_sig_hand_data_ptr = 0;
+volatile void *skid_sig_hand_data_ptr = NULL;
 volatile sig_atomic_t skid_sig_hand_ext = 0;
 volatile sig_atomic_t skid_sig_hand_pid = 0;
 volatile sig_atomic_t skid_sig_hand_queue = 0;
@@ -125,6 +125,34 @@ void handle_ext_read_queue_int(int signum, siginfo_t *info, void *context)
                 skid_sig_hand_uid = info->si_uid;
                 skid_sig_hand_data_int = data.sival_int;
                 skid_sig_hand_queue = integer;
+            }
+        }
+    }
+}
+
+
+void handle_ext_read_queue_ptr(int signum, siginfo_t *info, void *context)
+{
+    // LOCAL VARIABLES
+    union sigval data;              // Store the info->si_value here
+    QueueData_t ptr_val = Pointer;  // skid_sig_hand_queue value
+
+    // HANDLE IT
+    if (NULL != info)
+    {
+        if (SI_QUEUE == info->si_code)
+        {
+            // Block further signals
+            if (ENOERR == block_signal_safe(signum))
+            {
+                // Process the data
+                data = info->si_value;
+                skid_sig_hand_signum = info->si_signo;
+                skid_sig_hand_sigcode = info->si_code;
+                skid_sig_hand_pid = info->si_pid;
+                skid_sig_hand_uid = info->si_uid;
+                skid_sig_hand_data_ptr = data.sival_ptr;
+                skid_sig_hand_queue = ptr_val;
             }
         }
     }

--- a/code/test/test_sm_handle_ext_read_queue_ptr.c
+++ b/code/test/test_sm_handle_ext_read_queue_ptr.c
@@ -4,7 +4,8 @@
  *
  *  This manual test code performs the following actions:
  *  1. Install the handle_ext_read_queue_ptr() extended signal handler for SIGUSR2
- *  2. Fork
+ *  2. Map shared memory to be used between parent and child
+ *  3. Fork
  *  3.a. Parent
  *      3.a.i.      Read filename into mapped memory
  *      3.a.ii.     Send a signal to the child process with the mapped memory address
@@ -196,16 +197,16 @@ int main(int argc, char *argv[])
     }
 
     // 3. Execute
-    // 3.a. Parent
+    // Parent
     if (ENOERR == exit_code)
     {
         if (the_pid > 0)
         {
-            // 3.a.i.  Read filename into mapped memory
+            // Read filename into mapped memory
             exit_code = map_filename(filename, &file_map);
             if (ENOERR == exit_code)
             {
-                // 3.a.ii.  Send a signal to the child process with the mapped memory address
+                // Send a signal to the child process with the mapped memory address
                 exit_code = call_sigqueue_ptr(the_pid, signum, file_map.addr);
                 if (ENOERR != exit_code)
                 {
@@ -218,7 +219,7 @@ int main(int argc, char *argv[])
                 PRINT_ERROR(PARENT - The call to map_filename() failed);
                 PRINT_ERRNO(exit_code);
             }
-            // 3.a.iii.    Wait for the child to finish
+            // Wait for the child to finish
             while (ENOERR == exit_code)
             {
                 // Check the child process
@@ -260,7 +261,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    // 3.b. Child
+    // Child
     if (ENOERR == exit_code)
     {
         if (0 == the_pid)
@@ -546,7 +547,7 @@ int process_queue_verify(int signum)
 {
     // LOCAL VARIABLES
     int result = ENOERR;            // Results of execution
-    QueueData_t ptr_val = Pointer;  // Only accepting integer values in the queue
+    QueueData_t ptr_val = Pointer;  // Only accepting pointer values in the queue
 
     // VERIFY VARIABLES
     if (ptr_val != skid_sig_hand_queue)

--- a/code/test/test_sm_handle_ext_read_queue_ptr.c
+++ b/code/test/test_sm_handle_ext_read_queue_ptr.c
@@ -1,0 +1,531 @@
+/*
+ *  Manually test skid_memory.h's mapped memory functionality and
+ *  skid_signal_handlers.h's handle_ext_read_queue_ptr() functions.
+ *
+ *  This manual test code performs the following actions:
+ *  1. Install the handle_ext_read_queue_ptr() extended signal handler for SIGUSR2
+ *  2. Fork
+ *  3.a. Parent
+ *      3.a.i.      Read filename into mapped memory
+ *      3.a.ii.     Send a signal to the child process with the mapped memory address
+ *      3.a.iii.    Wait for the child to finish
+ *  3.b. Child
+ *      3.b.i.      Wait for a signal from the parent
+ *      3.b.ii.     Retrieve the memory address from the signal handler
+ *      3.b.iii.    Read the contents of that memory address
+ *
+ *  Copy/paste the following...
+
+./code/dist/test_sm_handle_ext_read_queue_ptr.bin <REGULAR_FILENAME>
+
+ *
+ */
+
+// Standard includes
+// #include <errno.h>                  // EINVAL, EINTR, EIO
+#include <stdbool.h>                  // bool, false, true
+#include <stdint.h>                   // SIZE_MAX
+// #include <stdio.h>                  // fprintf()
+#include <stdlib.h>                   // exit()
+#include <sys/wait.h>                 // waitpid()
+#include <unistd.h>                   // fork()
+// Local includes
+#define SKID_DEBUG                    // The DEBUG output is doing double duty as test output
+#include "skid_debug.h"               // DEBUG_* macros, PRINT_*()
+#include "skid_file_metadata_read.h"  // get_size()
+#include "skid_file_operations.h"     // read_file()
+#include "skid_macros.h"              // ENOERR
+#include "skid_memory.h"              // free_skid_string()
+#include "skid_signal_handlers.h"     // handle_ext_read_queue_ptr()
+#include "skid_signals.h"             // block_sig*(), set_sig*_handler_ext(), translate_sig*_code()
+
+/*
+ *  Description:
+ *      Queue a signal, with integer data, to a PID by calling sigqueue() (see: sigqueue(3)).
+ *
+ *  Args:
+ *      pid: The PID to queue the signal for.
+ *      signum: The signal number to queue.
+ *      sival_ptr: The pointer value to include with the signal.
+ *
+ *  Returns:
+ *      0 on success, errno on error.
+ */
+int call_sigqueue_ptr(pid_t pid, int signum, void *sival_ptr);
+
+/*
+ *  Safely(?) convert a signed off_t value to a size_t value.
+ */
+size_t convert_offset(off_t offset, int *errnum);
+
+/*
+ *  Get the file size of filename.
+ */
+size_t get_file_size(const char *filename, int *errnum);
+
+/*
+ *  Size the file, map memory, and read the file into mapped memory.
+ */
+int map_filename(const char *filename, skidMemMapRegion_ptr file_map);
+
+/*
+ *  Single point of truth for this manual test code's usage.
+ */
+void print_usage(const char *prog_name);
+
+/*
+ *  Call this when the signal handler indicates there's a pointer to retrieve.
+ *  1. Verifies atomic variables (e.g., set, right signal number)
+ *  2. Reads and prints the string
+ *  3. Resets atomic variables
+ *  4. Unblocks the signal (to allow the handler to process the next message in the queue)
+ *
+ *  Returns ENOERR on success, errno on failure.
+ */
+int process_queue(int signum);
+
+/*
+ *  2. Reads and prints the string
+ */
+int process_queue_read(void);
+
+/*
+ *  3. Resets atomic variables
+ */
+void process_queue_reset_flags(void);
+
+/*
+ *  4. Unblocks the signal (to allow the handler to process the next message in the queue)
+ */
+int process_queue_unblock(int signum);
+
+/*
+ *  1. Verifies atomic variables (e.g., set, right signal number)
+ */
+int process_queue_verify(int signum);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int exit_code = 0;          // Store errno and/or results here
+    int flags = SA_RESTART;     // Modifies signal behavior: restart system calls across signals
+    int signum = SIGUSR2;       // Signal number to use for communication
+    pid_t the_pid = 0;          // Return value from fork()
+    pid_t wait_ret = 0;         // Return value from the call to waitpid()
+    int child_status = 0;       // Status information about the child process
+    char *filename = NULL;      // argv[1] <REGULAR_FILENAME>
+    skidMemMapRegion file_map;  // Mapped contents of the filename
+
+    // INPUT VALIDATION
+    if (argc != 2)
+    {
+        print_usage(argv[0]);
+        exit_code = EINVAL;
+    }
+    else if (false == is_regular_file(argv[1], &exit_code))
+    {
+        fprintf(stderr, "%s much be a regular file.\n", argv[1]);
+        print_usage(argv[0]);
+        if (ENOERR == exit_code)
+        {
+            exit_code = EINVAL;
+        }
+    }
+    else
+    {
+        filename = argv[1];
+    }
+
+    // RUN IT
+    // Block a signal
+    if (ENOERR == exit_code)
+    {
+        fprintf(stdout, "%s Blocking signal %d: %s\n", DEBUG_INFO_STR, signum, strsignal(signum));
+        exit_code = block_signal(signum, NULL);
+        if (exit_code)
+        {
+            PRINT_ERROR(The call to block_signal() failed);
+            PRINT_ERRNO(exit_code);
+        }
+        else
+        {
+            printf("%s %s now temporarily blocking signal %d.\n", DEBUG_INFO_STR, argv[0], signum);
+        }
+    }
+    // 1. Setup Signal Handler
+    if (ENOERR == exit_code)
+    {
+        exit_code = set_signal_handler_ext(signum, handle_ext_read_queue_ptr, flags, NULL);
+        if (exit_code)
+        {
+            PRINT_ERROR(The call to set_signal_handler_ext() failed);
+            PRINT_ERRNO(exit_code);
+        }
+        else
+        {
+            printf("%s %s is now handling signal %d: %s.\n", DEBUG_INFO_STR, argv[0],
+                   signum, strsignal(signum));
+        }
+    }
+
+    // 2. Fork
+    if (ENOERR == exit_code)
+    {
+        the_pid = fork();
+        if (-1 == the_pid)
+        {
+            exit_code = errno;
+            if (ENOERR == exit_code)
+            {
+                exit_code = EINTR;  // Just in case
+            }
+            PRINT_ERROR(The call to fork() failed);
+            PRINT_ERRNO(exit_code);
+        }
+    }
+
+    // 3. Execute
+    // 3.a. Parent
+    if (ENOERR == exit_code)
+    {
+        if (the_pid > 0)
+        {
+            // 3.a.i.  Read filename into mapped memory
+            exit_code = map_filename(filename, &file_map);
+            if (ENOERR == exit_code)
+            {
+                // 3.a.ii.  Send a signal to the child process with the mapped memory address
+                exit_code = call_sigqueue_ptr(the_pid, signum, file_map.addr);
+                if (ENOERR != exit_code)
+                {
+                    PRINT_ERROR(PARENT - The call_sigqueue_ptr() function failed);
+                    PRINT_ERRNO(exit_code);
+                }
+            }
+            else
+            {
+                PRINT_ERROR(PARENT - The call to map_filename() failed);
+                PRINT_ERRNO(exit_code);
+            }
+            // 3.a.iii.    Wait for the child to finish
+            while (ENOERR == exit_code)
+            {
+                // Check the child process
+                wait_ret = waitpid(the_pid, &child_status, WNOHANG);  // Is the child alive?
+                if (the_pid == wait_ret)
+                {
+                    // The child's state has changed
+                    if (WIFEXITED(child_status) || WIFSIGNALED(child_status) \
+                        || WIFSTOPPED(child_status))
+                    {
+                        // The child is no more
+                        printf("%s PARENT - The child has finished\n",
+                               DEBUG_INFO_STR);
+                        break;
+                    }
+                }
+                else if (0 == wait_ret)
+                {
+                    // The child didn't change state yet... be patient
+                }
+                else if (-1 == wait_ret)
+                {
+                    PRINT_ERROR(PARENT - The waitpid() call failed);
+                    exit_code = child_status;
+                    PRINT_ERRNO(exit_code);
+                    break;
+                }
+                else
+                {
+                    PRINT_ERROR(PARENT - The call to waitpid() reported an unknown PID);
+                    FPRINTF_ERR("PARENT - The call to waitpid() reported an unknown PID: %d\n",
+                                wait_ret);
+                    break;
+                }
+            }
+
+            // CLEAN UP
+            unmap_skid_mem(&file_map);  // Best effort
+        }
+    }
+
+    // 3.b. Child
+    if (ENOERR == exit_code)
+    {
+        if (0 == the_pid)
+        {
+            exit_code = unblock_signal(signum, NULL);  // Receive data
+            while (ENOERR == exit_code)
+            {
+                // Process Data
+                exit_code = process_queue(signum);
+                if (ENODATA == exit_code)
+                {
+                    exit_code = ENOERR;  // Ignore a lack of data
+                }
+            }
+        }
+    }
+
+    // DONE
+    exit(exit_code);
+}
+
+
+int call_sigqueue_ptr(pid_t pid, int signum, void *sival_ptr)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;                     // Results of execution
+    union sigval data = { .sival_ptr = 0 };  // Data to send via sigqueue()
+
+    // PREPARE
+    data.sival_ptr = sival_ptr;
+
+    // QUEUE IT
+    if (sigqueue(pid, signum, data))
+    {
+        result = errno;
+        PRINT_ERROR(The call to sigqueue() failed);
+        if (ENOERR == result)
+        {
+            result = EINTR;  // Use this merely to indicate an error occurred
+        }
+        else
+        {
+            PRINT_ERRNO(result);
+        }
+        FPRINTF_ERR("Attempted to sigqueue(%d, %d, %p)\n", pid, signum, sival_ptr);
+    }
+
+    // DONE
+    return result;
+}
+
+
+size_t convert_offset(off_t offset, int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+    size_t new_val = 0;   // offset converted to a size_t
+
+    // INPUT VALIDATION
+    if (NULL == errnum)
+    {
+        result = EINVAL;
+    }
+    else if (offset < 0 || SIZE_MAX < offset)
+    {
+        result = ERANGE;
+    }
+    else
+    {
+        new_val = (size_t)offset;
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return new_val;
+}
+
+
+size_t get_file_size(const char *filename, int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;        // Results of execution
+    off_t file_size = 0;        // Filename's file size
+    size_t conv_file_size = 0;  // Filename's file size (off_t) converted to size_t
+
+    // INPUT VALIDATION
+
+    // GET IT
+    // Get the off_t file size
+    if (ENOERR == result)
+    {
+        file_size = get_size(filename, &result);  // Size filename
+    }
+    // Convert off_t to size_t
+    if (ENOERR == result)
+    {
+        conv_file_size = convert_offset(file_size, &result);  // Convert the value
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return conv_file_size;
+}
+
+
+int map_filename(const char *filename, skidMemMapRegion_ptr file_map)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;                // Results of execution
+    size_t file_size = 0;               // Size of filename
+    char *file_cont = NULL;             // Filename contents
+    int prot = PROT_READ | PROT_WRITE;  // mmap() protections
+    int flags = MAP_SHARED;             // mmap() flags
+
+    // INPUT VALIDATION
+    if (NULL == filename || NULL == file_map)
+    {
+        result = EINVAL;  // NULL pointers
+    }
+
+    // MAP IT
+    // Size the file
+    if (ENOERR == result)
+    {
+        file_size = get_file_size(filename, &result);
+    }
+    // Read the file
+    if (ENOERR == result)
+    {
+        file_cont = read_file(filename, &result);
+    }
+    // Map memory
+    if (ENOERR == result)
+    {
+        file_map->addr = NULL;
+        file_map->length = file_size + 1;  // Nul-terminate this memory space
+        result = map_skid_mem(file_map, prot, flags);
+    }
+    // Copy file contents into mapped memory
+    if (ENOERR == result)
+    {
+        memcpy(file_map->addr, file_cont, file_size);
+    }
+
+    // CLEAN UP
+    if (NULL != file_cont)
+    {
+        free_skid_string(&file_cont);  // Best effort
+    }
+
+    // DONE
+    return result;
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <REGULAR_FILENAME>\n", prog_name);
+}
+
+
+int process_queue(int signum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Results of execution
+
+    // PROCESS IT
+    // 1. Verifies atomic variables (e.g., set, right signal number)
+    result = process_queue_verify(signum);
+
+    // 2. Reads and prints the string
+    if (ENOERR == result)
+    {
+        result = process_queue_read();
+    }
+
+    // 3. Resets atomic variables
+    if (ENOERR == result)
+    {
+        process_queue_reset_flags();
+    }
+
+    // 4. Unblocks the signal (to allow the handler to process the next message in the queue)
+    if (ENOERR == result)
+    {
+        result = process_queue_unblock(signum);
+    }
+
+    // DONE
+    return result;
+}
+
+
+int process_queue_read(void)
+{
+    // LOCAL VARIABLE
+    int result = ENOERR;                          // Results of execution
+    void *data = (void *)skid_sig_hand_data_ptr;  // Pointer from the queue
+    int pid = skid_sig_hand_pid;                  // PID of the sending process
+    int code = skid_sig_hand_sigcode;             // Signal code
+    int signal = skid_sig_hand_signum;            // Signal number
+    int uid = skid_sig_hand_uid;                  // Real UID of the sending process
+    char *sig_code_str = NULL;                    // Human-readable description of the signal code
+
+    // PROCESS IT
+    // Translate the signal code
+    if (ENOERR == result)
+    {
+        sig_code_str = translate_signal_code(signal, code, &result);
+        if (result)
+        {
+            PRINT_ERROR(The call to translate_signal_code() failed);
+            PRINT_ERRNO(result);
+        }
+    }
+    // Print all the details
+    if (ENOERR == result)
+    {
+        fprintf(stderr, "%s CHILD - Received value %p inside signal number %d (%s) code "
+                "%d (%s) from UID %d at PID %d\n", DEBUG_INFO_STR, data, signal, strsignal(signal),
+                code, sig_code_str, uid, pid);
+        fprintf(stderr, "%s CHILD - The contents of the mapped memory:\n\n%s\n",
+                DEBUG_INFO_STR, (char *)data);
+    }
+
+    // CLEANUP
+    if (NULL != sig_code_str)
+    {
+        free_skid_string(&sig_code_str);  // Best effort
+    }
+
+    // DONE
+    return result;
+}
+
+
+void process_queue_reset_flags(void)
+{
+    skid_sig_hand_queue = 0;
+    skid_sig_hand_data_ptr = NULL;
+    skid_sig_hand_pid = 0;
+    skid_sig_hand_sigcode = 0;
+    skid_sig_hand_signum = 0;
+    skid_sig_hand_uid = 0;
+}
+
+
+int process_queue_unblock(int signum)
+{
+    return unblock_signal(signum, NULL);
+}
+
+
+int process_queue_verify(int signum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;            // Results of execution
+    QueueData_t ptr_val = Pointer;  // Only accepting integer values in the queue
+
+    // VERIFY VARIABLES
+    if (ptr_val != skid_sig_hand_queue)
+    {
+        result = ENODATA;  // Nothing that we care about
+    }
+    else if (signum != skid_sig_hand_signum)
+    {
+        result = ENODATA;  // Wrong signal number
+    }
+
+    // DONE
+    return result;
+}

--- a/code/test/test_sm_handle_ext_read_queue_ptr.c
+++ b/code/test/test_sm_handle_ext_read_queue_ptr.c
@@ -23,10 +23,10 @@
  */
 
 // Standard includes
-// #include <errno.h>                  // EINVAL, EINTR, EIO
+#include <errno.h>                    // EINVAL, ENODATA
 #include <stdbool.h>                  // bool, false, true
 #include <stdint.h>                   // SIZE_MAX
-// #include <stdio.h>                  // fprintf()
+#include <stdio.h>                    // fprintf(), printf()
 #include <stdlib.h>                   // exit()
 #include <sys/wait.h>                 // waitpid()
 #include <unistd.h>                   // fork()

--- a/code/test/test_sm_mapped_memory.c
+++ b/code/test/test_sm_mapped_memory.c
@@ -166,8 +166,6 @@ int main(int argc, char *argv[])
                 }
                 else
                 {
-                    // PRINT_ERROR(ABOUT TO RELEASE);  // DEBUGGING
-                    // FPRINTF_ERR("%s\n", (char *)map_file->addr);  // DEBUGGING
                     FPRINTF_ERR("%s PARENT - Semaphore released\n", DEBUG_INFO_STR);
                 }
             }
@@ -214,7 +212,6 @@ int main(int argc, char *argv[])
             // Destroy the semaphore
             sem_destroy((sem_t *)map_sem->addr);  // Best effort
             // Unmap the semaphore memory
-            // PRINT_ERROR(HERE);  // DEBUGGING
             unmap_skid_struct(&map_sem);  // Best effort
         }
     }
@@ -237,18 +234,10 @@ int main(int argc, char *argv[])
                 {
                     break;  // Something went truly wrong
                 }
-                // PRINT_ERROR(RESULTS);  // DEBUGGING
-                // FPRINTF_ERR("RESULTS %d\n", results);  // DEBUGGING
             }
-            // PRINT_ERROR(HERE);  // DEBUGGING
-            // FPRINTF_ERR("RESULTS %d\n", results);  // DEBUGGING
             // Print the resource
             if (ENOERR == results)
             {
-                // PRINT_ERROR(ABOUT TO PRINT);  // DEBUGGING
-                // FPRINTF_ERR("STRUCT POINTER %p\n", map_file);  // DEBUGGING
-                // FPRINTF_ERR("POINTER %p\n", (char *)map_file->addr);  // DEBUGGING
-                // FPRINTF_ERR("CONTENT %s\n", (char *)map_file->addr);  // DEBUGGING
                 for (size_t i = 0; i < map_file->length; i++)
                 {
                     if (EOF == putchar((*(((char *)map_file->addr) + i))))

--- a/code/test/test_sm_mapped_memory.c
+++ b/code/test/test_sm_mapped_memory.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
                 else
                 {
                     PRINT_ERROR(ABOUT TO RELEASE);  // DEBUGGING
-                    FPRINTF_ERR("%s\n", map_file.addr);  // DEBUGGING
+                    FPRINTF_ERR("%s\n", (char *)map_file.addr);  // DEBUGGING
                     FPRINTF_ERR("%s PARENT - Semaphore released\n", DEBUG_INFO_STR);
                 }
             }
@@ -227,10 +227,10 @@ int main(int argc, char *argv[])
             if (ENOERR == results)
             {
                 PRINT_ERROR(ABOUT TO PRINT);  // DEBUGGING
-                FPRINTF_ERR("%s\n", map_file.addr);  // DEBUGGING
+                FPRINTF_ERR("%s\n", (char *)map_file.addr);  // DEBUGGING
                 for (size_t i = 0; i < map_file.length; i++)
                 {
-                    if (EOF == putchar((*(map_file.addr + i))))
+                    if (EOF == putchar((*(((char *)map_file.addr) + i))))
                     {
                         results = EIO;  // As good an errno value as any
                         PRINT_ERROR(CHILD - The call to putchar() failed);

--- a/code/test/test_sm_mapped_memory.c
+++ b/code/test/test_sm_mapped_memory.c
@@ -1,0 +1,270 @@
+/*
+ *  Manually test skid_memory's map_skid_mem() and unmap_skid_mem() functions.
+ *
+ *  This manual test code performs the following actions:
+ *  1. Validate input
+ *  2. Fork
+ *  3.a. Parent:
+ *      i.   Maps memory to store a file's content
+ *      ii.  Reads the file into the mapped memory
+ *      iii. Release that resource
+ *  3.b. Child:
+ *      i.   Wait for the resource
+ *      ii.  Read and print the resource
+ *      iii. Unmap the mapped memory
+ *
+ *  Copy/paste the following...
+
+./code/dist/test_sm_mapped_memory.bin <REGULAR_FILENAME>
+
+ *
+ */
+
+// Standard includes
+#include <errno.h>                  // EINVAL
+#include <semaphore.h>              // sem_init(), sem_post()
+#include <stdbool.h>                // false
+#include <stdint.h>                 // SIZE_MAX
+#include <stdio.h>                  // fprintf()
+// #include <stdlib.h>                 // exit()
+// #include <sys/wait.h>               // waitpid()
+// #include <unistd.h>                 // fork()
+// Local includes
+#define SKID_DEBUG                  // The DEBUG output is doing double duty as test output
+// #include "devops_code.h"            // call_sigqueue()
+// #include "skid_debug.h"             // DEBUG_INFO_STR, DEBUG_WARNG_STR, PRINT_ERRNO(), PRINT_ERROR()
+// #include "skid_macros.h"            // ENOERR
+#include "skid_memory.h"            // map_skid_mem(), skidMemMapRegion, unmap_skid_mem()
+// #include "skid_signal_handlers.h"   // handle_ext_read_queue_int()
+// #include "skid_signals.h"           // set_signal_handler_ext(), translate_signal_code()
+
+/*
+ *  Safely(?) convert a signed off_t value to a size_t value.
+ */
+size_t convert_offset(off_t offset, int *errnum);
+
+
+/*
+ *  Size filename, map a memory region into map_file, and then read filename into it.
+ *  Does not validate input.  Returns ENOERR on success, errno value of failure.
+ */
+int run_parent(const char *filename, skidMemMapRegion_ptr map_file);
+
+
+/*
+ *  Single point of truth for this manual test code's usage.
+ */
+void print_usage(const char *prog_name);
+
+
+int main(int argc, char *argv[])
+{
+    // LOCAL VARIABLES
+    int results = ENOERR;               // Store errno and/or results here
+    int prot = PROT_READ | PROT_WRITE;  // mmap() prot value
+    int flags = MAP_SHARED;             // mmap() flags value
+    pid_t my_pid = 0;                   // My PID
+    pid_t wait_ret = 0;                 // Return value from the call to waitpid()
+    int child_status = 0;               // Status information about the child process
+    sem_t sem;                          // Semaphore to manage the virtual memory region
+    int pshared = 1;                    // Sempahore pshared value: 1 means process-shared
+    unsigned int sem_val = 0;           // Initial value of the semaphore: locked by the parent
+    skidMemMapRegion map_file;          // argv[1] mapped into shared memory
+
+    // INPUT VALIDATION
+    if (argc != 2)
+    {
+        print_usage(argv[0]);
+        results = EINVAL;
+    }
+    else if (false == is_regular_file(argv[1], &results))
+    {
+        fprintf(stderr, "%s much be a regular file.\n", argv[1]);
+        print_usage(argv[0]);
+        if (ENOERR == results)
+        {
+            results = EINVAL;
+        }
+    }
+    // SETUP
+    else
+    {
+        errno = ENOERR;  // Just in case
+        if (0 != sem_init(&sem, pshared, sem_val))
+        {
+            results = errno;
+            if (ENOERR == results)
+            {
+                results = EINVAL;
+            }
+            PRINT_ERROR(The call to sem_init() failed);
+            PRINT_ERRNO(results);
+        }
+    }
+
+    // DO IT
+    // Fork
+    if (ENOERR == results)
+    {
+        my_pid = fork();
+        if (-1 == my_pid)
+        {
+            results = errno;
+            if (ENOERR == results)
+            {
+                results = EINTR;  // Just in case
+            }
+            PRINT_ERROR(The call to fork() failed);
+            PRINT_ERRNO(results);
+        }
+    }
+    // Parent
+    if (ENOERR == results)
+    {
+        if (my_pid > 0)
+        {
+            results = run_parent(argv[1], &map_file);
+            if (ENOERR == results)
+            {
+                errno = ENOERR;  // Just in case
+                // Release the semaphore
+                if (0 != sem_post(&sem))
+                {
+                    results = errno;
+                    PRINT_ERROR(PARENT - The call to sem_post() failed);
+                    PRINT_ERRNO(results);
+                }
+            }
+            else
+            {
+                PRINT_ERROR(PARENT - The call to run_parent() failed);
+                PRINT_ERRNO(results);
+            }
+        }
+    }
+    // Child
+    if (ENOERR == results)
+    {
+        if (0 == my_pid)
+        {
+            // Obtain the lock
+            while (-1 == sem_trywait(&sem))
+            {
+                results = errno;
+                if (EAGAIN == results)
+                {
+                    FPRINTF_ERR("%s CHILD - Still waiting on the semaphore.\n", DEBUG_INFO_STR);
+                    results = ENOERR;  // Reset and keep waiting
+                }
+                else
+                {
+                    break;  // Something went truly wrong
+                }
+            }
+            // Print the resource
+            if (ENOERR == results)
+            {
+                for (size_t i = 0; i < map_file.length; i++)
+                {
+                    if (EOF == putchar((*(map_file.addr + i))))
+                    {
+                        results = EIO;  // As good an errno value as any
+                        PRINT_ERROR(CHILD - The call to putchar() failed);
+                        break;
+                    }
+                }
+                putchar('\n');
+            }
+            // Clean up
+            unmap_skid_mem(&map_file);  // Best effort
+        }
+    }
+
+    // DONE
+    return results;
+}
+
+
+size_t convert_offset(off_t offset, int *errnum)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;  // Errno values
+    size_t new_val = 0;   // offset converted to a size_t
+
+    // INPUT VALIDATION
+    if (NULL == errnum)
+    {
+        result = EINVAL;
+    }
+    else if (offset < 0 || SIZE_MAX < offset)
+    {
+        result = ERANGE;
+    }
+    else
+    {
+        new_val = (size_t)offset;
+    }
+
+    // DONE
+    if (NULL != errnum)
+    {
+        *errnum = result;
+    }
+    return new_val;
+}
+
+
+void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <REGULAR_FILENAME>\n", prog_name);
+}
+
+
+int run_parent(const char *filename, skidMemMapRegion_ptr map_file)
+{
+    // LOCAL VARIABLES
+    int result = ENOERR;                // Errno values
+    off_t file_size = 0;                // Size of filename
+    size_t conv_file_size = 0;          // file_size converted to size_t
+    int prot = PROT_READ | PROT_WRITE;  // mmap() protections
+    int flags = MAP_SHARED;             // mmap() flags
+    char *file_cont = NULL;             // Temporary heap pointer with file contents
+
+    // RUN IT
+    // Size filename
+    file_size = get_size(filename, &result);
+    if (ENOERR == result)
+    {
+        conv_file_size = convert_offset(file_size, &result);
+    }
+    // Map a memory region
+    if (ENOERR == result)
+    {
+        map_file->addr = NULL;
+        map_file->length = conv_file_size;
+        result = map_skid_mem(map_file, prot, flags);
+        if (ENOERR != result)
+        {
+            PRINT_ERROR(The call to map_skid_mem() failed);
+            PRINT_ERRNO(result);
+        }
+    }
+    // Read filename into it
+    if (ENOERR == result)
+    {
+        file_cont = read_file(filename, &result);
+        if (ENOERR == result)
+        {
+            memcpy(map_file->addr, file_cont, conv_file_size);
+        }
+    }
+
+    // CLEANUP
+    if (NULL != file_cont)
+    {
+        free_skid_string(&file_cont);  // Best effort
+    }
+
+    // DONE
+    return result;
+}

--- a/devops/files/4-5_output.txt
+++ b/devops/files/4-5_output.txt
@@ -1,0 +1,1053 @@
+
+*** This output was created by 4-5_export.sh on Thu Jul  3 19:49:32 UTC 2025 ***
+
+VALIDATING
+    Validating gcc
+        [✓] gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+    Validating glibc
+        [✓] ldd (Ubuntu GLIBC 2.35-0ubuntu3.10) 2.35
+    Validating Check
+        [✓] Check unit test version: (0) (15) (2)
+    Validating musl-gcc
+        [✓] x86_64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+
+CLEANING
+    Cleaning dist/ directory
+
+COMPILING
+    Compiling: src/devops_code.c
+    Compiling: src/skid_assembly.c
+    Compiling: src/skid_dir_operations.c
+    Compiling: src/skid_file_control.c
+    Compiling: src/skid_file_descriptors.c
+    Compiling: src/skid_file_link.c
+    Compiling: src/skid_file_metadata_read.c
+    Compiling: src/skid_file_metadata_write.c
+    Compiling: src/skid_file_operations.c
+    Compiling: src/skid_memory.c
+    Compiling: src/skid_network.c
+    Compiling: src/skid_signal_handlers.c
+    Compiling: src/skid_signals.c
+    Compiling: src/skid_time.c
+    Compiling: src/skid_validation.c
+    Compiling: src/unit_test_code.c
+    Compiling manual test object code: dist/test_devops_code_create_path_tree.o
+    Linking manual test binary: dist/test_devops_code_create_path_tree.bin
+    Compiling manual test object code: dist/test_devops_code_get_compatible_gid.o
+    Linking manual test binary: dist/test_devops_code_get_compatible_gid.bin
+    Compiling manual test object code: dist/test_feature_test_macros.o
+    Linking manual test binary: dist/test_feature_test_macros.bin
+    Compiling manual test object code: dist/test_libskid_sa_read_cpu_tsc.o
+    Linking manual test binary against libsketchyidea: dist/test_libskid_sa_read_cpu_tsc.bin
+    Compiling manual test object code: dist/test_libskid_sdo_read_dir_contents.o
+    Linking manual test binary against libsketchyidea: dist/test_libskid_sdo_read_dir_contents.bin
+    Compiling manual test object code: dist/test_libskid_sfmr_get_file_perms.o
+    Linking manual test binary against libsketchyidea: dist/test_libskid_sfmr_get_file_perms.bin
+    Statically compiling bespoke binary: dist/test_misc_glibc_vs_musl-static_glibc.bin
+    Statically compiling bespoke binary: dist/test_misc_glibc_vs_musl-static_musl.bin
+    Compiling manual test object code: dist/test_misc_packed_macro.o
+    Linking manual test binary: dist/test_misc_packed_macro.bin
+    Compiling manual test object code: dist/test_misc_setjmp_longjmp.o
+    Linking manual test binary: dist/test_misc_setjmp_longjmp.bin
+    Compiling bespoke binary: dist/test_misc_sfmr_call_stat.bin
+    Compiling manual test object code: dist/test_sa_read_cpu_tsc.o
+    Linking manual test binary: dist/test_sa_read_cpu_tsc.bin
+    Compiling manual test object code: dist/test_sdo_read_dir_contents.o
+    Linking manual test binary: dist/test_sdo_read_dir_contents.bin
+    Compiling manual test object code: dist/test_sfc_lock_and_write_fd.o
+    Linking manual test binary: dist/test_sfc_lock_and_write_fd.bin
+    Compiling manual test object code: dist/test_sfc_read_locked_fd.o
+    Linking manual test binary: dist/test_sfc_read_locked_fd.bin
+    Compiling manual test object code: dist/test_sfc_write_locked_fd.o
+    Linking manual test binary: dist/test_sfc_write_locked_fd.bin
+    Compiling manual test object code: dist/test_sfl_create_hard_link.o
+    Linking manual test binary: dist/test_sfl_create_hard_link.bin
+    Compiling manual test object code: dist/test_sfl_create_sym_link.o
+    Linking manual test binary: dist/test_sfl_create_sym_link.bin
+    Compiling manual test object code: dist/test_sfmr_file_metadata.o
+    Linking manual test binary: dist/test_sfmr_file_metadata.bin
+    Compiling manual test object code: dist/test_sfmr_get_block_size.o
+    Linking manual test binary: dist/test_sfmr_get_block_size.bin
+    Compiling manual test object code: dist/test_sfmr_get_container_device_id.o
+    Linking manual test binary: dist/test_sfmr_get_container_device_id.bin
+    Compiling manual test object code: dist/test_sfmr_get_file_device_id.o
+    Linking manual test binary: dist/test_sfmr_get_file_device_id.bin
+    Compiling manual test object code: dist/test_sfmr_get_file_perms.o
+    Linking manual test binary: dist/test_sfmr_get_file_perms.bin
+    Compiling manual test object code: dist/test_sfmr_get_file_times.o
+    Linking manual test binary: dist/test_sfmr_get_file_times.bin
+    Compiling manual test object code: dist/test_sfmr_is_block_device.o
+    Linking manual test binary: dist/test_sfmr_is_block_device.bin
+    Compiling manual test object code: dist/test_sfmr_is_character_device.o
+    Linking manual test binary: dist/test_sfmr_is_character_device.bin
+    Compiling manual test object code: dist/test_sfmr_is_named_pipe.o
+    Linking manual test binary: dist/test_sfmr_is_named_pipe.bin
+    Compiling manual test object code: dist/test_sfmr_is_regular_file.o
+    Linking manual test binary: dist/test_sfmr_is_regular_file.bin
+    Compiling manual test object code: dist/test_sfmr_is_symbolic_link.o
+    Linking manual test binary: dist/test_sfmr_is_symbolic_link.bin
+    Compiling manual test object code: dist/test_sfmw_set_atime_now.o
+    Linking manual test binary: dist/test_sfmw_set_atime_now.bin
+    Compiling manual test object code: dist/test_sfmw_set_ownership.o
+    Linking manual test binary: dist/test_sfmw_set_ownership.bin
+    Compiling manual test object code: dist/test_sfmw_set_times.o
+    Linking manual test binary: dist/test_sfmw_set_times.bin
+    Compiling manual test object code: dist/test_sm_handle_ext_read_queue_ptr.o
+    Linking manual test binary: dist/test_sm_handle_ext_read_queue_ptr.bin
+    Compiling manual test object code: dist/test_sm_mapped_memory.o
+    Linking manual test binary: dist/test_sm_mapped_memory.bin
+    Compiling manual test object code: dist/test_sm_raii_string_macro.o
+    Linking manual test binary: dist/test_sm_raii_string_macro.bin
+    Compiling manual test object code: dist/test_sm_raii_void_macro.o
+    Linking manual test binary: dist/test_sm_raii_void_macro.bin
+    Compiling manual test object code: dist/test_sn_multi_sniffer.o
+    Linking manual test binary: dist/test_sn_multi_sniffer.bin
+    Compiling manual test object code: dist/test_sn_simple_dgram_client.o
+    Linking manual test binary: dist/test_sn_simple_dgram_client.bin
+    Compiling manual test object code: dist/test_sn_simple_dgram_server.o
+    Linking manual test binary: dist/test_sn_simple_dgram_server.bin
+    Compiling manual test object code: dist/test_sn_simple_sniffer.o
+    Linking manual test binary: dist/test_sn_simple_sniffer.bin
+    Compiling manual test object code: dist/test_sn_simple_stream_client.o
+    Linking manual test binary: dist/test_sn_simple_stream_client.bin
+    Compiling manual test object code: dist/test_sn_simple_stream_server.o
+    Linking manual test binary: dist/test_sn_simple_stream_server.bin
+    Compiling manual test object code: dist/test_ss_block_unblock.o
+    Linking manual test binary: dist/test_ss_block_unblock.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_async_client.o
+    Linking manual test binary: dist/test_ssh_handle_ext_async_client.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_async_server.o
+    Linking manual test binary: dist/test_ssh_handle_ext_async_server.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_read_queue_int.o
+    Linking manual test binary: dist/test_ssh_handle_ext_read_queue_int.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_sending_process.o
+    Linking manual test binary: dist/test_ssh_handle_ext_sending_process.bin
+    Compiling manual test object code: dist/test_ssh_handle_ext_signal_code.o
+    Linking manual test binary: dist/test_ssh_handle_ext_signal_code.bin
+    Compiling manual test object code: dist/test_ssh_handle_interruptions.o
+    Linking manual test binary: dist/test_ssh_handle_interruptions.bin
+    Compiling manual test object code: dist/test_ssh_handle_signal_number.o
+    Linking manual test binary: dist/test_ssh_handle_signal_number.bin
+    Compiling bespoke binary: dist/redirect_bin_output.bin
+    Compiling Check unit test code: test/check_sdo_create_dir.c
+    Linking Check unit test binary: dist/check_sdo_create_dir.bin
+    Compiling Check unit test code: test/check_sdo_delete_dir.c
+    Linking Check unit test binary: dist/check_sdo_delete_dir.bin
+    Compiling Check unit test code: test/check_sdo_destroy_dir.c
+    Linking Check unit test binary: dist/check_sdo_destroy_dir.bin
+    Compiling Check unit test code: test/check_sdo_read_dir_contents.c
+    Linking Check unit test binary: dist/check_sdo_read_dir_contents.bin
+    Compiling Check unit test code: test/check_sfc_is_close_on_exec.c
+    Linking Check unit test binary: dist/check_sfc_is_close_on_exec.bin
+    Compiling Check unit test code: test/check_sfl_create_hard_link.c
+    Linking Check unit test binary: dist/check_sfl_create_hard_link.bin
+    Compiling Check unit test code: test/check_sfl_create_sym_link.c
+    Linking Check unit test binary: dist/check_sfl_create_sym_link.bin
+    Compiling Check unit test code: test/check_sfmr_get_access_time.c
+    Linking Check unit test binary: dist/check_sfmr_get_access_time.bin
+    Compiling Check unit test code: test/check_sfmr_get_block_count.c
+    Linking Check unit test binary: dist/check_sfmr_get_block_count.bin
+    Compiling Check unit test code: test/check_sfmr_get_block_size.c
+    Linking Check unit test binary: dist/check_sfmr_get_block_size.bin
+    Compiling Check unit test code: test/check_sfmr_get_change_time.c
+    Linking Check unit test binary: dist/check_sfmr_get_change_time.bin
+    Compiling Check unit test code: test/check_sfmr_get_container_device_id.c
+    Linking Check unit test binary: dist/check_sfmr_get_container_device_id.bin
+    Compiling Check unit test code: test/check_sfmr_get_file_device_id.c
+    Linking Check unit test binary: dist/check_sfmr_get_file_device_id.bin
+    Compiling Check unit test code: test/check_sfmr_get_file_perms.c
+    Linking Check unit test binary: dist/check_sfmr_get_file_perms.bin
+    Compiling Check unit test code: test/check_sfmr_get_file_type.c
+    Linking Check unit test binary: dist/check_sfmr_get_file_type.bin
+    Compiling Check unit test code: test/check_sfmr_get_group.c
+    Linking Check unit test binary: dist/check_sfmr_get_group.bin
+    Compiling Check unit test code: test/check_sfmr_get_hard_link_num.c
+    Linking Check unit test binary: dist/check_sfmr_get_hard_link_num.bin
+    Compiling Check unit test code: test/check_sfmr_get_mod_time.c
+    Linking Check unit test binary: dist/check_sfmr_get_mod_time.bin
+    Compiling Check unit test code: test/check_sfmr_get_owner.c
+    Linking Check unit test binary: dist/check_sfmr_get_owner.bin
+    Compiling Check unit test code: test/check_sfmr_get_serial_num.c
+    Linking Check unit test binary: dist/check_sfmr_get_serial_num.bin
+    Compiling Check unit test code: test/check_sfmr_get_size.c
+    Linking Check unit test binary: dist/check_sfmr_get_size.bin
+    Compiling Check unit test code: test/check_sfmr_is_block_device.c
+    Linking Check unit test binary: dist/check_sfmr_is_block_device.bin
+    Compiling Check unit test code: test/check_sfmr_is_character_device.c
+    Linking Check unit test binary: dist/check_sfmr_is_character_device.bin
+    Compiling Check unit test code: test/check_sfmr_is_directory.c
+    Linking Check unit test binary: dist/check_sfmr_is_directory.bin
+    Compiling Check unit test code: test/check_sfmr_is_named_pipe.c
+    Linking Check unit test binary: dist/check_sfmr_is_named_pipe.bin
+    Compiling Check unit test code: test/check_sfmr_is_regular_file.c
+    Linking Check unit test binary: dist/check_sfmr_is_regular_file.bin
+    Compiling Check unit test code: test/check_sfmr_is_socket.c
+    Linking Check unit test binary: dist/check_sfmr_is_socket.bin
+    Compiling Check unit test code: test/check_sfmr_is_sym_link.c
+    Linking Check unit test binary: dist/check_sfmr_is_sym_link.bin
+    Compiling Check unit test code: test/check_sfmw_add_mode.c
+    Linking Check unit test binary: dist/check_sfmw_add_mode.bin
+    Compiling Check unit test code: test/check_sfmw_remove_mode.c
+    Linking Check unit test binary: dist/check_sfmw_remove_mode.bin
+    Compiling Check unit test code: test/check_sfmw_set_atime.c
+    Linking Check unit test binary: dist/check_sfmw_set_atime.bin
+    Compiling Check unit test code: test/check_sfmw_set_atime_now.c
+    Linking Check unit test binary: dist/check_sfmw_set_atime_now.bin
+    Compiling Check unit test code: test/check_sfmw_set_mode.c
+    Linking Check unit test binary: dist/check_sfmw_set_mode.bin
+    Compiling Check unit test code: test/check_sfmw_set_mtime.c
+    Linking Check unit test binary: dist/check_sfmw_set_mtime.bin
+    Compiling Check unit test code: test/check_sfmw_set_mtime_now.c
+    Linking Check unit test binary: dist/check_sfmw_set_mtime_now.bin
+    Compiling Check unit test code: test/check_sfmw_set_ownership.c
+    Linking Check unit test binary: dist/check_sfmw_set_ownership.bin
+    Compiling Check unit test code: test/check_sfmw_set_times.c
+    Linking Check unit test binary: dist/check_sfmw_set_times.bin
+    Compiling Check unit test code: test/check_sfmw_set_times_now.c
+    Linking Check unit test binary: dist/check_sfmw_set_times_now.bin
+    Compiling Check unit test code: test/check_sv_validate_pathname.c
+    Linking Check unit test binary: dist/check_sv_validate_pathname.bin
+
+RUNNING TEST CASES
+./dist/check_sdo_create_dir.bin
+Running suite(s): SDO_Create_Dir
+100%: Checks: 20, Failures: 0, Errors: 0
+./dist/check_sdo_delete_dir.bin
+Running suite(s): SDO_Delete_Dir
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sdo_destroy_dir.bin
+Running suite(s): SDO_Destroy_Dir
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sdo_read_dir_contents.bin
+Running suite(s): SDO_Read_Dir_Contents
+100%: Checks: 27, Failures: 0, Errors: 0
+./dist/check_sfc_is_close_on_exec.bin
+Running suite(s): SFC_Is_Close_On_Exec
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfl_create_hard_link.bin
+Running suite(s): SFL_Create_Hard_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+./dist/check_sfl_create_sym_link.bin
+Running suite(s): SFL_Create_Sym_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+./dist/check_sfmr_get_access_time.bin
+Running suite(s): SFMR_Get_Access_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_block_count.bin
+Running suite(s): SFMR_Get_Block_Count
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_block_size.bin
+Running suite(s): SFMR_Get_Block_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_change_time.bin
+Running suite(s): SFMR_Get_Change_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_container_device_id.bin
+Running suite(s): SFMR_Get_Container_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_file_device_id.bin
+Running suite(s): SFMR_Get_File_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_file_perms.bin
+Running suite(s): SFMR_Get_File_Perms
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_file_type.bin
+Running suite(s): SFMR_Get_File_Type
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_group.bin
+Running suite(s): SFMR_Get_Group
+100%: Checks: 12, Failures: 0, Errors: 0
+./dist/check_sfmr_get_hard_link_num.bin
+Running suite(s): SFMR_Get_Hard_Link_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_mod_time.bin
+Running suite(s): SFMR_Get_Mod_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_owner.bin
+Running suite(s): SFMR_Get_Owner
+100%: Checks: 12, Failures: 0, Errors: 0
+./dist/check_sfmr_get_serial_num.bin
+Running suite(s): SFMR_Get_Serial_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_get_size.bin
+Running suite(s): SFMR_Get_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_block_device.bin
+Running suite(s): SFMR_Is_Block_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_character_device.bin
+Running suite(s): SFMR_Is_Character_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_directory.bin
+Running suite(s): SFMR_Is_Directory
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_named_pipe.bin
+Running suite(s): SFMR_Is_Named_Pipe
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_regular_file.bin
+Running suite(s): SFMR_Is_Regular_File
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_socket.bin
+Running suite(s): SFMR_Is_Socket
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmr_is_sym_link.bin
+Running suite(s): SFMR_Is_Sym_Link
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmw_add_mode.bin
+Running suite(s): SFMW_Add_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sfmw_remove_mode.bin
+Running suite(s): SFMW_Remove_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sfmw_set_atime.bin
+Running suite(s): SFMW_Set_Atime
+100%: Checks: 24, Failures: 0, Errors: 0
+./dist/check_sfmw_set_atime_now.bin
+Running suite(s): SFMW_Set_Atime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmw_set_mode.bin
+Running suite(s): SFMW_Set_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+./dist/check_sfmw_set_mtime.bin
+Running suite(s): SFMW_Set_Mtime
+100%: Checks: 24, Failures: 0, Errors: 0
+./dist/check_sfmw_set_mtime_now.bin
+Running suite(s): SFMW_Set_Mtime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sfmw_set_ownership.bin
+Running suite(s): SFMW_Set_Ownership
+100%: Checks: 20, Failures: 0, Errors: 0
+./dist/check_sfmw_set_times.bin
+Running suite(s): SFMW_Set_Times
+100%: Checks: 24, Failures: 0, Errors: 0
+./dist/check_sfmw_set_times_now.bin
+Running suite(s): SFMW_Set_Times_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+./dist/check_sv_validate_pathname.bin
+Running suite(s): SV_Validate_Pathname
+100%: Checks: 11, Failures: 0, Errors: 0
+
+RELEASING
+Releasing libsketchyidea.so.1.0.0
+
+==77754== Memcheck, a memory error detector
+==77754== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==77754== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==77754== Command: code/dist/check_sdo_create_dir.bin
+==77754== 
+Running suite(s): SDO_Create_Dir
+100%: Checks: 20, Failures: 0, Errors: 0
+==77754== 
+==77754== HEAP SUMMARY:
+==77754==     in use at exit: 0 bytes in 0 blocks
+==77754==   total heap usage: 1,142 allocs, 1,142 frees, 535,512 bytes allocated
+==77754== 
+==77754== All heap blocks were freed -- no leaks are possible
+==77754== 
+==77754== For lists of detected and suppressed errors, rerun with: -s
+==77754== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==77841== Memcheck, a memory error detector
+==77841== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==77841== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==77841== Command: code/dist/check_sdo_delete_dir.bin
+==77841== 
+Running suite(s): SDO_Delete_Dir
+100%: Checks: 11, Failures: 0, Errors: 0
+==77841== 
+==77841== HEAP SUMMARY:
+==77841==     in use at exit: 0 bytes in 0 blocks
+==77841==   total heap usage: 379 allocs, 379 frees, 174,636 bytes allocated
+==77841== 
+==77841== All heap blocks were freed -- no leaks are possible
+==77841== 
+==77841== For lists of detected and suppressed errors, rerun with: -s
+==77841== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==77847== Memcheck, a memory error detector
+==77847== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==77847== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==77847== Command: code/dist/check_sdo_destroy_dir.bin
+==77847== 
+Running suite(s): SDO_Destroy_Dir
+100%: Checks: 16, Failures: 0, Errors: 0
+==77847== 
+==77847== HEAP SUMMARY:
+==77847==     in use at exit: 0 bytes in 0 blocks
+==77847==   total heap usage: 1,100 allocs, 1,100 frees, 1,556,088 bytes allocated
+==77847== 
+==77847== All heap blocks were freed -- no leaks are possible
+==77847== 
+==77847== For lists of detected and suppressed errors, rerun with: -s
+==77847== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==77879== Memcheck, a memory error detector
+==77879== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==77879== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==77879== Command: code/dist/check_sdo_read_dir_contents.bin
+==77879== 
+Running suite(s): SDO_Read_Dir_Contents
+100%: Checks: 27, Failures: 0, Errors: 0
+==77879== 
+==77879== HEAP SUMMARY:
+==77879==     in use at exit: 0 bytes in 0 blocks
+==77879==   total heap usage: 4,188 allocs, 4,188 frees, 2,665,204 bytes allocated
+==77879== 
+==77879== All heap blocks were freed -- no leaks are possible
+==77879== 
+==77879== For lists of detected and suppressed errors, rerun with: -s
+==77879== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78073== Memcheck, a memory error detector
+==78073== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78073== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78073== Command: code/dist/check_sfc_is_close_on_exec.bin
+==78073== 
+Running suite(s): SFC_Is_Close_On_Exec
+100%: Checks: 11, Failures: 0, Errors: 0
+==78073== 
+==78073== HEAP SUMMARY:
+==78073==     in use at exit: 0 bytes in 0 blocks
+==78073==   total heap usage: 1,293 allocs, 1,293 frees, 380,239 bytes allocated
+==78073== 
+==78073== All heap blocks were freed -- no leaks are possible
+==78073== 
+==78073== For lists of detected and suppressed errors, rerun with: -s
+==78073== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78099== Memcheck, a memory error detector
+==78099== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78099== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78099== Command: code/dist/check_sfl_create_hard_link.bin
+==78099== 
+Running suite(s): SFL_Create_Hard_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+==78099== 
+==78099== HEAP SUMMARY:
+==78099==     in use at exit: 0 bytes in 0 blocks
+==78099==   total heap usage: 1,537 allocs, 1,537 frees, 477,742 bytes allocated
+==78099== 
+==78099== All heap blocks were freed -- no leaks are possible
+==78099== 
+==78099== For lists of detected and suppressed errors, rerun with: -s
+==78099== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78130== Memcheck, a memory error detector
+==78130== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78130== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78130== Command: code/dist/check_sfl_create_sym_link.bin
+==78130== 
+Running suite(s): SFL_Create_Sym_Link
+100%: Checks: 14, Failures: 0, Errors: 0
+==78130== 
+==78130== HEAP SUMMARY:
+==78130==     in use at exit: 0 bytes in 0 blocks
+==78130==   total heap usage: 1,513 allocs, 1,513 frees, 476,691 bytes allocated
+==78130== 
+==78130== All heap blocks were freed -- no leaks are possible
+==78130== 
+==78130== For lists of detected and suppressed errors, rerun with: -s
+==78130== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78162== Memcheck, a memory error detector
+==78162== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78162== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78162== Command: code/dist/check_sfmr_get_access_time.bin
+==78162== 
+Running suite(s): SFMR_Get_Access_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+==78162== 
+==78162== HEAP SUMMARY:
+==78162==     in use at exit: 0 bytes in 0 blocks
+==78162==   total heap usage: 1,256 allocs, 1,256 frees, 410,552 bytes allocated
+==78162== 
+==78162== All heap blocks were freed -- no leaks are possible
+==78162== 
+==78162== For lists of detected and suppressed errors, rerun with: -s
+==78162== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78201== Memcheck, a memory error detector
+==78201== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78201== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78201== Command: code/dist/check_sfmr_get_block_count.bin
+==78201== 
+Running suite(s): SFMR_Get_Block_Count
+100%: Checks: 11, Failures: 0, Errors: 0
+==78201== 
+==78201== HEAP SUMMARY:
+==78201==     in use at exit: 0 bytes in 0 blocks
+==78201==   total heap usage: 403 allocs, 403 frees, 195,701 bytes allocated
+==78201== 
+==78201== All heap blocks were freed -- no leaks are possible
+==78201== 
+==78201== For lists of detected and suppressed errors, rerun with: -s
+==78201== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78218== Memcheck, a memory error detector
+==78218== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78218== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78218== Command: code/dist/check_sfmr_get_block_size.bin
+==78218== 
+Running suite(s): SFMR_Get_Block_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+==78218== 
+==78218== HEAP SUMMARY:
+==78218==     in use at exit: 0 bytes in 0 blocks
+==78218==   total heap usage: 395 allocs, 395 frees, 194,992 bytes allocated
+==78218== 
+==78218== All heap blocks were freed -- no leaks are possible
+==78218== 
+==78218== For lists of detected and suppressed errors, rerun with: -s
+==78218== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78235== Memcheck, a memory error detector
+==78235== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78235== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78235== Command: code/dist/check_sfmr_get_change_time.bin
+==78235== 
+Running suite(s): SFMR_Get_Change_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+==78235== 
+==78235== HEAP SUMMARY:
+==78235==     in use at exit: 0 bytes in 0 blocks
+==78235==   total heap usage: 375 allocs, 375 frees, 194,672 bytes allocated
+==78235== 
+==78235== All heap blocks were freed -- no leaks are possible
+==78235== 
+==78235== For lists of detected and suppressed errors, rerun with: -s
+==78235== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78252== Memcheck, a memory error detector
+==78252== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78252== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78252== Command: code/dist/check_sfmr_get_container_device_id.bin
+==78252== 
+Running suite(s): SFMR_Get_Container_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+==78252== 
+==78252== HEAP SUMMARY:
+==78252==     in use at exit: 0 bytes in 0 blocks
+==78252==   total heap usage: 318 allocs, 318 frees, 162,147 bytes allocated
+==78252== 
+==78252== All heap blocks were freed -- no leaks are possible
+==78252== 
+==78252== For lists of detected and suppressed errors, rerun with: -s
+==78252== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78255== Memcheck, a memory error detector
+==78255== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78255== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78255== Command: code/dist/check_sfmr_get_file_device_id.bin
+==78255== 
+Running suite(s): SFMR_Get_File_Device_ID
+100%: Checks: 11, Failures: 0, Errors: 0
+==78255== 
+==78255== HEAP SUMMARY:
+==78255==     in use at exit: 0 bytes in 0 blocks
+==78255==   total heap usage: 403 allocs, 403 frees, 196,340 bytes allocated
+==78255== 
+==78255== All heap blocks were freed -- no leaks are possible
+==78255== 
+==78255== For lists of detected and suppressed errors, rerun with: -s
+==78255== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78271== Memcheck, a memory error detector
+==78271== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78271== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78271== Command: code/dist/check_sfmr_get_file_perms.bin
+==78271== 
+Running suite(s): SFMR_Get_File_Perms
+100%: Checks: 11, Failures: 0, Errors: 0
+==78271== 
+==78271== HEAP SUMMARY:
+==78271==     in use at exit: 0 bytes in 0 blocks
+==78271==   total heap usage: 403 allocs, 403 frees, 195,488 bytes allocated
+==78271== 
+==78271== All heap blocks were freed -- no leaks are possible
+==78271== 
+==78271== For lists of detected and suppressed errors, rerun with: -s
+==78271== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78288== Memcheck, a memory error detector
+==78288== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78288== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78288== Command: code/dist/check_sfmr_get_file_type.bin
+==78288== 
+Running suite(s): SFMR_Get_File_Type
+100%: Checks: 11, Failures: 0, Errors: 0
+==78288== 
+==78288== HEAP SUMMARY:
+==78288==     in use at exit: 0 bytes in 0 blocks
+==78288==   total heap usage: 301 allocs, 301 frees, 154,685 bytes allocated
+==78288== 
+==78288== All heap blocks were freed -- no leaks are possible
+==78288== 
+==78288== For lists of detected and suppressed errors, rerun with: -s
+==78288== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78291== Memcheck, a memory error detector
+==78291== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78291== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78291== Command: code/dist/check_sfmr_get_group.bin
+==78291== 
+Running suite(s): SFMR_Get_Group
+100%: Checks: 12, Failures: 0, Errors: 0
+==78291== 
+==78291== HEAP SUMMARY:
+==78291==     in use at exit: 0 bytes in 0 blocks
+==78291==   total heap usage: 442 allocs, 442 frees, 213,025 bytes allocated
+==78291== 
+==78291== All heap blocks were freed -- no leaks are possible
+==78291== 
+==78291== For lists of detected and suppressed errors, rerun with: -s
+==78291== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78309== Memcheck, a memory error detector
+==78309== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78309== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78309== Command: code/dist/check_sfmr_get_hard_link_num.bin
+==78309== 
+Running suite(s): SFMR_Get_Hard_Link_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+==78309== 
+==78309== HEAP SUMMARY:
+==78309==     in use at exit: 0 bytes in 0 blocks
+==78309==   total heap usage: 403 allocs, 403 frees, 196,127 bytes allocated
+==78309== 
+==78309== All heap blocks were freed -- no leaks are possible
+==78309== 
+==78309== For lists of detected and suppressed errors, rerun with: -s
+==78309== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78326== Memcheck, a memory error detector
+==78326== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78326== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78326== Command: code/dist/check_sfmr_get_mod_time.bin
+==78326== 
+Running suite(s): SFMR_Get_Mod_Time
+100%: Checks: 11, Failures: 0, Errors: 0
+==78326== 
+==78326== HEAP SUMMARY:
+==78326==     in use at exit: 0 bytes in 0 blocks
+==78326==   total heap usage: 375 allocs, 375 frees, 194,117 bytes allocated
+==78326== 
+==78326== All heap blocks were freed -- no leaks are possible
+==78326== 
+==78326== For lists of detected and suppressed errors, rerun with: -s
+==78326== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78343== Memcheck, a memory error detector
+==78343== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78343== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78343== Command: code/dist/check_sfmr_get_owner.bin
+==78343== 
+Running suite(s): SFMR_Get_Owner
+100%: Checks: 12, Failures: 0, Errors: 0
+==78343== 
+==78343== HEAP SUMMARY:
+==78343==     in use at exit: 0 bytes in 0 blocks
+==78343==   total heap usage: 442 allocs, 442 frees, 213,025 bytes allocated
+==78343== 
+==78343== All heap blocks were freed -- no leaks are possible
+==78343== 
+==78343== For lists of detected and suppressed errors, rerun with: -s
+==78343== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78362== Memcheck, a memory error detector
+==78362== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78362== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78362== Command: code/dist/check_sfmr_get_serial_num.bin
+==78362== 
+Running suite(s): SFMR_Get_Serial_Num
+100%: Checks: 11, Failures: 0, Errors: 0
+==78362== 
+==78362== HEAP SUMMARY:
+==78362==     in use at exit: 0 bytes in 0 blocks
+==78362==   total heap usage: 1,284 allocs, 1,284 frees, 411,396 bytes allocated
+==78362== 
+==78362== All heap blocks were freed -- no leaks are possible
+==78362== 
+==78362== For lists of detected and suppressed errors, rerun with: -s
+==78362== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78404== Memcheck, a memory error detector
+==78404== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78404== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78404== Command: code/dist/check_sfmr_get_size.bin
+==78404== 
+Running suite(s): SFMR_Get_Size
+100%: Checks: 11, Failures: 0, Errors: 0
+==78404== 
+==78404== HEAP SUMMARY:
+==78404==     in use at exit: 0 bytes in 0 blocks
+==78404==   total heap usage: 403 allocs, 403 frees, 194,210 bytes allocated
+==78404== 
+==78404== All heap blocks were freed -- no leaks are possible
+==78404== 
+==78404== For lists of detected and suppressed errors, rerun with: -s
+==78404== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78421== Memcheck, a memory error detector
+==78421== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78421== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78421== Command: code/dist/check_sfmr_is_block_device.bin
+==78421== 
+Running suite(s): SFMR_Is_Block_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+==78421== 
+==78421== HEAP SUMMARY:
+==78421==     in use at exit: 0 bytes in 0 blocks
+==78421==   total heap usage: 301 allocs, 301 frees, 154,997 bytes allocated
+==78421== 
+==78421== All heap blocks were freed -- no leaks are possible
+==78421== 
+==78421== For lists of detected and suppressed errors, rerun with: -s
+==78421== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78424== Memcheck, a memory error detector
+==78424== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78424== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78424== Command: code/dist/check_sfmr_is_character_device.bin
+==78424== 
+Running suite(s): SFMR_Is_Character_Device
+100%: Checks: 11, Failures: 0, Errors: 0
+==78424== 
+==78424== HEAP SUMMARY:
+==78424==     in use at exit: 0 bytes in 0 blocks
+==78424==   total heap usage: 301 allocs, 301 frees, 155,621 bytes allocated
+==78424== 
+==78424== All heap blocks were freed -- no leaks are possible
+==78424== 
+==78424== For lists of detected and suppressed errors, rerun with: -s
+==78424== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78426== Memcheck, a memory error detector
+==78426== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78426== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78426== Command: code/dist/check_sfmr_is_directory.bin
+==78426== 
+Running suite(s): SFMR_Is_Directory
+100%: Checks: 11, Failures: 0, Errors: 0
+==78426== 
+==78426== HEAP SUMMARY:
+==78426==     in use at exit: 0 bytes in 0 blocks
+==78426==   total heap usage: 301 allocs, 301 frees, 154,529 bytes allocated
+==78426== 
+==78426== All heap blocks were freed -- no leaks are possible
+==78426== 
+==78426== For lists of detected and suppressed errors, rerun with: -s
+==78426== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78428== Memcheck, a memory error detector
+==78428== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78428== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78428== Command: code/dist/check_sfmr_is_named_pipe.bin
+==78428== 
+Running suite(s): SFMR_Is_Named_Pipe
+100%: Checks: 11, Failures: 0, Errors: 0
+==78428== 
+==78428== HEAP SUMMARY:
+==78428==     in use at exit: 0 bytes in 0 blocks
+==78428==   total heap usage: 301 allocs, 301 frees, 154,685 bytes allocated
+==78428== 
+==78428== All heap blocks were freed -- no leaks are possible
+==78428== 
+==78428== For lists of detected and suppressed errors, rerun with: -s
+==78428== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78430== Memcheck, a memory error detector
+==78430== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78430== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78430== Command: code/dist/check_sfmr_is_regular_file.bin
+==78430== 
+Running suite(s): SFMR_Is_Regular_File
+100%: Checks: 11, Failures: 0, Errors: 0
+==78430== 
+==78430== HEAP SUMMARY:
+==78430==     in use at exit: 0 bytes in 0 blocks
+==78430==   total heap usage: 301 allocs, 301 frees, 154,997 bytes allocated
+==78430== 
+==78430== All heap blocks were freed -- no leaks are possible
+==78430== 
+==78430== For lists of detected and suppressed errors, rerun with: -s
+==78430== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78432== Memcheck, a memory error detector
+==78432== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78432== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78432== Command: code/dist/check_sfmr_is_socket.bin
+==78432== 
+Running suite(s): SFMR_Is_Socket
+100%: Checks: 11, Failures: 0, Errors: 0
+==78432== 
+==78432== HEAP SUMMARY:
+==78432==     in use at exit: 0 bytes in 0 blocks
+==78432==   total heap usage: 301 allocs, 301 frees, 154,061 bytes allocated
+==78432== 
+==78432== All heap blocks were freed -- no leaks are possible
+==78432== 
+==78432== For lists of detected and suppressed errors, rerun with: -s
+==78432== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78434== Memcheck, a memory error detector
+==78434== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78434== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78434== Command: code/dist/check_sfmr_is_sym_link.bin
+==78434== 
+Running suite(s): SFMR_Is_Sym_Link
+100%: Checks: 11, Failures: 0, Errors: 0
+==78434== 
+==78434== HEAP SUMMARY:
+==78434==     in use at exit: 0 bytes in 0 blocks
+==78434==   total heap usage: 301 allocs, 301 frees, 154,373 bytes allocated
+==78434== 
+==78434== All heap blocks were freed -- no leaks are possible
+==78434== 
+==78434== For lists of detected and suppressed errors, rerun with: -s
+==78434== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78436== Memcheck, a memory error detector
+==78436== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78436== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78436== Command: code/dist/check_sfmw_add_mode.bin
+==78436== 
+Running suite(s): SFMW_Add_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+==78436== 
+==78436== HEAP SUMMARY:
+==78436==     in use at exit: 0 bytes in 0 blocks
+==78436==   total heap usage: 5,321 allocs, 5,321 frees, 1,417,570 bytes allocated
+==78436== 
+==78436== All heap blocks were freed -- no leaks are possible
+==78436== 
+==78436== For lists of detected and suppressed errors, rerun with: -s
+==78436== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==78822== Memcheck, a memory error detector
+==78822== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==78822== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==78822== Command: code/dist/check_sfmw_remove_mode.bin
+==78822== 
+Running suite(s): SFMW_Remove_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+==78822== 
+==78822== HEAP SUMMARY:
+==78822==     in use at exit: 0 bytes in 0 blocks
+==78822==   total heap usage: 5,321 allocs, 5,321 frees, 1,429,537 bytes allocated
+==78822== 
+==78822== All heap blocks were freed -- no leaks are possible
+==78822== 
+==78822== For lists of detected and suppressed errors, rerun with: -s
+==78822== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79205== Memcheck, a memory error detector
+==79205== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79205== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79205== Command: code/dist/check_sfmw_set_atime.bin
+==79205== 
+Running suite(s): SFMW_Set_Atime
+100%: Checks: 24, Failures: 0, Errors: 0
+==79205== 
+==79205== HEAP SUMMARY:
+==79205==     in use at exit: 0 bytes in 0 blocks
+==79205==   total heap usage: 2,628 allocs, 2,628 frees, 706,269 bytes allocated
+==79205== 
+==79205== All heap blocks were freed -- no leaks are possible
+==79205== 
+==79205== For lists of detected and suppressed errors, rerun with: -s
+==79205== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79211== Memcheck, a memory error detector
+==79211== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79211== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79211== Command: code/dist/check_sfmw_set_atime_now.bin
+==79211== 
+Running suite(s): SFMW_Set_Atime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+==79211== 
+==79211== HEAP SUMMARY:
+==79211==     in use at exit: 0 bytes in 0 blocks
+==79211==   total heap usage: 738 allocs, 738 frees, 315,349 bytes allocated
+==79211== 
+==79211== All heap blocks were freed -- no leaks are possible
+==79211== 
+==79211== For lists of detected and suppressed errors, rerun with: -s
+==79211== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79214== Memcheck, a memory error detector
+==79214== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79214== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79214== Command: code/dist/check_sfmw_set_mode.bin
+==79214== 
+Running suite(s): SFMW_Set_Mode
+100%: Checks: 16, Failures: 0, Errors: 0
+==79214== 
+==79214== HEAP SUMMARY:
+==79214==     in use at exit: 0 bytes in 0 blocks
+==79214==   total heap usage: 5,225 allocs, 5,225 frees, 1,359,890 bytes allocated
+==79214== 
+==79214== All heap blocks were freed -- no leaks are possible
+==79214== 
+==79214== For lists of detected and suppressed errors, rerun with: -s
+==79214== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79576== Memcheck, a memory error detector
+==79576== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79576== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79576== Command: code/dist/check_sfmw_set_mtime.bin
+==79576== 
+Running suite(s): SFMW_Set_Mtime
+100%: Checks: 24, Failures: 0, Errors: 0
+==79576== 
+==79576== HEAP SUMMARY:
+==79576==     in use at exit: 0 bytes in 0 blocks
+==79576==   total heap usage: 2,628 allocs, 2,628 frees, 706,269 bytes allocated
+==79576== 
+==79576== All heap blocks were freed -- no leaks are possible
+==79576== 
+==79576== For lists of detected and suppressed errors, rerun with: -s
+==79576== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79581== Memcheck, a memory error detector
+==79581== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79581== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79581== Command: code/dist/check_sfmw_set_mtime_now.bin
+==79581== 
+Running suite(s): SFMW_Set_Mtime_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+==79581== 
+==79581== HEAP SUMMARY:
+==79581==     in use at exit: 0 bytes in 0 blocks
+==79581==   total heap usage: 738 allocs, 738 frees, 315,349 bytes allocated
+==79581== 
+==79581== All heap blocks were freed -- no leaks are possible
+==79581== 
+==79581== For lists of detected and suppressed errors, rerun with: -s
+==79581== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79584== Memcheck, a memory error detector
+==79584== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79584== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79584== Command: code/dist/check_sfmw_set_ownership.bin
+==79584== 
+Running suite(s): SFMW_Set_Ownership
+100%: Checks: 20, Failures: 0, Errors: 0
+==79584== 
+==79584== HEAP SUMMARY:
+==79584==     in use at exit: 0 bytes in 0 blocks
+==79584==   total heap usage: 7,287 allocs, 7,287 frees, 1,517,442 bytes allocated
+==79584== 
+==79584== All heap blocks were freed -- no leaks are possible
+==79584== 
+==79584== For lists of detected and suppressed errors, rerun with: -s
+==79584== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79875== Memcheck, a memory error detector
+==79875== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79875== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79875== Command: code/dist/check_sfmw_set_times.bin
+==79875== 
+Running suite(s): SFMW_Set_Times
+100%: Checks: 24, Failures: 0, Errors: 0
+==79875== 
+==79875== HEAP SUMMARY:
+==79875==     in use at exit: 0 bytes in 0 blocks
+==79875==   total heap usage: 2,748 allocs, 2,748 frees, 709,959 bytes allocated
+==79875== 
+==79875== All heap blocks were freed -- no leaks are possible
+==79875== 
+==79875== For lists of detected and suppressed errors, rerun with: -s
+==79875== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79881== Memcheck, a memory error detector
+==79881== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79881== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79881== Command: code/dist/check_sfmw_set_times_now.bin
+==79881== 
+Running suite(s): SFMW_Set_Times_Now
+100%: Checks: 11, Failures: 0, Errors: 0
+==79881== 
+==79881== HEAP SUMMARY:
+==79881==     in use at exit: 0 bytes in 0 blocks
+==79881==   total heap usage: 802 allocs, 802 frees, 317,573 bytes allocated
+==79881== 
+==79881== All heap blocks were freed -- no leaks are possible
+==79881== 
+==79881== For lists of detected and suppressed errors, rerun with: -s
+==79881== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==79885== Memcheck, a memory error detector
+==79885== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==79885== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==79885== Command: code/dist/check_sv_validate_pathname.bin
+==79885== 
+Running suite(s): SV_Validate_Pathname
+100%: Checks: 11, Failures: 0, Errors: 0
+==79885== 
+==79885== HEAP SUMMARY:
+==79885==     in use at exit: 0 bytes in 0 blocks
+==79885==   total heap usage: 1,160 allocs, 1,160 frees, 375,356 bytes allocated
+==79885== 
+==79885== All heap blocks were freed -- no leaks are possible
+==79885== 
+==79885== For lists of detected and suppressed errors, rerun with: -s
+==79885== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+
+TOTAL CHECK UNIT TESTS: 530
+
+*** Manual Test Code ***
+The full command is './code/dist/test_sm_handle_ext_read_queue_ptr.bin ./code/test/test_input/regular_file.txt'
+Command output:
+[INFO] CHILD - Received value 0x7f08c653e000 inside signal number 12 (User defined signal 2) code -1 (SI_QUEUE: See sigqueue(3)) from UID 1000 at PID 82499
+[INFO] CHILD - The contents of the mapped memory:
+
+Tester's Creed
+
+
+This is my test input. There are many like it, but this one is mine.
+
+My test input is my best friend. It is my life. I must master it as I must master my life.
+
+Without me, my test input is useless. Without my test input, I am useless. I must test my production code true. I must test my production code better than my adversary who is trying to reverse engineer my code. I must fix my code before they exploit it.
+
+I will ...
+
+My test input and I know that what counts in testing is not the number of test cases, the number of statements we test, nor our code coverage. We know that it is the requirements that count. We will trace ...
+
+My test code is human, even as I am human, because it is my life. Thus, I will learn my test code as a brother. I will learn its weaknesses, its strength, its classes, its functions, its decorators, its execution, and its flow control. I will keep my test code clean and DRY, even as I like to be clean and dry. We will become part of each other. We will ...
+
+Before Guido, I swear this creed. My test code and I are the defenders of my production code. We are the masters of our adversaries. We are the saviors of my career.
+
+So be it, until delivery is ours and there are no bugs, but operationally accepted capabilities!
+
+
+[INFO] Blocking signal 12: User defined signal 2
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin now temporarily blocking signal 12.
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin is now handling signal 12: User defined signal 2.
+[INFO] Blocking signal 12: User defined signal 2
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin now temporarily blocking signal 12.
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin is now handling signal 12: User defined signal 2.
+[INFO] PARENT - The child has finished
+
+
+*** Manual Test Code (with Valgrind) ***
+The full command is 'valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all ./code/dist/test_sm_handle_ext_read_queue_ptr.bin ./code/test/test_input/regular_file.txt'
+Command output:
+==82501== Memcheck, a memory error detector
+==82501== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==82501== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==82501== Command: ./code/dist/test_sm_handle_ext_read_queue_ptr.bin ./code/test/test_input/regular_file.txt
+==82501== 
+[INFO] CHILD - Received value 0x4037000 inside signal number 12 (User defined signal 2) code -1 (SI_QUEUE: See sigqueue(3)) from UID 1000 at PID 82501
+[INFO] CHILD - The contents of the mapped memory:
+
+Tester's Creed
+
+
+This is my test input. There are many like it, but this one is mine.
+
+My test input is my best friend. It is my life. I must master it as I must master my life.
+
+Without me, my test input is useless. Without my test input, I am useless. I must test my production code true. I must test my production code better than my adversary who is trying to reverse engineer my code. I must fix my code before they exploit it.
+
+I will ...
+
+My test input and I know that what counts in testing is not the number of test cases, the number of statements we test, nor our code coverage. We know that it is the requirements that count. We will trace ...
+
+My test code is human, even as I am human, because it is my life. Thus, I will learn my test code as a brother. I will learn its weaknesses, its strength, its classes, its functions, its decorators, its execution, and its flow control. I will keep my test code clean and DRY, even as I like to be clean and dry. We will become part of each other. We will ...
+
+Before Guido, I swear this creed. My test code and I are the defenders of my production code. We are the masters of our adversaries. We are the saviors of my career.
+
+So be it, until delivery is ours and there are no bugs, but operationally accepted capabilities!
+
+
+[INFO] Blocking signal 12: User defined signal 2
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin now temporarily blocking signal 12.
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin is now handling signal 12: User defined signal 2.
+==82503== 
+==82503== HEAP SUMMARY:
+==82503==     in use at exit: 0 bytes in 0 blocks
+==82503==   total heap usage: 2 allocs, 2 frees, 4,122 bytes allocated
+==82503== 
+==82503== All heap blocks were freed -- no leaks are possible
+==82503== 
+==82503== For lists of detected and suppressed errors, rerun with: -s
+==82503== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+[INFO] Blocking signal 12: User defined signal 2
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin now temporarily blocking signal 12.
+[INFO] ./code/dist/test_sm_handle_ext_read_queue_ptr.bin is now handling signal 12: User defined signal 2.
+[INFO] PARENT - The child has finished
+==82501== 
+==82501== HEAP SUMMARY:
+==82501==     in use at exit: 0 bytes in 0 blocks
+==82501==   total heap usage: 4 allocs, 4 frees, 9,946 bytes allocated
+==82501== 
+==82501== All heap blocks were freed -- no leaks are possible
+==82501== 
+==82501== For lists of detected and suppressed errors, rerun with: -s
+==82501== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+
+
+

--- a/devops/scripts/4-5_export.sh
+++ b/devops/scripts/4-5_export.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# This script was made to help automate exporting SKID output into a single
+# text file to use as "proof" for my mentor.  It performs the following:
+#
+# 1. Prints identifying information
+# 2. Runs the build system (which also executes the Check-based unit tests)
+# 3. Executes the unit tests with Valgrind
+# 4. Counts the number of unit tests
+# 5. Misc. (e.g., executing bespoke manual test code highlighting features/functionality)
+# 5.A. Executes that manual test code
+# 5.B. Does it again with Valgrind
+# 5.C. Profit
+
+
+BOOKEND="***"  # SPOT for formatting titles and banners
+
+
+#
+# PURPOSE:
+#   Standardize how high-level banners are printed
+#       *****************
+#       *** The title ***
+#       *****************
+# ARGUMENTS:
+#   title: The title to print as a string inside a banner
+# RETURN:
+#   The exit code
+#
+print_banner()
+{
+    # LOCAL VARIABLES
+    EXIT_CODE=0                                                # Exit code from command execution
+    FORMAT_CHAR="${BOOKEND:0:1}"                               # Formatting
+    TITLE="$@"                                                 # The title argument
+    LENGTH=$((${#BOOKEND} + 1 + ${#TITLE} + 1 + ${#BOOKEND}))  # Length of the title
+    BANNER=$(printf "%${LENGTH}s" | tr " " "$FORMAT_CHAR")     # Banner string
+
+    # DO IT
+    printf "\n%s\n" "$BANNER"  # Header
+    print_title "$TITLE"
+    EXIT_CODE=$?
+    printf "%s\n" "$BANNER"  # Footer
+
+    # DONE
+    return $EXIT_CODE
+}
+
+#
+# PURPOSE:
+#   Standardize how titles are printed in the exported output:
+#   No leading newline will be added
+#       *** The title ***
+# ARGUMENTS:
+#   title: The title to print as a string
+# RETURN:
+#   The exit code
+#
+print_title()
+{
+    # LOCAL VARIABLES
+    EXIT_CODE=0    # Exit code from command execution
+    TITLE="$@"     # The title argument
+
+    # DO IT
+    printf "%s %s %s\n" "$BOOKEND" "$TITLE" "$BOOKEND"
+    EXIT_CODE=$?
+
+    # DONE
+    return $EXIT_CODE
+}
+
+#
+# PURPOSE:
+#   Run manual test code in a standardized way
+# ARGUMENTS:
+#   command: The command, with a variable number of argments, to echo and then execute
+# RETURN:
+#   The exit code from command execution
+#
+run_manual_test_command()
+{
+    # LOCAL VARIABLES
+    EXIT_CODE=0  # Exit code from command execution
+
+    # DO IT
+    # Echo
+    printf "The full command is '%s'\n" "$@"
+    printf "Command output:\n"
+    # Execute
+    bash -c "$@"
+    EXIT_CODE=$?
+    # Vertical whitespace
+    printf "\n\n"
+
+    # DONE
+    return $EXIT_CODE
+}
+
+#
+# PURPOSE:
+#   Verbosely run manual test code in a standardized way (calls run_manual_test_command())
+# ARGUMENTS:
+#   command: The command, with a variable number of argments, to print usage for, echo and then
+#       execute
+# RETURN:
+#   The exit code from command execution
+#
+run_manual_test_command_verbose()
+{
+    # LOCAL VARIABLES
+    FULL_CMD="$@"             # Full manual test command
+    CMD_ARRAY=($FULL_CMD)     # Full manual test command as an array
+    BASE_CMD=${CMD_ARRAY[0]}  # Base manual test binary
+    EXIT_CODE=0               # Exit code from command execution
+
+    # DO IT
+    # Invoke Usage
+    bash -c "$BASE_CMD"
+    echo
+    # Call run_manual_test_command()
+    run_manual_test_command "$FULL_CMD"
+    EXIT_CODE=$?
+
+    # DONE
+    return $EXIT_CODE
+}
+
+BOOKEND="***"                                                       # Formatting
+TEMP_RET=0                                                          # Temporary exit code var
+EXIT_CODE=0                                                         # Exit value
+
+# 1. Stores the date
+printf "\n%s This output was created by %s on %s %s\n" "$BOOKEND" "$(basename "$0")" "$(date)" "$BOOKEND" && \
+# 2. Runs the build system (which also executes the Check-based unit tests)
+make && echo && \
+# 3. Executes the unit tests with Valgrind
+./devops/scripts/run_valgrind.sh; [[ $? -ne 0 ]] && exit; echo && \
+# 4. Counts the number of unit tests (by running them again)
+for check_bin in $(ls code/dist/check_*.bin); do $check_bin; [[ $? -ne 0 ]] && break; done | grep "100%: Checks: " | awk '{sum += $3} END {print "TOTAL CHECK UNIT TESTS: "sum}' && echo
+# 5.A. Executes that manual test code
+print_title "Manual Test Code"
+run_manual_test_command "./code/dist/test_sm_handle_ext_read_queue_ptr.bin ./code/test/test_input/regular_file.txt"
+TEMP_RET=$?
+if [ $TEMP_RET -ne 0 ]
+then
+    EXIT_CODE=$TEMP_RET
+    echo "The manual test code failed: $TEMP_RET"
+fi
+# 5.B. Does it again with Valgrind
+print_title "Manual Test Code (with Valgrind)"
+run_manual_test_command "valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all ./code/dist/test_sm_handle_ext_read_queue_ptr.bin ./code/test/test_input/regular_file.txt"
+TEMP_RET=$?
+if [ $TEMP_RET -ne 0 ]
+then
+    EXIT_CODE=$TEMP_RET
+    echo "Valgrind disapproves of the manual test code: $TEMP_RET"
+fi
+# 5.C. Profit
+echo
+
+# DONE
+if [ $EXIT_CODE -ne 0 ]
+then
+    echo "There appears to have been an error in the execution of this script: $EXIT_CODE"
+fi
+exit $EXIT_CODE


### PR DESCRIPTION
- Added another extended signal handler to the "signals" library
- Added some manual test code (some good, some meh) to help showcase `mmap()`
- Extended the the `skid_memory` library with some `mmap` helper functions
- Wrote a shell script to automate the output/proof of the manual test code
- Source-controlled that output